### PR TITLE
Increase NUM_LOCKS available for ideal state update during segment commit

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -55,6 +55,7 @@ public class ControllerConf extends PropertiesConfiguration {
   // Amount of the time the segment can take from the beginning of upload to the end of upload. Used when parallel push
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
+  private static final String REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS = "controller.realtime.ideal.state.update.num.locks";
 
   private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
   private static final int DEFAULT_VALIDATION_CONTROLLER_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
@@ -71,6 +72,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String DEFAULT_ACCESS_CONTROL_FACTORY_CLASS =
       "com.linkedin.pinot.controller.api.access.AllowAllAccessFactory";
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
+  private static final int DEFAULT_REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS = 64;
 
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
@@ -362,5 +364,13 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public void setSegmentUploadTimeoutInMillis(long segmentUploadTimeoutInMillis) {
     setProperty(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, segmentUploadTimeoutInMillis);
+  }
+
+  public int getRealtimeSegmentIdealStateUpdateNumLocks() {
+    return getInt(REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS, DEFAULT_REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS);
+  }
+
+  public void setRealtimeSegmentIdealStateUpdateNumLocks(int realtimeSegmentIdealStateUpdateNumLocks) {
+    setProperty(REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS, realtimeSegmentIdealStateUpdateNumLocks);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -55,7 +55,7 @@ public class ControllerConf extends PropertiesConfiguration {
   // Amount of the time the segment can take from the beginning of upload to the end of upload. Used when parallel push
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
-  private static final String REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS = "controller.realtime.ideal.state.update.num.locks";
+  private static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = "controller.realtime.segment.metadata.commit.numLocks";
 
   private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
   private static final int DEFAULT_VALIDATION_CONTROLLER_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
@@ -72,7 +72,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String DEFAULT_ACCESS_CONTROL_FACTORY_CLASS =
       "com.linkedin.pinot.controller.api.access.AllowAllAccessFactory";
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
-  private static final int DEFAULT_REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS = 64;
+  private static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
 
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
@@ -366,11 +366,11 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, segmentUploadTimeoutInMillis);
   }
 
-  public int getRealtimeSegmentIdealStateUpdateNumLocks() {
-    return getInt(REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS, DEFAULT_REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS);
+  public int getRealtimeSegmentMetadataCommitNumLocks() {
+    return getInt(REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS, DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS);
   }
 
-  public void setRealtimeSegmentIdealStateUpdateNumLocks(int realtimeSegmentIdealStateUpdateNumLocks) {
-    setProperty(REALTIME_SEGMENT_IDEAL_STATE_UPDATE_NUM_LOCKS, realtimeSegmentIdealStateUpdateNumLocks);
+  public void setRealtimeSegmentMetadataCommitNumLocks(int realtimeSegmentMetadataCommitNumLocks) {
+    setProperty(REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS, realtimeSegmentMetadataCommitNumLocks);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -104,7 +104,6 @@ public class PinotLLCRealtimeSegmentManager {
   private static final String KAFKA_SMALLEST_OFFSET = "smallest";
   protected static final int STARTING_SEQUENCE_NUMBER = 0; // Initial sequence number for new table segments
   protected static final long END_OFFSET_FOR_CONSUMING_SEGMENTS = Long.MAX_VALUE;
-  private static final int NUM_LOCKS = 4;
 
   private static final String METADATA_TEMP_DIR_SUFFIX = ".metadata.tmp";
   private static final String METADATA_EVENT_NOTIFIER_PREFIX = "metadata.event.notifier";
@@ -128,6 +127,7 @@ public class PinotLLCRealtimeSegmentManager {
   private boolean _amILeader = false;
   private final ControllerConf _controllerConf;
   private final ControllerMetrics _controllerMetrics;
+  private final int _numIdealStateUpdateLocks;
   private final Lock[] _idealstateUpdateLocks;
   private final TableConfigCache _tableConfigCache;
   private final StreamPartitionAssignmentGenerator _streamPartitionAssignmentGenerator;
@@ -173,8 +173,9 @@ public class PinotLLCRealtimeSegmentManager {
     _clusterName = clusterName;
     _controllerConf = controllerConf;
     _controllerMetrics = controllerMetrics;
-    _idealstateUpdateLocks = new Lock[NUM_LOCKS];
-    for (int i = 0; i < NUM_LOCKS; i++) {
+    _numIdealStateUpdateLocks = controllerConf.getRealtimeSegmentIdealStateUpdateNumLocks();
+    _idealstateUpdateLocks = new Lock[_numIdealStateUpdateLocks];
+    for (int i = 0; i < _numIdealStateUpdateLocks; i++) {
       _idealstateUpdateLocks[i] = new ReentrantLock();
     }
     _tableConfigCache = new TableConfigCache(_propertyStore);
@@ -459,7 +460,7 @@ public class PinotLLCRealtimeSegmentManager {
     // to reduce this contention. We may still contend with RetentionManager, or other updates
     // to idealstate from other controllers, but then we have the retry mechanism to get around that.
     // hash code can be negative, so make sure we are getting a positive lock index
-    int lockIndex = (realtimeTableName.hashCode() & Integer.MAX_VALUE) % NUM_LOCKS;
+    int lockIndex = (realtimeTableName.hashCode() & Integer.MAX_VALUE) % _numIdealStateUpdateLocks;
     Lock lock = _idealstateUpdateLocks[lockIndex];
     try {
       lock.lock();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -173,7 +173,7 @@ public class PinotLLCRealtimeSegmentManager {
     _clusterName = clusterName;
     _controllerConf = controllerConf;
     _controllerMetrics = controllerMetrics;
-    _numIdealStateUpdateLocks = controllerConf.getRealtimeSegmentIdealStateUpdateNumLocks();
+    _numIdealStateUpdateLocks = controllerConf.getRealtimeSegmentMetadataCommitNumLocks();
     _idealstateUpdateLocks = new Lock[_numIdealStateUpdateLocks];
     for (int i = 0; i < _numIdealStateUpdateLocks; i++) {
       _idealstateUpdateLocks[i] = new ReentrantLock();

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class ServerSegmentCompletionProtocolHandler {
   private static Logger LOGGER = LoggerFactory.getLogger(ServerSegmentCompletionProtocolHandler.class);
   private static final int SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 30_000;
-  private static final int OTHER_REQUESTS_TIMEOUT = 5_000;
+  private static final int OTHER_REQUESTS_TIMEOUT = 10_000;
   private static final String HTTPS_PROTOCOL = "https";
   private static final String HTTP_PROTOCOL = "http";
 


### PR DESCRIPTION
Making it configurable and changing default from 4 to 64, so that more tables are allowed to enter the update ideal state block