### PR TITLE
Reduce the number of threads used in test

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyServer.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyServer.java
@@ -105,8 +105,8 @@ public abstract class NettyServer implements Runnable {
   //TODO: Need configs to control number of threads
   // NOTE/atumbde: With ScheduledRequestHandler, queries are executed asynchronously.
   // So, these netty threads are not blocked. Config is still important
-  protected final EventLoopGroup _bossGroup = new NioEventLoopGroup(1);
-  protected final EventLoopGroup _workerGroup = new NioEventLoopGroup(20);
+  protected final EventLoopGroup _bossGroup;
+  protected final EventLoopGroup _workerGroup;
 
   // Netty Channel
   protected volatile Channel _channel = null;
@@ -123,11 +123,18 @@ public abstract class NettyServer implements Runnable {
   protected final long _defaultLargeQueryLatencyMs;
 
   public NettyServer(int port, RequestHandlerFactory handlerFactory, AggregatedMetricsRegistry registry, long defaultLargeQueryLatencyMs) {
+    this(port, handlerFactory, registry, defaultLargeQueryLatencyMs, 1, 20);
+  }
+
+  public NettyServer(int port, RequestHandlerFactory handlerFactory, AggregatedMetricsRegistry registry, long defaultLargeQueryLatencyMs,
+      int numThreadsForBossGroup, int numThreadsForWorkerGroup) {
     _port = port;
     _handlerFactory = handlerFactory;
     _metricsRegistry = registry;
     _metrics = new AggregatedTransportServerMetrics(_metricsRegistry, AGGREGATED_SERVER_METRICS_NAME + port + "_");
     _defaultLargeQueryLatencyMs = defaultLargeQueryLatencyMs;
+    _bossGroup = new NioEventLoopGroup(numThreadsForBossGroup);
+    _workerGroup = new NioEventLoopGroup(numThreadsForWorkerGroup);
   }
 
   @Override

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPServer.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPServer.java
@@ -46,6 +46,11 @@ public class NettyTCPServer extends NettyServer {
     this(port, handlerFactory, registry, 100);
   }
 
+  public NettyTCPServer(int port, RequestHandlerFactory handlerFactory, AggregatedMetricsRegistry registry, long defaultLargeQueryLatencyMs,
+      int numThreadsForBossGroup, int numThreadsForWorkerGroup) {
+    super(port, handlerFactory, registry, defaultLargeQueryLatencyMs, numThreadsForBossGroup, numThreadsForWorkerGroup);
+  }
+
   @Override
   protected ServerBootstrap getServerBootstrap() {
     ServerBootstrap b = new ServerBootstrap();

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
@@ -45,7 +45,7 @@ public class NettyCloseChannelTest {
     requestHandler.setResponse(NettyTestUtils.DUMMY_RESPONSE);
     NettyTestUtils.LatchControlledRequestHandlerFactory handlerFactory =
         new NettyTestUtils.LatchControlledRequestHandlerFactory(requestHandler);
-    _nettyTCPServer = new NettyTCPServer(NettyTestUtils.DEFAULT_PORT, handlerFactory, null);
+    _nettyTCPServer = new NettyTCPServer(NettyTestUtils.DEFAULT_PORT, handlerFactory, null, 100, 1, 2);
     Thread serverThread = new Thread(_nettyTCPServer, "NettyTCPServer");
     serverThread.start();
     // Wait for at most 10 seconds for server to start

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -66,7 +66,7 @@ public class NettySingleConnectionIntegrationTest {
     _requestHandler.setResponse(NettyTestUtils.DUMMY_RESPONSE);
     NettyTestUtils.LatchControlledRequestHandlerFactory handlerFactory =
         new NettyTestUtils.LatchControlledRequestHandlerFactory(_requestHandler);
-    _nettyTCPServer = new NettyTCPServer(NettyTestUtils.DEFAULT_PORT, handlerFactory, null);
+    _nettyTCPServer = new NettyTCPServer(NettyTestUtils.DEFAULT_PORT, handlerFactory, null, 100, 1, 6);
     Thread serverThread = new Thread(_nettyTCPServer, "NettyTCPServer");
     serverThread.start();
     // Wait for at most 10 seconds for server to start


### PR DESCRIPTION
Previously this test often failed at the following exception:
```
java.lang.IllegalStateException: Unable to shutdown the worker group in 60000 ms
	at com.linkedin.pinot.transport.netty.NettyCloseChannelTest.testCloseServerChannel(NettyCloseChannelTest.java:96)
```
Looking into the code, worker group is assigned 20 threads when the constructor gets called. While in Travis, the machine could be lack of available threads.