### PR TITLE
[PINOT-6609] Ignore tables for segment status check if they are disabled in ideal state

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.metrics;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.yammer.metrics.core.MetricName;
@@ -361,6 +362,16 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
       }
     } else {
       _gaugeValues.get(gaugeName).set(value);
+    }
+  }
+
+  @VisibleForTesting
+  public long getValueOfGlobalGauge(final G gauge) {
+    String gaugeName = gauge.getGaugeName();
+    if (!_gaugeValues.containsKey(gaugeName)) {
+      return 0;
+    } else {
+      return _gaugeValues.get(gaugeName).get();
     }
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
@@ -28,10 +28,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
                                          // to replicas in ideal state
   SEGMENTS_IN_ERROR_STATE("segments", false),
   PERCENT_SEGMENTS_AVAILABLE("segments", false), // Percentage of segments with at least one online replica in external view
-                                          // as compared to total number of segments in ideal state
+                                                 // as compared to total number of segments in ideal state
   IDEALSTATE_ZNODE_SIZE("idealstate", false),
   REALTIME_TABLE_COUNT("TableCount", true),
   OFFLINE_TABLE_COUNT("TableCount", true),
+  DISABLED_TABLE_COUNT("TableCount", true),
 
   SHORT_OF_LIVE_INSTANCES("ShortOfLiveInstances", false), // Number of extra live instances needed.
 


### PR DESCRIPTION
This PR has 2 main changes:
- Segment status checking is skipped for tables that are disabled in helix. Instead we now emit a disabled table count.
- The run() loop for the status check is modified to catch/log all throwables as any error in the run method will result in further checks silently suppressed (and typically, there will be no associated log for it to help debugging either)

Added unit test to cover the new code.