### PR TITLE
Raise a metric indicating the response from the controller for segment commit

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -48,7 +48,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LLC_CONTROLLER_RESPONSE_KEEP("messages", true),
   LLC_CONTROLLER_RESPONSE_NOT_LEADER("messages", true),
   LLC_CONTROLLER_RESPONSE_FAILED("messages", true),
-  LLC_CONTROLLER_RESPONSE_COMMIT_SUCCESS("messages", true);
+  LLC_CONTROLLER_RESPONSE_COMMIT_SUCCESS("messages", true),
+  LLC_CONTROLLER_RESPONSE_COMMIT_CONTINUE("messages", true),
+  LLC_CONTROLLER_RESPONSE_PROCESSED("messages", true),
+  LLC_CONTROLLER_RESPONSE_UPLOAD_SUCCESS("messages", true);
 
   private final String meterName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -40,14 +40,15 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   ROWS_NEEDING_CONVERSIONS("rows", false),
   ROWS_WITH_NULL_VALUES("rows", false),
   COLUMNS_WITH_NULL_VALUES("columns", false),
-  LLC_CONTROLLER_RESPONSE_COMMIT("messages", false),
-  LLC_CONTROLLER_RESPONSE_HOLD("messages", false),
-  LLC_CONTROLLER_RESPONSE_CATCH_UP("messages", false),
-  LLC_CONTROLLER_RESPONSE_DISCARD("messages", false),
-  LLC_CONTROLLER_RESPONSE_KEEP("messages", false),
-  LLC_CONTROLLER_RESPONSE_NOT_LEADER("messages", false),
-  LLC_CONTROLLER_RESPONSE_FAILED("messages", false),
-  LLC_CONTROLLER_RESPONSE_COMMIT_SUCCESS("messages", false);
+  LLC_CONTROLLER_RESPONSE_NOT_SENT("messages", true),
+  LLC_CONTROLLER_RESPONSE_COMMIT("messages", true),
+  LLC_CONTROLLER_RESPONSE_HOLD("messages", true),
+  LLC_CONTROLLER_RESPONSE_CATCH_UP("messages", true),
+  LLC_CONTROLLER_RESPONSE_DISCARD("messages", true),
+  LLC_CONTROLLER_RESPONSE_KEEP("messages", true),
+  LLC_CONTROLLER_RESPONSE_NOT_LEADER("messages", true),
+  LLC_CONTROLLER_RESPONSE_FAILED("messages", true),
+  LLC_CONTROLLER_RESPONSE_COMMIT_SUCCESS("messages", true);
 
   private final String meterName;
   private final String unit;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -78,7 +78,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   @Override
   protected void doInit() {
-    _leaseExtender = SegmentBuildTimeLeaseExtender.create(_instanceId);
+    _leaseExtender = SegmentBuildTimeLeaseExtender.create(_instanceId, _serverMetrics);
     int maxParallelBuilds = _tableDataManagerConfig.getMaxParallelSegmentBuilds();
     if (maxParallelBuilds > 0) {
       _segmentBuildSemaphore = new Semaphore(maxParallelBuilds, true);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.data.manager.realtime;
 
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,20 +53,20 @@ public class SegmentBuildTimeLeaseExtender {
     return INSTANCE_TO_LEASE_EXTENDER.get(instanceId);
   }
 
-  public static synchronized  SegmentBuildTimeLeaseExtender create(final String instanceId) {
+  public static synchronized  SegmentBuildTimeLeaseExtender create(final String instanceId, ServerMetrics serverMetrics) {
     SegmentBuildTimeLeaseExtender leaseExtender = INSTANCE_TO_LEASE_EXTENDER.get(instanceId);
     if (leaseExtender != null) {
       LOGGER.warn("Instance already exists");
     } else {
-      leaseExtender = new SegmentBuildTimeLeaseExtender(instanceId);
+      leaseExtender = new SegmentBuildTimeLeaseExtender(instanceId, serverMetrics);
       INSTANCE_TO_LEASE_EXTENDER.put(instanceId, leaseExtender);
     }
     return leaseExtender;
   }
 
-  private SegmentBuildTimeLeaseExtender(String instanceId) {
+  private SegmentBuildTimeLeaseExtender(String instanceId, ServerMetrics serverMetrics) {
     _instanceId = instanceId;
-    _protocolHandler = new ServerSegmentCompletionProtocolHandler();
+    _protocolHandler = new ServerSegmentCompletionProtocolHandler(serverMetrics);
     _executor = new ScheduledThreadPoolExecutor(1);
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -115,7 +115,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
   private RealtimeTableDataManager createTableDataManager() {
     final String instanceId = "server-1";
-    SegmentBuildTimeLeaseExtender.create(instanceId);
+    SegmentBuildTimeLeaseExtender.create(instanceId, new ServerMetrics(new MetricsRegistry()));
     RealtimeTableDataManager tableDataManager = mock(RealtimeTableDataManager.class);
     when(tableDataManager.getServerInstance()).thenReturn(instanceId);
     RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.integration.tests;
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.config.TagNameUtils;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -28,6 +29,7 @@ import com.linkedin.pinot.server.realtime.ControllerLeaderLocator;
 import com.linkedin.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import com.linkedin.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
 import com.linkedin.pinot.util.TestUtils;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
@@ -125,7 +127,7 @@ public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegra
 
     // Now report to the controller that we had to stop consumption
     ServerSegmentCompletionProtocolHandler protocolHandler =
-        new ServerSegmentCompletionProtocolHandler();
+        new ServerSegmentCompletionProtocolHandler(new ServerMetrics(new MetricsRegistry()));
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withOffset(45688L).withSegmentName(_currentSegment).withReason("RandomReason").withInstanceId(_serverInstance);
     SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(params);


### PR DESCRIPTION
We were experiencing socket timeouts from the controller when posting segment commit message. This issue went unnoticed because we never did any reporting of the status of the post, and because if the other replicas committed successfully, the problem never has a chance to leave a trail on the consumption or segments.