### PR TITLE
Lower the probability of intermittent test failure for LargeClusterRoutingTableBuilderTest

### DIFF
--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.testng.Assert;
-import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -42,10 +41,6 @@ public class LargeClusterRoutingTableBuilderTest {
   private interface RoutingTableValidator {
     boolean isRoutingTableValid(Map<String, List<String>> routingTable, ExternalView externalView,
         List<InstanceConfig> instanceConfigs);
-  }
-
-  @BeforeSuite
-  public void setUp() {
   }
 
   @Test

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -35,7 +37,6 @@ import static org.testng.Assert.*;
  */
 public class LargeClusterRoutingTableBuilderTest {
   private static final boolean EXHAUSTIVE = false;
-  private static final long RANDOM_SEED = System.currentTimeMillis();
   private LargeClusterRoutingTableBuilder _largeClusterRoutingTableBuilder = new LargeClusterRoutingTableBuilder();
 
   private interface RoutingTableValidator {
@@ -43,9 +44,8 @@ public class LargeClusterRoutingTableBuilderTest {
         List<InstanceConfig> instanceConfigs);
   }
 
-  @Test
+  @BeforeSuite
   public void setUp() {
-    System.out.println("RANDOM_SEED = " + RANDOM_SEED);
   }
 
   @Test
@@ -131,7 +131,7 @@ public class LargeClusterRoutingTableBuilderTest {
     }
 
     assertTrue(largerThanDesiredRoutingTableCount / 0.6 < routingTableCount,
-        "More than 60% of routing tables exceed the desired routing table size, RANDOM_SEED = " + RANDOM_SEED);
+        "More than 60% of routing tables exceed the desired routing table size");
   }
 
   @Test
@@ -140,48 +140,58 @@ public class LargeClusterRoutingTableBuilderTest {
     final int segmentCount = 300;
     final int replicationFactor = 10;
     final int instanceCount = 50;
+    final int maxNumIterations = 5;   // max times we try to satisfy the load criteria. after that we fail the test
+    boolean done = false;
+    int iterationCount = 1;
 
-    ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
-    List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
+    while (!done) {
+      ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
+      List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
 
-    _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+      _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
 
-    List<Map<String, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
+      List<Map<String, List<String>>> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
-    Map<String, Integer> segmentCountPerServer = new HashMap<>();
+      Map<String, Integer> segmentCountPerServer = new HashMap<>();
 
-    // Count number of segments assigned per server
-    for (Map<String, List<String>> routingTable : routingTables) {
-      for (Map.Entry<String, List<String>> entry : routingTable.entrySet()) {
-        String serverName = entry.getKey();
-        Integer numSegmentsForServer = segmentCountPerServer.get(serverName);
+      // Count number of segments assigned per server
+      for (Map<String, List<String>> routingTable : routingTables) {
+        for (Map.Entry<String, List<String>> entry : routingTable.entrySet()) {
+          String serverName = entry.getKey();
+          Integer numSegmentsForServer = segmentCountPerServer.get(serverName);
 
-        if (numSegmentsForServer == null) {
-          numSegmentsForServer = 0;
+          if (numSegmentsForServer == null) {
+            numSegmentsForServer = 0;
+          }
+
+          numSegmentsForServer += entry.getValue().size();
+          segmentCountPerServer.put(serverName, numSegmentsForServer);
+        }
+      }
+
+      int minNumberOfSegmentsAssignedPerServer = Integer.MAX_VALUE;
+      int maxNumberOfSegmentsAssignedPerServer = 0;
+
+      for (Integer segmentCountForServer : segmentCountPerServer.values()) {
+        if (segmentCountForServer < minNumberOfSegmentsAssignedPerServer) {
+          minNumberOfSegmentsAssignedPerServer = segmentCountForServer;
         }
 
-        numSegmentsForServer += entry.getValue().size();
-        segmentCountPerServer.put(serverName, numSegmentsForServer);
+        if (maxNumberOfSegmentsAssignedPerServer < segmentCountForServer) {
+          maxNumberOfSegmentsAssignedPerServer = segmentCountForServer;
+        }
+      }
+
+      if (maxNumberOfSegmentsAssignedPerServer < minNumberOfSegmentsAssignedPerServer * 1.5) {
+        done = true;
+      } else {
+        if (iterationCount++ >= maxNumIterations) {
+          Assert.fail("At least one server has more than 150% of the load of the least loaded server, minNumberOfSegmentsAssignedPerServer = "
+                + minNumberOfSegmentsAssignedPerServer + " maxNumberOfSegmentsAssignedPerServer = "
+                + maxNumberOfSegmentsAssignedPerServer);
+        }
       }
     }
-
-    int minNumberOfSegmentsAssignedPerServer = Integer.MAX_VALUE;
-    int maxNumberOfSegmentsAssignedPerServer = 0;
-
-    for (Integer segmentCountForServer : segmentCountPerServer.values()) {
-      if (segmentCountForServer < minNumberOfSegmentsAssignedPerServer) {
-        minNumberOfSegmentsAssignedPerServer = segmentCountForServer;
-      }
-
-      if (maxNumberOfSegmentsAssignedPerServer < segmentCountForServer) {
-        maxNumberOfSegmentsAssignedPerServer = segmentCountForServer;
-      }
-    }
-
-    assertTrue(maxNumberOfSegmentsAssignedPerServer < minNumberOfSegmentsAssignedPerServer * 1.5,
-        "At least one server has more than 150% of the load of the least loaded server, minNumberOfSegmentsAssignedPerServer = "
-            + minNumberOfSegmentsAssignedPerServer + " maxNumberOfSegmentsAssignedPerServer = "
-            + maxNumberOfSegmentsAssignedPerServer + " RANDOM_SEED = " + RANDOM_SEED);
   }
 
   private String buildInstanceName(int instanceId) {


### PR DESCRIPTION
This test fails occasionally when the variance between least loaded and highest loaded server
is more than 50% across all routing tables. Since we have a random generation of routing tables
it is not guaranteed that this is always the case.

Lowered the probability of failure further by testing the criteria 5 consecutive times before
asserting a failure.