### PR TITLE
Remove leadership check when setting up metadata for new table

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -110,6 +110,7 @@ public class PinotTableRestletResource {
     try {
       ensureMinReplicas(tableConfig);
       _pinotHelixResourceManager.addTable(tableConfig);
+      // TODO: validate that table was created successfully (in realtime case, metadata might not have been created)
       return new SuccessResponse("Table " + tableName + " succesfully added");
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -355,7 +355,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     CommittingSegmentDescriptor committingSegmentDescriptor =
         new CommittingSegmentDescriptor(segmentName, nextOffset, 0);
     segmentManager.createNewSegmentMetadataZNRecord(tableConfig, llcSegmentName, newLlcSegmentName, partitionAssignment,
-        committingSegmentDescriptor);
+        committingSegmentDescriptor, true);
     segmentManager.updateIdealStateOnSegmentCompletion(idealState, segmentName, newLlcSegmentName.getSegmentName(),
         partitionAssignment);
   }
@@ -560,7 +560,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
           CommittingSegmentDescriptor committingSegmentDescriptor =
               new CommittingSegmentDescriptor(latestSegment.getSegmentName(), latestMetadata.getStartOffset() + 100, 0);
           segmentManager.createNewSegmentMetadataZNRecord(tableConfig, latestSegment, newLlcSegmentName,
-              expectedPartitionAssignment, committingSegmentDescriptor);
+              expectedPartitionAssignment, committingSegmentDescriptor, true);
 
           // get old state
           Assert.assertNull(idealState.getRecord().getMapFields().get(newLlcSegmentName.getSegmentName()));
@@ -1359,10 +1359,10 @@ public class PinotLLCRealtimeSegmentManagerTest {
     @Override
     protected boolean createNewSegmentMetadataZNRecord(TableConfig realtimeTableConfig,
         LLCSegmentName committingSegmentName, LLCSegmentName newLLCSegmentName, PartitionAssignment partitionAssignment,
-        CommittingSegmentDescriptor committingSegmentDescriptor) {
+        CommittingSegmentDescriptor committingSegmentDescriptor, boolean checkLeader) {
       _nCallsToCreateNewSegmentMetadata++;
       return super.createNewSegmentMetadataZNRecord(realtimeTableConfig, committingSegmentName, newLLCSegmentName,
-          partitionAssignment, committingSegmentDescriptor);
+          partitionAssignment, committingSegmentDescriptor, checkLeader);
     }
 
     @Override


### PR DESCRIPTION
Adding a new table can be done by any controller, not just the leader. We should not check for leadership when adding metadata in this case, else we will end up not creating metadata but updating the ideal state. This results in an incorrect setup for an hour until the validation anager fixes it