### PR TITLE
Update storage checker log to provide clearer stats

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/StorageQuotaChecker.java
@@ -42,7 +42,8 @@ public class StorageQuotaChecker {
   private final TableConfig _tableConfig;
   private final ControllerMetrics _controllerMetrics;
 
-  public StorageQuotaChecker(TableConfig tableConfig, TableSizeReader tableSizeReader, ControllerMetrics controllerMetrics) {
+  public StorageQuotaChecker(TableConfig tableConfig, TableSizeReader tableSizeReader,
+      ControllerMetrics controllerMetrics) {
     _tableConfig = tableConfig;
     _tableSizeReader = tableSizeReader;
     _controllerMetrics = controllerMetrics;
@@ -51,11 +52,13 @@ public class StorageQuotaChecker {
   public class QuotaCheckerResponse {
     public boolean isSegmentWithinQuota;
     public String reason;
+
     QuotaCheckerResponse(boolean isSegmentWithinQuota, String reason) {
       this.isSegmentWithinQuota = isSegmentWithinQuota;
       this.reason = reason;
     }
   }
+
   /**
    * check if the segment represented by segmentFile is within the storage quota
    * @param segmentFile untarred segment. This should not be null.
@@ -66,8 +69,7 @@ public class StorageQuotaChecker {
    *
    */
   public QuotaCheckerResponse isSegmentStorageWithinQuota(@Nonnull File segmentFile, @Nonnull String tableNameWithType,
-      @Nonnull String segmentName,
-      @Nonnegative int timeoutMsec) throws InvalidConfigException {
+      @Nonnull String segmentName, @Nonnegative int timeoutMsec) throws InvalidConfigException {
     Preconditions.checkNotNull(segmentFile);
     Preconditions.checkNotNull(tableNameWithType);
     Preconditions.checkNotNull(segmentName);
@@ -86,15 +88,13 @@ public class StorageQuotaChecker {
     if (quotaConfig == null || Strings.isNullOrEmpty(quotaConfig.getStorage())) {
       // no quota configuration...so ignore for backwards compatibility
       LOGGER.warn("Quota configuration not set for table: {}", tableNameWithType);
-      return new QuotaCheckerResponse(true,
-          "Quota configuration not set for table: " + tableNameWithType);
+      return new QuotaCheckerResponse(true, "Quota configuration not set for table: " + tableNameWithType);
     }
 
     long allowedStorageBytes = numReplicas * quotaConfig.storageSizeBytes();
     if (allowedStorageBytes < 0) {
       LOGGER.warn("Storage quota is not configured for table: {}", tableNameWithType);
-      return new QuotaCheckerResponse(true,
-          "Storage quota is not configured for table: " + tableNameWithType);
+      return new QuotaCheckerResponse(true, "Storage quota is not configured for table: " + tableNameWithType);
     }
     _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.TABLE_QUOTA, allowedStorageBytes);
 
@@ -111,21 +111,28 @@ public class StorageQuotaChecker {
 
     // If the segment exists(refresh), get the existing size
     TableSizeReader.SegmentSizeDetails sizeDetails = tableSubtypeSize.segments.get(segmentName);
-    long existingSegmentSizeBytes = sizeDetails != null ?  sizeDetails.estimatedSizeInBytes : 0;
+    long existingSegmentSizeBytes = sizeDetails != null ? sizeDetails.estimatedSizeInBytes : 0;
 
     // Since tableNameWithType comes with the table type(OFFLINE), thus we guarantee that
     // tableSubtypeSize.estimatedSizeInBytes is the offline table size.
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE, tableSubtypeSize.estimatedSizeInBytes);
+    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE,
+        tableSubtypeSize.estimatedSizeInBytes);
 
-    long estimatedFinalSizeBytes = tableSubtypeSize.estimatedSizeInBytes - existingSegmentSizeBytes + incomingSegmentSizeBytes;
+    // incomingSegmentSizeBytes is compressed data size for just 1 replica. Dictionary and indices sizes aren't included.
+    long estimatedFinalSizeBytes =
+        tableSubtypeSize.estimatedSizeInBytes - existingSegmentSizeBytes + (incomingSegmentSizeBytes * numReplicas);
     if (estimatedFinalSizeBytes <= allowedStorageBytes) {
-      String message = String.format("Estimated size: %d bytes is within the configured quota of %d (bytes) for table %s. Incoming segment size: %d (bytes)",
-          estimatedFinalSizeBytes, allowedStorageBytes, tableName, incomingSegmentSizeBytes);
+      String message = String.format(
+          "Estimated size: %d bytes is within the total configured quota of %d bytes for table %s.\nStorage quota: %s (%d bytes). Number of replicas: %d.\nExisting total usage among all replicas: %d bytes.\nIncoming compressed segment size: %d bytes.",
+          estimatedFinalSizeBytes, allowedStorageBytes, tableName, quotaConfig.getStorage(),
+          quotaConfig.storageSizeBytes(), numReplicas, tableSubtypeSize.estimatedSizeInBytes, incomingSegmentSizeBytes);
       LOGGER.info(message);
       return new QuotaCheckerResponse(true, message);
     } else {
-      String message = String.format("Estimated size: %d bytes exceeds the configured quota of %d (bytes) for table %s. Incoming segment size: %d (bytes)",
-          estimatedFinalSizeBytes, allowedStorageBytes, tableName, incomingSegmentSizeBytes);
+      String message = String.format(
+          "Estimated size: %d bytes exceeds the total configured quota of %d bytes for table %s.\nStorage quota: %s (%d bytes). Number of replicas: %d.\nExisting total usage among all replicas: %d bytes.\nIncoming compressed segment size: %d bytes.",
+          estimatedFinalSizeBytes, allowedStorageBytes, tableName, quotaConfig.getStorage(),
+          quotaConfig.storageSizeBytes(), numReplicas, tableSubtypeSize.estimatedSizeInBytes, incomingSegmentSizeBytes);
       LOGGER.warn(message);
       return new QuotaCheckerResponse(false, message);
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -33,8 +33,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 public class StorageQuotaCheckerTest {
@@ -106,7 +105,10 @@ public class StorageQuotaCheckerTest {
     try (FileOutputStream ostr = new FileOutputStream(tempFile)) {
       ostr.write(data);
     }
-    setupTableSegmentSize(5800, 900);
+    setupTableSegmentSize(4800, 900);
+//    doReturn(_quotaConfig).when(_tableConfig.getQuotaConfig());
+//    doReturn(3000L).when(_quotaConfig.storageSizeBytes());
+//    doReturn("3K").when(_quotaConfig.getStorage());
     when(_tableConfig.getQuotaConfig()).thenReturn(_quotaConfig);
     when(_quotaConfig.storageSizeBytes()).thenReturn(3000L);
     when(_quotaConfig.getStorage()).thenReturn("3K");

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -106,9 +106,6 @@ public class StorageQuotaCheckerTest {
       ostr.write(data);
     }
     setupTableSegmentSize(4800, 900);
-//    doReturn(_quotaConfig).when(_tableConfig.getQuotaConfig());
-//    doReturn(3000L).when(_quotaConfig.storageSizeBytes());
-//    doReturn("3K").when(_quotaConfig.getStorage());
     when(_tableConfig.getQuotaConfig()).thenReturn(_quotaConfig);
     when(_quotaConfig.storageSizeBytes()).thenReturn(3000L);
     when(_quotaConfig.getStorage()).thenReturn("3K");

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -105,7 +105,8 @@ public class StorageQuotaCheckerTest {
     try (FileOutputStream ostr = new FileOutputStream(tempFile)) {
       ostr.write(data);
     }
-    setupTableSegmentSize(4800, 900);
+    setupTableSegmentSize(4800L, 900);
+    when(_tableConfig.getTableName()).thenReturn("testTable");
     when(_tableConfig.getQuotaConfig()).thenReturn(_quotaConfig);
     when(_quotaConfig.storageSizeBytes()).thenReturn(3000L);
     when(_quotaConfig.getStorage()).thenReturn("3K");
@@ -114,6 +115,14 @@ public class StorageQuotaCheckerTest {
         checker.isSegmentStorageWithinQuota(TEST_DIR, "testTable", "segment1", 1000);
     Assert.assertTrue(response.isSegmentWithinQuota);
 
+    // Quota exceeded.
+    when(_quotaConfig.storageSizeBytes()).thenReturn(2800L);
+    when(_quotaConfig.getStorage()).thenReturn("2.8K");
+    response = checker.isSegmentStorageWithinQuota(TEST_DIR, "testTable", "segment1", 1000);
+    Assert.assertFalse(response.isSegmentWithinQuota);
+
+    // Table already over quota.
+    setupTableSegmentSize(6000L, 900);
     when(_quotaConfig.storageSizeBytes()).thenReturn(2800L);
     when(_quotaConfig.getStorage()).thenReturn("2.8K");
     response = checker.isSegmentStorageWithinQuota(TEST_DIR, "testTable", "segment1", 1000);


### PR DESCRIPTION
This PR updates storage checker log to provide clearer statistics.

Previously the estimated size is just existing size + newly incoming compress segment size, and it's hard for user to understand.

This changes explicitly show the static data(storage quota, num replicas), dynamic data (existing quota usage), and newly incoming data(new segment compressed size).