### PR TITLE
[PINOT-6628] Add instance ID when reporting stopped consumption

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -799,7 +799,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   protected void postStopConsumedMsg(String reason) {
     do {
       SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-      params.withOffset(_currentOffset).withReason(reason).withSegmentName(_segmentNameStr);
+      params.withOffset(_currentOffset).withReason(reason).withSegmentName(_segmentNameStr).withInstanceId(_instanceId);
 
       SegmentCompletionProtocol.Response response = _protocolHandler.segmentStoppedConsuming(params);
       if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED) {


### PR DESCRIPTION
Include instance ID when placing an http call to the controller after encountering permanent stream
consumption errors.

If the instance ID is not included, the controller ends up changing the Idealstate to include
"UNKNOWN_INSTANCE" in OFFLINE state. If at least one instance continues to consume, then this is
not a fatal problem, because eventually that instance will complete the segment and all instances will
go to ONLINE state.

However, if all instances face stream consumption issue, we will have an issue where consumption has stopped
but the state is still CONSUMING. This will trigger consumption alerts, but the auto-correction logic will
not be able to detect the situation.