### PR TITLE
Ignore NettyCloseChannelTest

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
@@ -193,7 +193,7 @@ public class NettyTCPClientConnection extends NettyClientConnection  {
        * simultaneously. Netty does not provide guarantees around this. So in worst case, the thread that
        * is flushing request could block for sometime and gets executed after the response is obtained.
        * We should checkin the connection to the pool only after all outstanding callbacks are complete.
-       * We do this by trancking the connection state. If we detect that response/error is already obtained,
+       * We do this by tracking the connection state. If we detect that response/error is already obtained,
        * we then do the process of checking back the connection to the pool or destroying (if error)
        */
       synchronized(_handler)

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
@@ -24,7 +24,6 @@ import io.netty.util.HashedWheelTimer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -85,9 +84,14 @@ public class NettyCloseChannelTest {
 
   /**
    * Client sends a request. Server closes the channel.
+   * This test sometimes fails only in Travis because the hardware who run this test may not have sufficient cores to be assigned to all the threads at a time.
+   * The reason why this test can be ignored is the purpose of this test is to test the response is null when the server connection gets closed.
+   * Whereas because of the hardware in Travis, threads in worker group may still get the request and thus cannot be closed in time.
+   * The expected behavior is that response is null but it's still acceptable when this response isn't null, i.e. getting a real response.
+   * And users won't have any big effect when getting a non-null response. What's more, discussed with Jackie offline, this part of code will be rewritten in the near future.
+   * So for now it's ok to just ignore this test.
    */
-  @Test
-  @Ignore
+  @Test(enabled = false)
   public void testCloseServerChannel()
       throws Exception {
     Assert.assertTrue(_nettyTCPClientConnection.connect());

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
@@ -24,6 +24,7 @@ import io.netty.util.HashedWheelTimer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -86,6 +87,7 @@ public class NettyCloseChannelTest {
    * Client sends a request. Server closes the channel.
    */
   @Test
+  @Ignore
   public void testCloseServerChannel()
       throws Exception {
     Assert.assertTrue(_nettyTCPClientConnection.connect());


### PR DESCRIPTION
This test sometimes fails only in Travis because the hardwares who run this test may not have sufficient cores to be assigned to all the threads at a time.   
The reason why this test can be ignored is the purpose of this test is to test the response is null when the server connection gets closed. Whereas because of the hardware in Travis, threads in worker group may still get the request and thus cannot be closed in time. The expected behavior is that response is null but it's still acceptable when this response isn't null, i.e. getting a real response. And users won't have any big effect when getting a non-null response. What's more, discussed with Jackie offline, this part of code will be rewritten in the near future. So for now it's ok to just ignore this test. 