### PR TITLE
Retrieve hadoop parameters from controller

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -83,11 +83,15 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   public static final int DEFAULT_SOCKET_TIMEOUT_MS = 600 * 1000; // 10 minutes
+  public static final int GET_REQUEST_SOCKET_TIMEOUT_MS = 5 * 1000; // 5 seconds
 
   private static final String HTTP = "http";
   private static final String HTTPS = "https";
   private static final String SCHEMA_PATH = "/schemas";
   private static final String SEGMENT_PATH = "/segments";
+  private static final String GET_TABLES_PATH = "/tables";
+  private static final String GET_SCHEMA_PATH = "/schema";
+  private static final String TYPE_DELIMITER = "?type=";
 
   private final CloseableHttpClient _httpClient;
 
@@ -109,6 +113,16 @@ public class FileUploadDownloadClient implements Closeable {
 
   private static URI getURI(String scheme, String host, int port, String path) throws URISyntaxException {
     return new URI(scheme, null, host, port, path, null, null);
+  }
+
+  public static URI getRetrieveTableConfigURI(String host, int port, String tableType, String tableName) throws URISyntaxException {
+    String path = GET_TABLES_PATH + tableName + TYPE_DELIMITER + tableType;
+    return getURI(HTTP, host, port, path);
+  }
+
+  public static URI getRetrieveSchemaHttpURI(String host, int port, String tableName) throws URISyntaxException {
+    String path = GET_TABLES_PATH + tableName + GET_SCHEMA_PATH;
+    return getURI(HTTP, host, port, SCHEMA_PATH);
   }
 
   public static URI getUploadSchemaHttpURI(String host, int port) throws URISyntaxException {
@@ -140,6 +154,13 @@ public class FileUploadDownloadClient implements Closeable {
         RequestBuilder.create(method).setVersion(HttpVersion.HTTP_1_1).setUri(uri).setEntity(entity);
     addHeadersAndParameters(requestBuilder, headers, parameters);
     setTimeout(requestBuilder, socketTimeoutMs);
+    return requestBuilder.build();
+  }
+
+  private static HttpUriRequest constructGetRequest(URI uri) {
+    RequestBuilder requestBuilder = RequestBuilder.get(uri)
+        .setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, GET_REQUEST_SOCKET_TIMEOUT_MS);
     return requestBuilder.build();
   }
 
@@ -266,6 +287,30 @@ public class FileUploadDownloadClient implements Closeable {
           String.format("%s to controller: %s, version: %s", errorMessage, controllerHost, controllerVersion);
     }
     return errorMessage;
+  }
+
+  /**
+   * Get request to retrieve table config
+   * @param uri URI
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse getTableConfig(URI uri)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(constructGetRequest(uri));
+  }
+
+  /**
+   * Get request to retrieve schema
+   * @param uri URI
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse getSchema(URI uri)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(constructGetRequest(uri));
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -89,9 +89,9 @@ public class FileUploadDownloadClient implements Closeable {
   private static final String HTTPS = "https";
   private static final String SCHEMA_PATH = "/schemas";
   private static final String SEGMENT_PATH = "/segments";
-  private static final String GET_TABLES_PATH = "/tables";
-  private static final String GET_SCHEMA_PATH = "/schema";
+  private static final String TABLES_PATH = "/tables";
   private static final String TYPE_DELIMITER = "?type=";
+  private static final String SLASH = "/";
 
   private final CloseableHttpClient _httpClient;
 
@@ -115,14 +115,14 @@ public class FileUploadDownloadClient implements Closeable {
     return new URI(scheme, null, host, port, path, null, null);
   }
 
-  public static URI getRetrieveTableConfigURI(String host, int port, String tableType, String tableName) throws URISyntaxException {
-    String path = GET_TABLES_PATH + tableName + TYPE_DELIMITER + tableType;
+  public static URI getRetrieveTableConfigURI(String host, int port, String tableName) throws URISyntaxException {
+    String path = TABLES_PATH + SLASH + tableName;
     return getURI(HTTP, host, port, path);
   }
 
   public static URI getRetrieveSchemaHttpURI(String host, int port, String tableName) throws URISyntaxException {
-    String path = GET_TABLES_PATH + tableName + GET_SCHEMA_PATH;
-    return getURI(HTTP, host, port, SCHEMA_PATH);
+    String path = SCHEMA_PATH + SLASH + tableName;
+    return getURI(HTTP, host, port, path);
   }
 
   public static URI getUploadSchemaHttpURI(String host, int port) throws URISyntaxException {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.hadoop.job;
 
 import com.linkedin.pinot.common.config.TableConfig;

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
@@ -1,0 +1,84 @@
+package com.linkedin.pinot.hadoop.job;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.SimpleHttpResponse;
+import com.linkedin.pinot.hadoop.utils.PushLocation;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ControllerRestApi {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerRestApi.class);
+  private final List<PushLocation> _pushLocations;
+  private final String _tableName;
+
+  private static final String OFFLINE = "offline";
+
+  public ControllerRestApi(List<PushLocation> pushLocations, String tableName) {
+    LOGGER.info("Push Locations are: " + pushLocations);
+    _pushLocations = pushLocations;
+    _tableName = tableName;
+  }
+
+  public TableConfig getTableConfig() {
+    FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient();
+    List<URI> tableConfigURIs = new ArrayList<>();
+    try {
+      for (PushLocation pushLocation : _pushLocations) {
+        tableConfigURIs.add(FileUploadDownloadClient.getRetrieveTableConfigURI(pushLocation.getHost(), pushLocation.getPort(), _tableName, OFFLINE));
+      }
+    } catch (URISyntaxException e) {
+      LOGGER.error("Could not construct table config URI for table {}", _tableName);
+      throw new RuntimeException(e);
+    }
+
+    // Return the first table config it can retrieve
+    for (URI uri : tableConfigURIs) {
+      try {
+        SimpleHttpResponse response = fileUploadDownloadClient.getTableConfig(uri);
+        JSONObject queryResponse = new JSONObject(response.getResponse());
+        JSONObject offlineTableConfig = queryResponse.getJSONObject("OFFLINE");
+        LOGGER.info("Got table config {}", offlineTableConfig);
+        if (!queryResponse.isNull("OFFLINE")) {
+          return TableConfig.fromJSONConfig(offlineTableConfig);
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Caught exception while trying to get table config for " + _tableName + " " + e);
+      }
+    }
+    LOGGER.error("Could not get table configs from any push locations provided for " + _tableName);
+    throw new RuntimeException("Could not get table config for table " + _tableName);
+  }
+
+  public String getSchema() {
+    FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient();
+    List<URI> schemaURIs = new ArrayList<>();
+    try {
+      for (PushLocation pushLocation : _pushLocations) {
+        schemaURIs.add(FileUploadDownloadClient.getRetrieveSchemaHttpURI(pushLocation.getHost(), pushLocation.getPort(), _tableName));
+      }
+    } catch (URISyntaxException e) {
+      LOGGER.error("Could not construct schema URI for table {}", _tableName);
+      throw new RuntimeException(e);
+    }
+
+    for (URI schemaURI : schemaURIs) {
+      try {
+        SimpleHttpResponse response = fileUploadDownloadClient.getSchema(schemaURI);
+        if (response != null) {
+          return response.getResponse();
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Caught exception while trying to get schema for " + _tableName + " " + e);
+      }
+    }
+    LOGGER.error("Could not get schema configs for any push locations provided for " + _tableName);
+    throw new RuntimeException("Could not get schema for table " + _tableName);
+  }
+}

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/ControllerRestApi.java
@@ -33,7 +33,7 @@ public class ControllerRestApi {
   private final List<PushLocation> _pushLocations;
   private final String _tableName;
 
-  private static final String OFFLINE = "offline";
+  private static final String OFFLINE = "OFFLINE";
 
   public ControllerRestApi(List<PushLocation> pushLocations, String tableName) {
     LOGGER.info("Push Locations are: " + pushLocations);
@@ -46,7 +46,7 @@ public class ControllerRestApi {
     List<URI> tableConfigURIs = new ArrayList<>();
     try {
       for (PushLocation pushLocation : _pushLocations) {
-        tableConfigURIs.add(FileUploadDownloadClient.getRetrieveTableConfigURI(pushLocation.getHost(), pushLocation.getPort(), _tableName, OFFLINE));
+        tableConfigURIs.add(FileUploadDownloadClient.getRetrieveTableConfigURI(pushLocation.getHost(), pushLocation.getPort(), _tableName));
       }
     } catch (URISyntaxException e) {
       LOGGER.error("Could not construct table config URI for table {}", _tableName);
@@ -58,9 +58,9 @@ public class ControllerRestApi {
       try {
         SimpleHttpResponse response = fileUploadDownloadClient.getTableConfig(uri);
         JSONObject queryResponse = new JSONObject(response.getResponse());
-        JSONObject offlineTableConfig = queryResponse.getJSONObject("OFFLINE");
+        JSONObject offlineTableConfig = queryResponse.getJSONObject(OFFLINE);
         LOGGER.info("Got table config {}", offlineTableConfig);
-        if (!queryResponse.isNull("OFFLINE")) {
+        if (!queryResponse.isNull(OFFLINE)) {
           return TableConfig.fromJSONConfig(offlineTableConfig);
         }
       } catch (Exception e) {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -21,4 +21,11 @@ public class JobConfigConstants {
   public static final String PATH_TO_OUTPUT = "path.to.output";
 
   public static final String TARGZ = ".tar.gz";
+
+  public static final String TIME_COLUMN_NAME = "table.time.column.name";
+  public static final String TIME_COLUMN_TYPE = "table.time.column.type";
+  public static final String TABLE_PUSH_TYPE = "table.push.type";
+  public static final String SCHEMA = "data.schema";
+  public static final String SEGMENT_TABLE_NAME = "segment.table.name";
+
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -28,4 +28,7 @@ public class JobConfigConstants {
   public static final String SCHEMA = "data.schema";
   public static final String SEGMENT_TABLE_NAME = "segment.table.name";
 
+  public static final String PUSH_TO_HOSTS = "push.to.hosts";
+  public static final String PUSH_TO_PORT = "push.to.port";
+
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentTarPushJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentTarPushJob.java
@@ -38,9 +38,9 @@ public class SegmentTarPushJob extends Configured {
 
   public SegmentTarPushJob(String name, Properties properties) {
     super(new Configuration());
-    _segmentPath = properties.getProperty("path.to.output") + "/";
-    _hosts = properties.getProperty("push.to.hosts").split(",");
-    _port = Integer.parseInt(properties.getProperty("push.to.port"));
+    _segmentPath = properties.getProperty(JobConfigConstants.PATH_TO_OUTPUT) + "/";
+    _hosts = properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS).split(",");
+    _port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
   }
 
   public void run() throws Exception {
@@ -77,7 +77,7 @@ public class SegmentTarPushJob extends Configured {
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       for (String host : _hosts) {
         try (InputStream inputStream = fs.open(path)) {
-          fileName = fileName.split(".tar.gz")[0];
+          fileName = fileName.split(JobConfigConstants.TARGZ)[0];
           LOGGER.info("******** Uploading file: {} to Host: {} and Port: {} *******", fileName, host, _port);
           SimpleHttpResponse response =
               fileUploadDownloadClient.uploadSegment(FileUploadDownloadClient.getUploadSegmentHttpURI(host, _port),

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
@@ -41,9 +41,9 @@ public class SegmentUriPushJob extends Configured {
     super(new Configuration());
     _pushUriPrefix = properties.getProperty("uri.prefix", "");
     _pushUriSuffix = properties.getProperty("uri.suffix", "");
-    _segmentPath = properties.getProperty("path.to.output") + "/";
-    _hosts = properties.getProperty("push.to.hosts").split(",");
-    _port = Integer.parseInt(properties.getProperty("push.to.port"));
+    _segmentPath = properties.getProperty(JobConfigConstants.PATH_TO_OUTPUT) + "/";
+    _hosts = properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS).split(",");
+    _port = Integer.parseInt(properties.getProperty(JobConfigConstants.PUSH_TO_PORT));
   }
 
   public void run() throws Exception {
@@ -74,7 +74,7 @@ public class SegmentUriPushJob extends Configured {
 
   public void pushOneTarFile(FileSystem fs, Path path) throws Exception {
     String fileName = path.getName();
-    if (!fileName.endsWith(".tar.gz")) {
+    if (!fileName.endsWith(JobConfigConstants.TARGZ)) {
       return;
     }
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/TableConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/TableConfigConstants.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.linkedin.pinot.hadoop.job;
 
 public class TableConfigConstants {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/TableConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/TableConfigConstants.java
@@ -1,0 +1,5 @@
+package com.linkedin.pinot.hadoop.job;
+
+public class TableConfigConstants {
+  public static final String APPEND = "APPEND";
+}

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
@@ -1,0 +1,41 @@
+package com.linkedin.pinot.hadoop.utils;
+
+public class PushLocation {
+  private final String _host;
+  private final int _port;
+
+  private PushLocation(PushLocationBuilder pushLocationBuilder) {
+    _host = pushLocationBuilder._host;
+    _port = pushLocationBuilder._port;
+  }
+
+  public String getHost() {
+    return _host;
+  }
+
+  public int getPort() {
+    return _port;
+  }
+
+  public static class PushLocationBuilder{
+    private String _host;
+    private int _port;
+
+    public PushLocationBuilder() {
+    }
+
+    public PushLocationBuilder setHost(String host) {
+      _host = host;
+      return this;
+    }
+
+    public PushLocationBuilder setPort(int port) {
+      _port = port;
+      return this;
+    }
+
+    public PushLocation build() {
+      return new PushLocation(this);
+    }
+  }
+}

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.linkedin.pinot.hadoop.utils;
 
 public class PushLocation {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/utils/PushLocation.java
@@ -54,4 +54,9 @@ public class PushLocation {
       return new PushLocation(this);
     }
   }
+
+  @Override
+  public String toString() {
+    return _host + ":" + _port;
+  }
 }


### PR DESCRIPTION
* In the offline hadoop job, we do not have the option to retrieve the schema and table config from the controller host in order to create segments. We depend on the user to pass in parameters regarding whether their table is append/refresh and we serialize the schema file they pass in. It is better to have the control on the Pinot side so that their parameters can be consistent with what they set in table config. For now, I have added append/refresh from table config and using the schema we retrieve.
* This change paves the way for us to add startree/hll/other parameters from table config into segment generation. This will also allow Pinot admins to set table-level control according to parameters on their side (eg: if inverted index shouldn't be generated, etc)
* Will add option for https/http into the PushLocation object along with other options