### PR TITLE
[PINOT-6677] Clean up any existing segment dir before replacing a segment

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -259,12 +259,14 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     File tempSegmentFolder =
         new File(_indexDir, "tmp-" + segmentName + "." + String.valueOf(System.currentTimeMillis()));
     File tempFile = new File(_indexDir, segmentName + ".tar.gz");
+    final File segmentFolder = new File(_indexDir, segmentName);
+    FileUtils.deleteQuietly(segmentFolder);
     try {
       SegmentFetcherFactory.getInstance().getSegmentFetcherBasedOnURI(uri).fetchSegmentToLocal(uri, tempFile);
       _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, tempFile, tempFile.length());
       TarGzCompressionUtils.unTar(tempFile, tempSegmentFolder);
       _logger.info("Uncompressed file {} into tmp dir {}", tempFile, tempSegmentFolder);
-      FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], new File(_indexDir, segmentName));
+      FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], segmentFolder);
       _logger.info("Replacing LLC Segment {}", segmentName);
       replaceLLSegment(segmentName, indexLoadingConfig);
     } catch (Exception e) {


### PR DESCRIPTION
In LLC, it is possible that a server tries to commit a segment, the commit fails, and eventually
another server commits the same segment with a different end offset. In that case, the
server that originally tried to commit the segment will get a DISCARD on for the consumer,
and eventually a state transition to ONLINE. In that case, we should clean out the original
segment before replacing it.