### PR TITLE
[TE] rootcause - display selected entities in top

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-table/component.js
@@ -1,4 +1,4 @@
-import { computed, getProperties } from '@ember/object';
+import { computed, getProperties, set } from '@ember/object';
 import Component from '@ember/component';
 import {
   toCurrentUrn,
@@ -153,7 +153,7 @@ export default Component.extend({
         });
       });
 
-      return _.sortBy(rows, (row) => -1 * Math.abs(row.changeContribution));
+      return _.sortBy(rows, (row) => row.label);
     }
   ),
 
@@ -161,13 +161,7 @@ export default Component.extend({
    * Keeps track of items that are selected in the table
    * @type {Array}
    */
-  preselectedItems: computed(
-    'metricsTableData',
-    'selectedUrns',
-    function () {
-      return []; // FIXME: this is broken across all of RCA and works by accident only
-    }
-  ),
+  preselectedItems: [], // FIXME: this is broken across all of RCA and works by accident only
 
   /**
    * Sums all values for a given dimension name
@@ -218,6 +212,7 @@ export default Component.extend({
         updates[toBaselineUrn(urn)] = state;
       }
 
+      set(this, 'preselectedItems', []);
       onSelection(updates);
     }
   }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import { computed, getProperties, set } from '@ember/object';
 import Component from '@ember/component';
 import {
   toCurrentUrn,
@@ -89,7 +89,7 @@ export default Component.extend({
   links: computed(
     'entities',
     function() {
-      const { entities } = this.getProperties('entities');
+      const { entities } = getProperties(this, 'entities');
       let metricUrlMapping = {};
 
       filterPrefix(Object.keys(entities), 'thirdeye:metric:')
@@ -125,7 +125,7 @@ export default Component.extend({
     'links',
     function() {
       const { selectedUrns, entities, aggregates, scores, links } =
-        this.getProperties('selectedUrns', 'entities', 'aggregates', 'scores', 'links');
+        getProperties(this, 'selectedUrns', 'entities', 'aggregates', 'scores', 'links');
 
       const rows = filterPrefix(Object.keys(entities), 'thirdeye:metric:')
         .map(urn => {
@@ -150,7 +150,7 @@ export default Component.extend({
           };
         });
 
-      return _.sortBy(rows, (row) => -1 * scores[row.urn]);
+      return _.sortBy(rows, (row) => row.label);
     }
   ),
 
@@ -194,14 +194,7 @@ export default Component.extend({
    * Keeps track of items that are selected in the table
    * @type {Array}
    */
-  preselectedItems: computed(
-    'metricsTableData',
-    'selectedUrns',
-    function () {
-      const { metricsTableData, selectedUrns } = this.getProperties('metricsTableData', 'selectedUrns');
-      return [...selectedUrns].filter(urn => metricsTableData[urn]).map(urn => metricsTableData[urn]);
-    }
-  ),
+  preselectedItems: [], // FIXME: this is broken across all of RCA and works by accident only
 
   actions: {
     /**
@@ -212,7 +205,7 @@ export default Component.extend({
     displayDataChanged (e) {
       if (_.isEmpty(e.selectedItems)) { return; }
 
-      const { selectedUrns, onSelection } = this.getProperties('selectedUrns', 'onSelection');
+      const { selectedUrns, onSelection } = getProperties(this, 'selectedUrns', 'onSelection');
 
       if (!onSelection) { return; }
 
@@ -225,6 +218,7 @@ export default Component.extend({
         updates[toBaselineUrn(urn)] = state;
       }
 
+      set(this, 'preselectedItems', []);
       onSelection(updates);
     }
   }

--- a/thirdeye/thirdeye-frontend/app/shared/dimensionsTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/dimensionsTableColumns.js
@@ -1,6 +1,11 @@
 // rootcause dimensions table columns
 export default [
   {
+    propertyName: 'isSelected',
+    isHidden: true,
+    sortDirection: 'desc',
+    sortPrecedence: 0
+  }, {
     template: 'custom/table-checkbox',
     className: 'metrics-table__column metrics-table__column--checkbox'
   }, {
@@ -32,7 +37,9 @@ export default [
     sortedBy: 'sortable_changeContribution',
     title: 'Change in Contribution',
     disableFiltering: true,
-    className: 'metrics-table__column metrics-table__column--small'
+    className: 'metrics-table__column metrics-table__column--small',
+    sortDirection: 'desc',
+    sortPrecedence: 1
   }, {
     template: 'custom/dimensions-table-change',
     propertyName: 'contributionToChange',

--- a/thirdeye/thirdeye-frontend/app/shared/eventTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/eventTableColumns.js
@@ -1,25 +1,27 @@
 // rootcause event table columns mock
 export default [
   {
+    propertyName: 'isSelected',
+    isHidden: true,
+    sortDirection: 'desc',
+    sortPrecedence: 0
+  }, {
     template: 'custom/table-checkbox',
     useFilter: false,
     mayBeHidden: false,
     className: 'events-table__column events-table__column--checkbox'
-  },
-  {
+  }, {
     template: 'custom/table-label',
     propertyName: 'label',
     title: 'Event Name',
     className: 'events-table__column'
-  },
-  {
+  }, {
     propertyName: 'humanStart',
     title: 'Start Time',
     sortedBy: 'start',
     className: 'events-table__column events-table__column--compact',
     disableFiltering: true
-  },
-  {
+  }, {
     propertyName: 'humanDuration',
     title: 'Duration',
     sortedBy: 'duration',

--- a/thirdeye/thirdeye-frontend/app/shared/metricsTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/metricsTableColumns.js
@@ -1,6 +1,11 @@
 // rootcause metrics table columns mock
 export default [
   {
+    propertyName: 'isSelected',
+    isHidden: true,
+    sortDirection: 'desc',
+    sortPrecedence: 0
+  }, {
     template: 'custom/table-checkbox',
     className: 'metrics-table__column  metrics-table__column--checkbox'
   }, {
@@ -54,7 +59,9 @@ export default [
     propertyName: 'score',
     title: 'Outlier',
     disableFiltering: true,
-    className: 'metrics-table__column metrics-table__column--small'
+    className: 'metrics-table__column metrics-table__column--small',
+    sortDirection: 'desc',
+    sortPrecedence: 1
   }, {
     template: 'custom/rca-metric-links',
     propertyName: 'links',


### PR DESCRIPTION
Rank selected entities on top in RCA tables. also support split sorting for selected and unselected entities.