### PR TITLE
Re-implement TimerContext to avoid mixing of millis and nanos

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -24,9 +24,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
 import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,11 +91,16 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    *
    * @param request The broker request associated with this query
    * @param phase The query phase for which to log time
-   * @param nanos The number of nanoseconds that the phase execution took to complete
+   * @param duration The duration that the phase execution took to complete
+   * @param timeUnit The time unit of the duration
    */
-  public void addPhaseTiming(@Nullable final BrokerRequest request, final QP phase, final long nanos) {
-    final String fullTimerName = buildMetricName(request, phase.getQueryPhaseName());
-    addValueToTimer(fullTimerName, nanos, TimeUnit.NANOSECONDS);
+  public void addPhaseTiming(BrokerRequest request, QP phase, long duration, TimeUnit timeUnit) {
+    String fullTimerName = buildMetricName(request, phase.getQueryPhaseName());
+    addValueToTimer(fullTimerName, duration, timeUnit);
+  }
+
+  public void addPhaseTiming(BrokerRequest request, QP phase, long nanos) {
+    addPhaseTiming(request, phase, nanos, TimeUnit.NANOSECONDS);
   }
 
   public void addPhaseTiming(String tableName, QP phase, long nanos) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
@@ -41,12 +41,13 @@ public class ServerQueryRequest {
 
   private int _segmentCountAfterPruning = -1;
 
-  public ServerQueryRequest(@Nonnull InstanceRequest instanceRequest, @Nonnull ServerMetrics serverMetrics) {
+  public ServerQueryRequest(@Nonnull InstanceRequest instanceRequest, @Nonnull ServerMetrics serverMetrics,
+      long queryArrivalTimeMs) {
     _instanceRequest = instanceRequest;
     _serverMetrics = serverMetrics;
     _brokerRequest = instanceRequest.getQuery();
     _filterQueryTree = RequestUtils.generateFilterQueryTree(_brokerRequest);
-    _timerContext = new TimerContext(_brokerRequest, serverMetrics);
+    _timerContext = new TimerContext(_brokerRequest, serverMetrics, queryArrivalTimeMs);
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
@@ -19,127 +19,81 @@ package com.linkedin.pinot.common.query.context;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
 import com.linkedin.pinot.common.request.BrokerRequest;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+
 
 public class TimerContext {
+  private final BrokerRequest _brokerRequest;
+  private final ServerMetrics _serverMetrics;
+  private final long _queryArrivalTimeMs;
+  private final Timer[] _phaseTimers = new Timer[ServerQueryPhase.values().length];
 
-  private final ServerMetrics serverMetrics;
-  private final Map<ServerQueryPhase, Timer> phaseTimers = new HashMap<>();
-  private final BrokerRequest brokerRequest;
-  private long queryArrivalTimeNs;
+  public class Timer {
+    private final ServerQueryPhase _queryPhase;
+    private final long _startTimeMs;
 
-  public class Timer implements AutoCloseable {
-    private final ServerQueryPhase queryPhase;
-    long startTimeNs;
-    long endTimeNs;
-    boolean isRunning;
+    private long _durationMs;
+    private boolean _ended;
 
-    Timer(ServerQueryPhase phase) {
-      this.queryPhase = phase;
-    }
-
-    void start() {
-      startTimeNs = System.nanoTime();
-      isRunning = true;
-    }
-
-    void setStartTimeNs(long startTimeNs) {
-      this.startTimeNs = startTimeNs;
-      isRunning = true;
+    private Timer(ServerQueryPhase queryPhase, long startTimeMs) {
+      _queryPhase = queryPhase;
+      _startTimeMs = startTimeMs;
     }
 
     public void stopAndRecord() {
-      if (isRunning) {
-        endTimeNs = System.nanoTime();
-
-        recordPhaseTime(this);
-        isRunning = false;
+      if (!_ended) {
+        _durationMs = System.currentTimeMillis() - _startTimeMs;
+        _serverMetrics.addPhaseTiming(_brokerRequest, _queryPhase, _durationMs, TimeUnit.MILLISECONDS);
+        _ended = true;
       }
     }
 
-    public long getDurationNs() {
-      return endTimeNs - startTimeNs;
-    }
-
     public long getDurationMs() {
-      return TimeUnit.MILLISECONDS.convert(endTimeNs - startTimeNs, TimeUnit.NANOSECONDS);
-    }
-    @Override
-    public void close()
-        throws Exception {
-      stopAndRecord();
+      return _ended ? _durationMs : -1;
     }
   }
 
-  public TimerContext(BrokerRequest brokerRequest, ServerMetrics serverMetrics) {
-    this.brokerRequest = brokerRequest;
-    this.serverMetrics = serverMetrics;
-  }
-
-  public void setQueryArrivalTimeNs(long queryStartTimeNs) {
-    this.queryArrivalTimeNs = queryStartTimeNs;
-  }
-
-  public long getQueryArrivalTimeNs() {
-    return queryArrivalTimeNs;
+  public TimerContext(BrokerRequest brokerRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs) {
+    _brokerRequest = brokerRequest;
+    _serverMetrics = serverMetrics;
+    _queryArrivalTimeMs = queryArrivalTimeMs;
   }
 
   public long getQueryArrivalTimeMs() {
-    return TimeUnit.MILLISECONDS.convert(queryArrivalTimeNs, TimeUnit.NANOSECONDS);
+    return _queryArrivalTimeMs;
   }
 
   /**
-   * Creates and starts a new timer for query phase.
-   * Calling this again for same phase will overwrite existing timing information
-   * @param queryPhase query phase that is being timed
-   * @return
+   * Creates a new timer for query phase with the given start time in millis.
+   * <p>Calling this again for same phase will overwrite existing timing information.
+   *
+   * @param queryPhase Query phase to be timed
+   * @param startTimeMs Timer start time in millis
+   * @return Timer for the query phase
+   */
+  public Timer startNewPhaseTimer(ServerQueryPhase queryPhase, long startTimeMs) {
+    Timer phaseTimer = new Timer(queryPhase, startTimeMs);
+    _phaseTimers[queryPhase.ordinal()] = phaseTimer;
+    return phaseTimer;
+  }
+
+  /**
+   * Creates a new timer for query phase with {@link System#currentTimeMillis()} as the start time.
+   * <p>Calling this again for same phase will overwrite existing timing information.
+   *
+   * @param queryPhase Query phase to be timed
+   * @return Timer for the query phase
    */
   public Timer startNewPhaseTimer(ServerQueryPhase queryPhase) {
-    Timer phaseTimer = new Timer(queryPhase);
-    phaseTimers.put(queryPhase, phaseTimer);
-    phaseTimer.start();
-    return phaseTimer;
+    return startNewPhaseTimer(queryPhase, System.currentTimeMillis());
   }
 
-  public Timer startNewPhaseTimerAtNs(ServerQueryPhase queryPhase, long startTimeNs) {
-    Timer phaseTimer = startNewPhaseTimer(queryPhase);
-    phaseTimer.setStartTimeNs(startTimeNs);
-    return phaseTimer;
-  }
-
-  public @Nullable Timer getPhaseTimer(ServerQueryPhase queryPhase) {
-    return phaseTimers.get(queryPhase);
-  }
-
-  public long getPhaseDurationNs(ServerQueryPhase queryPhase) {
-    Timer timer = phaseTimers.get(queryPhase);
-    if (timer == null) {
-      return -1;
-    }
-    return timer.getDurationNs();
+  public Timer getPhaseTimer(ServerQueryPhase queryPhase) {
+    return _phaseTimers[queryPhase.ordinal()];
   }
 
   public long getPhaseDurationMs(ServerQueryPhase queryPhase) {
-    return TimeUnit.MILLISECONDS.convert(getPhaseDurationNs(queryPhase), TimeUnit.NANOSECONDS);
-  }
-
-  void recordPhaseTime(Timer phaseTimer) {
-    serverMetrics.addPhaseTiming(brokerRequest, phaseTimer.queryPhase, phaseTimer.getDurationNs());
-  }
-
-  // for logging
-  @Override
-  public String toString() {
-    return String.format("%d,%d,%d,%d,%d,%d,%d,%d (in ns)", queryArrivalTimeNs,
-        getPhaseDurationNs(ServerQueryPhase.REQUEST_DESERIALIZATION),
-        getPhaseDurationNs(ServerQueryPhase.SCHEDULER_WAIT),
-        getPhaseDurationNs(ServerQueryPhase.BUILD_QUERY_PLAN),
-        getPhaseDurationNs(ServerQueryPhase.QUERY_PLAN_EXECUTION),
-        getPhaseDurationNs(ServerQueryPhase.QUERY_PROCESSING),
-        getPhaseDurationNs(ServerQueryPhase.RESPONSE_SERIALIZATION),
-        getPhaseDurationNs(ServerQueryPhase.TOTAL_QUERY_TIME));
+    Timer phaseTimer = _phaseTimers[queryPhase.ordinal()];
+    return phaseTimer != null ? phaseTimer.getDurationMs() : -1;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -201,7 +201,7 @@ public abstract class QueryScheduler {
     }
 
     responseSerializationTimer.stopAndRecord();
-    timerContext.startNewPhaseTimerAtNs(ServerQueryPhase.TOTAL_QUERY_TIME, timerContext.getQueryArrivalTimeNs())
+    timerContext.startNewPhaseTimer(ServerQueryPhase.TOTAL_QUERY_TIME, timerContext.getQueryArrivalTimeMs())
         .stopAndRecord();
 
     return responseByte;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
@@ -37,32 +37,24 @@ public class FCFSSchedulerGroup extends AbstractSchedulerGroup {
    */
   @Override
   public int compareTo(SchedulerGroupAccountant rhs) {
-    return compareTo(this, ((SchedulerGroup) rhs));
+    return compare(this, ((SchedulerGroup) rhs));
   }
 
-  public static int compareTo(SchedulerGroup lhs, SchedulerGroup rhs) {
-    if (rhs == null) {
-      return 1;
-    }
-
+  public static int compare(SchedulerGroup lhs, SchedulerGroup rhs) {
     if (lhs == rhs) {
       return 0;
+    }
+    if (rhs == null) {
+      return 1;
     }
 
     SchedulerQueryContext lhsFirst = lhs.peekFirst();
     SchedulerQueryContext rhsFirst = rhs.peekFirst();
     if (lhsFirst != null && rhsFirst != null) {
-      long lhsArrivalMs = lhsFirst.getArrivalTimeMs();
-      long rhsArrivalMs = rhsFirst.getArrivalTimeMs();
-      if (lhsArrivalMs < rhsArrivalMs) {
-        return 1;
-      } else if (lhsArrivalMs > rhsArrivalMs) {
-        return -1;
-      }
-      return 0;
-    } else if (lhsFirst != null && rhsFirst == null) {
+      return Long.compare(rhsFirst.getArrivalTimeMs(), lhsFirst.getArrivalTimeMs());
+    } else if (lhsFirst != null) {
       return 1;
-    } else if (lhsFirst == null && rhsFirst != null) {
+    } else if (rhsFirst != null) {
       return -1;
     } else {
       return 0;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroup.java
@@ -132,7 +132,7 @@ public class TokenSchedulerGroup extends AbstractSchedulerGroup {
     if (leftTokens < rightTokens) {
       return -1;
     }
-    return FCFSSchedulerGroup.compareTo(this, (SchedulerGroup)rhs);
+    return FCFSSchedulerGroup.compare(this, (SchedulerGroup)rhs);
   }
 
   public String toString() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestHelper.java
@@ -21,15 +21,12 @@ import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.request.QuerySource;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class TestHelper {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
-  public static ServerQueryRequest createServerQueryRequest(String table, ServerMetrics metrics) {
+  public static ServerQueryRequest createServerQueryRequest(String table, ServerMetrics metrics,
+      long queryArrivalTimeMs) {
     InstanceRequest request = new InstanceRequest();
     request.setBrokerId("broker");
     request.setEnableTrace(false);
@@ -40,15 +37,18 @@ public class TestHelper {
     qs.setTableName(table);
     br.setQuerySource(qs);
     request.setQuery(br);
-    ServerQueryRequest qr = new ServerQueryRequest(request, metrics);
-    qr.getTimerContext().setQueryArrivalTimeNs(
-        TimeUnit.NANOSECONDS.convert(
-            System.currentTimeMillis(), TimeUnit.MILLISECONDS));
-    return qr;
+    return new ServerQueryRequest(request, metrics, queryArrivalTimeMs);
+  }
+
+  public static ServerQueryRequest createServerQueryRequest(String table, ServerMetrics metrics) {
+    return createServerQueryRequest(table, metrics, System.currentTimeMillis());
+  }
+
+  public static SchedulerQueryContext createQueryRequest(String table, ServerMetrics metrics, long queryArrivalTimeMs) {
+    return new SchedulerQueryContext(createServerQueryRequest(table, metrics, queryArrivalTimeMs));
   }
 
   public static SchedulerQueryContext createQueryRequest(String table, ServerMetrics metrics) {
-    return new SchedulerQueryContext(createServerQueryRequest(table, metrics));
+    return createQueryRequest(table, metrics, System.currentTimeMillis());
   }
-
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroupTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroupTest.java
@@ -29,28 +29,27 @@ public class FCFSSchedulerGroupTest {
 
   @Test
   public void testCompare() {
+    // Both groups are null
+    assertEquals(FCFSSchedulerGroup.compare(null, null), 0);
+
     FCFSSchedulerGroup lhs = new FCFSSchedulerGroup("one");
     FCFSSchedulerGroup rhs = new FCFSSchedulerGroup("two");
+    assertEquals(FCFSSchedulerGroup.compare(lhs, lhs), 0);
 
-    // both groups are empty
+    // Both groups are empty
     assertNull(lhs.peekFirst());
     assertNull(rhs.peekFirst());
-    assertEquals(lhs.compareTo(lhs), 0);
     assertEquals(lhs.compareTo(rhs), 0);
     assertEquals(rhs.compareTo(lhs), 0);
-    SchedulerQueryContext firstRequest = createQueryRequest("groupOne", metrics);
-    firstRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1000 * 1_000_000L);
-    lhs.addLast(firstRequest);
 
+    SchedulerQueryContext firstRequest = createQueryRequest("groupOne", metrics, 2000);
+    lhs.addLast(firstRequest);
     assertEquals(lhs.compareTo(rhs), 1);
     assertEquals(rhs.compareTo(lhs), -1);
-    SchedulerQueryContext secondRequest = createQueryRequest("groupTwo", metrics);
-    secondRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(2000 * 1_000_000L);
+
+    SchedulerQueryContext secondRequest = createQueryRequest("groupTwo", metrics, 3000);
     rhs.addLast(secondRequest);
     assertEquals(lhs.compareTo(rhs), 1);
     assertEquals(rhs.compareTo(lhs), -1);
-    secondRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1 * 1_000_000L);
-    assertEquals(lhs.compareTo(rhs), -1);
-    assertEquals(rhs.compareTo(lhs), 1);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
@@ -118,7 +118,8 @@ public class QueryExecutorTest {
     String query = "SELECT COUNT(*) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics);
+    ServerQueryRequest queryRequest =
+        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getLong(0, 0), 400002L);
   }
@@ -128,7 +129,8 @@ public class QueryExecutorTest {
     String query = "SELECT SUM(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics);
+    ServerQueryRequest queryRequest =
+        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 40000200000.0);
   }
@@ -138,7 +140,8 @@ public class QueryExecutorTest {
     String query = "SELECT MAX(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics);
+    ServerQueryRequest queryRequest =
+        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 200000.0);
   }
@@ -148,7 +151,8 @@ public class QueryExecutorTest {
     String query = "SELECT MIN(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics);
+    ServerQueryRequest queryRequest =
+        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 0.0);
   }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
@@ -50,7 +50,7 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
 
   @Override
   public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
-    final long queryStartTimeNs = System.nanoTime();
+    long queryArrivalTimeMs = System.currentTimeMillis();
     serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
 
     LOGGER.debug("Processing request : {}", request);
@@ -67,10 +67,10 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
       return Futures.immediateFuture(null);
     }
 
-    final ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
-    final TimerContext timerContext = queryRequest.getTimerContext();
-    timerContext.setQueryArrivalTimeNs(queryStartTimeNs);
-    timerContext.startNewPhaseTimerAtNs(ServerQueryPhase.REQUEST_DESERIALIZATION, queryStartTimeNs).stopAndRecord();
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics, queryArrivalTimeMs);
+    queryRequest.getTimerContext()
+        .startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
+        .stopAndRecord();
 
     LOGGER.debug("Processing requestId:{},request={}", instanceRequest.getRequestId(), instanceRequest);
     return queryScheduler.submit(queryRequest);


### PR DESCRIPTION
Because we don't need nanos resolution for latency, change all of then using wall-clock time
Also fix the bug in the scheduler where we compare CPU time with wall-clock time