### PR TITLE
[TE] rootcause - display gaps in time series data

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
@@ -89,7 +89,7 @@ export default Component.extend({
   },
 
   line: { // on init only
-    connectNull: true
+    connectNull: false
   },
 
   _makeDiffConfig() {

--- a/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
+++ b/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
@@ -67,11 +67,11 @@ const getValues = (hoverUrns, hoverTimestamp, lookup, entities) => {
     // find first smaller or equal element
     const currentLookup = (lookup[toCurrentUrn(urn)] || []).reverse();
     const currentTimeseries = currentLookup.find(t => t[0] <= hoverTimestamp);
-    const current = currentTimeseries ? currentTimeseries[1] ? currentTimeseries[1] : Number.NaN : Number.NaN;
+    const current = currentTimeseries && currentTimeseries[1] ? currentTimeseries[1] : Number.NaN;
 
     const baselineLookup = (lookup[toBaselineUrn(urn)] || []).reverse();
     const baselineTimeseries = baselineLookup.find(t => t[0] <= hoverTimestamp);
-    const baseline = baselineTimeseries ? baselineTimeseries[1] ? baselineTimeseries[1] : Number.NaN : Number.NaN;
+    const baseline = baselineTimeseries && baselineTimeseries[1] ? baselineTimeseries[1] : Number.NaN;
 
     const change = current / baseline - 1;
 

--- a/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
+++ b/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
@@ -66,12 +66,12 @@ const getValues = (hoverUrns, hoverTimestamp, lookup, entities) => {
   metricUrns.forEach(urn => {
     // find first smaller or equal element
     const currentLookup = (lookup[toCurrentUrn(urn)] || []).reverse();
-    const currentTimeseries = currentLookup.find(t => t[0] <= hoverTimestamp && t[1] != null);
-    const current = currentTimeseries ? currentTimeseries[1] : parseFloat('NaN');
+    const currentTimeseries = currentLookup.find(t => t[0] <= hoverTimestamp);
+    const current = currentTimeseries ? currentTimeseries[1] ? currentTimeseries[1] : Number.NaN : Number.NaN;
 
     const baselineLookup = (lookup[toBaselineUrn(urn)] || []).reverse();
-    const baselineTimeseries = baselineLookup.find(t => t[0] <= hoverTimestamp && t[1] != null);
-    const baseline = baselineTimeseries ? baselineTimeseries[1] : parseFloat('NaN');
+    const baselineTimeseries = baselineLookup.find(t => t[0] <= hoverTimestamp);
+    const baseline = baselineTimeseries ? baselineTimeseries[1] ? baselineTimeseries[1] : Number.NaN : Number.NaN;
 
     const change = current / baseline - 1;
 


### PR DESCRIPTION
ThirdEye RCA currently connects time series charts over missing time series values. While this helps aesthetics, it is detrimental to users trouble shooting issues. This PR enhances the frontend code to impute expected - but missing - time stamps with non-connecting null values.

![image](https://user-images.githubusercontent.com/25439965/42595784-2c52c8f0-8508-11e8-85d2-4a805675107f.png)
