### PR TITLE
Fix NPE when rebalance is called with a table that does not exist

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -135,6 +135,11 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName);
   }
 
+  public String forTableRebalance(String tableName, String tableType) {
+    String query = "rebalance?dryrun=false&type=" + tableType;
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, query);
+  }
+
   public String forTableUpdateIndexingConfigs(String tableName) {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "indexingConfigs");
   }


### PR DESCRIPTION
Currently a typo in the tablename when we invoke rebalance results in NPE.
 curl -X POST 'localhost:11984/tables/non-existent/rebalance?dryrun=false&type=offline'
{"code":500,"error":null}

This PR fixes it and adds tests for the same.