### PR TITLE
Replace LBufferAPI in star-tree with PinotDataBuffer

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
@@ -172,7 +172,7 @@ public class FixedByteSingleValueMultiColReader implements Closeable {
     final int length = getColumnSizes()[col];
     final byte[] dst = new byte[length];
     final int offset = computeOffset(row, col);
-    indexDataBuffer.copyTo(offset, dst);
+    indexDataBuffer.copyTo(offset, dst, 0, length);
     return dst;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/FixedByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/FixedByteChunkSingleValueReader.java
@@ -115,7 +115,7 @@ public class FixedByteChunkSingleValueReader extends BaseChunkSingleValueReader 
   public byte[] getBytes(int row) {
     if (!isCompressed()) {
       byte[] bytes = _reusableBytes.get();
-      getRawData().copyTo(row * _lengthOfLongestEntry, bytes);
+      getRawData().copyTo(row * _lengthOfLongestEntry, bytes, 0, _lengthOfLongestEntry);
       return bytes;
     } else {
       throw new UnsupportedOperationException("Read without context not supported for compressed data.");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/DimensionBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/DimensionBuffer.java
@@ -15,47 +15,44 @@
  */
 package com.linkedin.pinot.core.startree;
 
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.IntBuffer;
 
 
 public class DimensionBuffer {
-  private static final ByteOrder NATIVE_ORDER = ByteOrder.nativeOrder();
-
-  private final int _numDimensions;
-  private final IntBuffer _intBuffer;
-
-  public DimensionBuffer(int numDimensions) {
-    _numDimensions = numDimensions;
-    _intBuffer = ByteBuffer.wrap(new byte[numDimensions * V1Constants.Numbers.INTEGER_SIZE]).asIntBuffer();
-  }
-
-  public DimensionBuffer(byte[] bytes) {
-    _numDimensions = bytes.length / V1Constants.Numbers.INTEGER_SIZE;
-    // NOTE: the byte array is returned from Unsafe which uses native order
-    _intBuffer = ByteBuffer.wrap(bytes).order(NATIVE_ORDER).asIntBuffer();
-  }
+  private final ByteBuffer _buffer;
 
   public static DimensionBuffer fromBytes(byte[] bytes) {
     return new DimensionBuffer(bytes);
   }
 
-  public int getDimension(int index) {
-    return _intBuffer.get(index);
+  public DimensionBuffer(int numDimensions) {
+    _buffer = ByteBuffer.wrap(new byte[numDimensions * Integer.BYTES]).order(PinotDataBuffer.NATIVE_ORDER);
   }
 
-  public void setDimension(int index, int value) {
-    _intBuffer.put(index, value);
+  private DimensionBuffer(byte[] bytes) {
+    _buffer = ByteBuffer.wrap(bytes).order(PinotDataBuffer.NATIVE_ORDER);
   }
 
-  @SuppressWarnings({"EqualsWhichDoesntCheckParameterClass", "CheckStyle"})
-  @Override
-  public boolean equals(Object obj) {
-    DimensionBuffer that = (DimensionBuffer) obj;
-    for (int i = 0; i < _numDimensions; i++) {
-      if (_intBuffer.get(i) != that._intBuffer.get(i)) {
+  public int getDictId(int index) {
+    return _buffer.getInt(index * Integer.BYTES);
+  }
+
+  public void setDictId(int index, int dictId) {
+    _buffer.putInt(index * Integer.BYTES, dictId);
+  }
+
+  public byte[] toBytes() {
+    return _buffer.array();
+  }
+
+  // NOTE: we don't check whether the array is null or the length of the array for performance concern. All the
+  // dimension buffers should have the same length.
+  public boolean hasSameBytes(byte[] dimensionBytes) {
+    byte[] bytes = _buffer.array();
+    int numBytes = bytes.length;
+    for (int i = 0; i < numBytes; i++) {
+      if (bytes[i] != dimensionBytes[i]) {
         return false;
       }
     }
@@ -66,8 +63,9 @@ public class DimensionBuffer {
   public String toString() {
     StringBuilder builder = new StringBuilder("[");
     String delimiter = "";
-    for (int i = 0; i < _numDimensions; i++) {
-      builder.append(delimiter).append(_intBuffer.get(i));
+    int numBytes = _buffer.limit();
+    for (int i = 0; i < numBytes; i += Integer.BYTES) {
+      builder.append(delimiter).append(_buffer.getInt(i));
       delimiter = ", ";
     }
     builder.append("]");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/MetricBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/MetricBuffer.java
@@ -17,157 +17,131 @@ package com.linkedin.pinot.core.startree;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec.DerivedMetricType;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import com.linkedin.pinot.core.startree.hll.HllUtil;
-import com.linkedin.pinot.startree.hll.HllSizeUtils;
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 
-/**
- * fromBytes and toBytes methods are used only in {@link OffHeapStarTreeBuilder}, as read and write to temp files.
- * Thus no serialization of hll type to string is necessary at these steps.
- */
+
 public class MetricBuffer {
-
-  /**
-   * stored as number or hyperLogLog, but serialized out as number or string
-   */
-  private final Object[] values;
-  private final List<MetricFieldSpec> metricFieldSpecs;
-
-  public MetricBuffer(Object[] values, List<MetricFieldSpec> metricFieldSpecs) {
-    this.values = values;
-    this.metricFieldSpecs = metricFieldSpecs;
-  }
-
-  public MetricBuffer(MetricBuffer copy) {
-    this.values = new Object[copy.values.length];
-    for (int i = 0; i < this.values.length; i++) {
-      Object copyValue = copy.values[i];
-      if (copyValue instanceof HyperLogLog) {
-        // deep copy of hll field
-        this.values[i] = HllUtil.clone((HyperLogLog)copyValue,
-            HllSizeUtils.getLog2mFromHllFieldSize(copy.metricFieldSpecs.get(i).getFieldSize()));
-      } else if (copyValue instanceof Number) {
-        // number field is immutable
-        this.values[i] = copyValue;
-      } else {
-        throw new IllegalArgumentException("Unsupported metric type: " + copyValue.getClass());
-      }
-    }
-    this.metricFieldSpecs = copy.metricFieldSpecs;
-  }
+  private final Object[] _values;
+  private final List<MetricFieldSpec> _metricFieldSpecs;
 
   public static MetricBuffer fromBytes(byte[] bytes, List<MetricFieldSpec> metricFieldSpecs) {
-    ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    Object[] values = new Object[metricFieldSpecs.size()];
+    int numMetrics = metricFieldSpecs.size();
+    Object[] values = new Object[numMetrics];
 
-    for (int i = 0; i < metricFieldSpecs.size(); i++) {
-      MetricFieldSpec metric = metricFieldSpecs.get(i);
-      if (metric.getDerivedMetricType() == DerivedMetricType.HLL) {
-        byte[] hllBytes = new byte[metric.getFieldSize()]; // TODO: buffer reuse
-        buffer.get(hllBytes);
-        values[i] = HllUtil.buildHllFromBytes(hllBytes);
-      } else {
-        switch (metric.getDataType()) {
-          case INT:
-            values[i] = buffer.getInt();
-            break;
-          case LONG:
-            values[i] = buffer.getLong();
-            break;
-          case FLOAT:
-            values[i] = buffer.getFloat();
-            break;
-          case DOUBLE:
-            values[i] = buffer.getDouble();
-            break;
-          default:
-            throw new IllegalArgumentException("Unsupported metric type " + metric.getDataType());
-        }
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(PinotDataBuffer.NATIVE_ORDER);
+    for (int i = 0; i < numMetrics; i++) {
+      MetricFieldSpec metricFieldSpec = metricFieldSpecs.get(i);
+      switch (metricFieldSpec.getDataType()) {
+        case INT:
+          values[i] = buffer.getInt();
+          break;
+        case LONG:
+          values[i] = buffer.getLong();
+          break;
+        case FLOAT:
+          values[i] = buffer.getFloat();
+          break;
+        case DOUBLE:
+          values[i] = buffer.getDouble();
+          break;
+        case STRING:
+          assert metricFieldSpec.getDerivedMetricType() == DerivedMetricType.HLL;
+          byte[] hllBytes = new byte[metricFieldSpec.getFieldSize()];
+          buffer.get(hllBytes);
+          values[i] = HllUtil.buildHllFromBytes(hllBytes);
+          break;
+        default:
+          throw new IllegalStateException();
       }
     }
+
     return new MetricBuffer(values, metricFieldSpecs);
   }
 
-  public byte[] toBytes(int numBytes) throws IOException {
-    byte[] bytes = new byte[numBytes];
-    ByteBuffer buffer = ByteBuffer.wrap(bytes);
-
-    for (int i = 0; i < metricFieldSpecs.size(); i++) {
-      MetricFieldSpec metric = metricFieldSpecs.get(i);
-      if (metric.getDerivedMetricType() == DerivedMetricType.HLL) {
-        buffer.put(((HyperLogLog)values[i]).getBytes());
-      } else {
-        switch (metric.getDataType()) {
-          case INT:
-            buffer.putInt(((Number) values[i]).intValue());
-            break;
-          case LONG:
-            buffer.putLong(((Number) values[i]).longValue());
-            break;
-          case FLOAT:
-            buffer.putFloat(((Number) values[i]).floatValue());
-            break;
-          case DOUBLE:
-            buffer.putDouble(((Number) values[i]).doubleValue());
-            break;
-          default:
-            throw new IllegalArgumentException("Unsupported metric type " + metric.getDataType());
-        }
-      }
-    }
-    return bytes;
-  }
-
-  public void aggregate(MetricBuffer metrics) {
-    for (int i = 0; i < metricFieldSpecs.size(); i++) {
-      MetricFieldSpec metric = metricFieldSpecs.get(i);
-      if (metric.getDerivedMetricType() == DerivedMetricType.HLL) {
-        try {
-          ((HyperLogLog) values[i]).addAll((HyperLogLog) metrics.values[i]);
-        } catch (CardinalityMergeException e) {
-          throw new RuntimeException(e);
-        }
-      } else {
-        switch (metric.getDataType()) {
-          case INT:
-            values[i] = ((Number) values[i]).intValue() + ((Number) metrics.values[i]).intValue();
-            break;
-          case LONG:
-            values[i] = ((Number) values[i]).longValue() + ((Number) metrics.values[i]).longValue();
-            break;
-          case FLOAT:
-            values[i] = ((Number) values[i]).floatValue() + ((Number) metrics.values[i]).floatValue();
-            break;
-          case DOUBLE:
-            values[i] = ((Number) values[i]).doubleValue() + ((Number) metrics.values[i]).doubleValue();
-            break;
-          default:
-            throw new IllegalArgumentException("Unsupported metric type " + metric.getDataType());
-        }
-      }
-    }
+  public MetricBuffer(Object[] values, List<MetricFieldSpec> metricFieldSpecs) {
+    _values = values;
+    _metricFieldSpecs = metricFieldSpecs;
   }
 
   /**
-   * this method should return correct value conformed to datatype to iterators
-   * @param index
-   * @return
+   * NOTE: pass in byte size for performance. Byte size can be calculated by adding up field size for all metrics.
    */
-  public Object getValueConformToDataType(int index) {
-    if (metricFieldSpecs.get(index).getDerivedMetricType() == DerivedMetricType.HLL) {
-      return HllUtil.convertHllToString((HyperLogLog) values[index]);
-    } else {
-      return values[index];
+  public byte[] toBytes(int byteSize) {
+    byte[] bytes = new byte[byteSize];
+    ByteBuffer buffer = ByteBuffer.wrap(bytes).order(PinotDataBuffer.NATIVE_ORDER);
+
+    int numValues = _values.length;
+    for (int i = 0; i < numValues; i++) {
+      MetricFieldSpec metricFieldSpec = _metricFieldSpecs.get(i);
+      switch (metricFieldSpec.getDataType()) {
+        case INT:
+          buffer.putInt((Integer) _values[i]);
+          break;
+        case LONG:
+          buffer.putLong((Long) _values[i]);
+          break;
+        case FLOAT:
+          buffer.putFloat((Float) _values[i]);
+          break;
+        case DOUBLE:
+          buffer.putDouble((Double) _values[i]);
+          break;
+        case STRING:
+          assert metricFieldSpec.getDerivedMetricType() == DerivedMetricType.HLL;
+          buffer.put(HllUtil.toBytes((HyperLogLog) _values[i]));
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+    }
+
+    return bytes;
+  }
+
+  public void aggregate(MetricBuffer buffer) {
+    int numValues = _values.length;
+    for (int i = 0; i < numValues; i++) {
+      MetricFieldSpec metricFieldSpec = _metricFieldSpecs.get(i);
+      switch (metricFieldSpec.getDataType()) {
+        case INT:
+          _values[i] = (Integer) _values[i] + (Integer) buffer._values[i];
+          break;
+        case LONG:
+          _values[i] = (Long) _values[i] + (Long) buffer._values[i];
+          break;
+        case FLOAT:
+          _values[i] = (Float) _values[i] + (Float) buffer._values[i];
+          break;
+        case DOUBLE:
+          _values[i] = (Double) _values[i] + (Double) buffer._values[i];
+          break;
+        case STRING:
+          assert metricFieldSpec.getDerivedMetricType() == DerivedMetricType.HLL;
+          try {
+            ((HyperLogLog) _values[i]).addAll((HyperLogLog) buffer._values[i]);
+          } catch (CardinalityMergeException e) {
+            throw new RuntimeException(e);
+          }
+          break;
+        default:
+          throw new IllegalStateException();
+      }
     }
   }
 
-  @Override
-  public String toString() {
-    return Arrays.toString(values);
+  public Object getValueConformToDataType(int index) {
+    MetricFieldSpec metricFieldSpec = _metricFieldSpecs.get(index);
+    if (metricFieldSpec.getDataType() == FieldSpec.DataType.STRING) {
+      assert metricFieldSpec.getDerivedMetricType() == DerivedMetricType.HLL;
+      return HllUtil.convertHllToString((HyperLogLog) _values[index]);
+    } else {
+      return _values[index];
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTree.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTree.java
@@ -18,22 +18,16 @@ package com.linkedin.pinot.core.startree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import xerial.larray.buffer.LBuffer;
-import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.mmap.MMapBuffer;
-import xerial.larray.mmap.MMapMode;
 
 
 /**
@@ -45,9 +39,8 @@ public class OffHeapStarTree implements StarTree {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
   private static final int DIMENSION_NAME_MAX_LENGTH = 4096;
-  private static final int LOAD_FILE_BUFFER_SIZE = 10 * 1024 * 1024;
 
-  private final LBufferAPI _dataBuffer;
+  private final PinotDataBuffer _dataBuffer;
   private final OffHeapStarTreeNode _root;
   private final List<String> _dimensionNames;
 
@@ -57,37 +50,40 @@ public class OffHeapStarTree implements StarTree {
    * - Loads/MMap's the OffHeapStarTreeNode array.
    */
   public OffHeapStarTree(File starTreeFile, ReadMode readMode) throws IOException {
+    // Backward-compatible: star-tree file is always little-endian
     if (readMode.equals(ReadMode.mmap)) {
-      _dataBuffer = new MMapBuffer(starTreeFile, MMapMode.READ_ONLY);
+      _dataBuffer = PinotDataBuffer.mapFile(starTreeFile, true, 0, starTreeFile.length(), ByteOrder.LITTLE_ENDIAN,
+          "OffHeapStarTree");
     } else {
-      _dataBuffer = loadFrom(starTreeFile);
+      _dataBuffer =
+          PinotDataBuffer.loadFile(starTreeFile, 0, starTreeFile.length(), ByteOrder.LITTLE_ENDIAN, "OffHeapStarTree");
     }
 
     long offset = 0L;
     Preconditions.checkState(MAGIC_MARKER == _dataBuffer.getLong(offset), "Invalid magic marker in Star Tree file");
-    offset += V1Constants.Numbers.LONG_SIZE;
+    offset += Long.BYTES;
 
     Preconditions.checkState(VERSION == _dataBuffer.getInt(offset), "Invalid version in Star Tree file");
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     int rootNodeOffset = _dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     int numDimensions = _dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     String[] dimensionNames = new String[numDimensions];
     byte[] dimensionNameBytes = new byte[DIMENSION_NAME_MAX_LENGTH];
     for (int i = 0; i < numDimensions; i++) {
       // NOTE: In old version, index might not be stored in order
       int dimensionId = _dataBuffer.getInt(offset);
-      offset += V1Constants.Numbers.INTEGER_SIZE;
+      offset += Integer.BYTES;
 
       int dimensionLength = _dataBuffer.getInt(offset);
       Preconditions.checkState(dimensionLength < DIMENSION_NAME_MAX_LENGTH);
-      offset += V1Constants.Numbers.INTEGER_SIZE;
+      offset += Integer.BYTES;
 
-      _dataBuffer.copyTo((int) offset, dimensionNameBytes, 0, dimensionLength);
+      _dataBuffer.copyTo(offset, dimensionNameBytes, 0, dimensionLength);
       offset += dimensionLength;
 
       String dimensionName = new String(dimensionNameBytes, 0, dimensionLength, UTF_8);
@@ -96,31 +92,13 @@ public class OffHeapStarTree implements StarTree {
     _dimensionNames = Arrays.asList(dimensionNames);
 
     int numNodes = _dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
     Preconditions.checkState(offset == rootNodeOffset, "Error reading Star Tree file, header length mis-match");
     long fileLength = starTreeFile.length();
     Preconditions.checkState(offset + numNodes * OffHeapStarTreeNode.SERIALIZABLE_SIZE_IN_BYTES == fileLength,
         "Error reading Star Tree file, file length mis-match");
 
     _root = new OffHeapStarTreeNode(_dataBuffer.view(rootNodeOffset, fileLength), 0);
-  }
-
-  /**
-   * Helper method to create an LBuffer from a given file.
-   */
-  private static LBuffer loadFrom(File file) throws IOException {
-    try (FileChannel fileChannel = new FileInputStream(file).getChannel()) {
-      ByteBuffer byteBuffer = ByteBuffer.allocate(LOAD_FILE_BUFFER_SIZE);
-      LBuffer lBuffer = new LBuffer(file.length());
-
-      long offset = 0;
-      int numBytesRead;
-      while ((numBytesRead = fileChannel.read(byteBuffer, offset)) > 0) {
-        lBuffer.readFrom(byteBuffer.array(), 0, offset, numBytesRead);
-        offset += numBytesRead;
-      }
-      return lBuffer;
-    }
   }
 
   @Override
@@ -187,10 +165,6 @@ public class OffHeapStarTree implements StarTree {
 
   @Override
   public void close() throws IOException {
-    if (_dataBuffer instanceof MMapBuffer) {
-      ((MMapBuffer) _dataBuffer).close();
-    } else {
-      _dataBuffer.release();
-    }
+    _dataBuffer.close();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -25,10 +25,10 @@ import com.linkedin.pinot.common.utils.Pairs.IntPair;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.segment.creator.ColumnIndexCreationInfo;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import com.linkedin.pinot.core.startree.hll.HllUtil;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.io.BufferedOutputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -38,8 +38,6 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -54,10 +52,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import xerial.larray.buffer.LBuffer;
-import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.mmap.MMapBuffer;
-import xerial.larray.mmap.MMapMode;
 
 
 /**
@@ -103,14 +97,15 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapStarTreeBuilder.class);
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  // If the temporary buffer needed is larger than 500M, create a file and use MMapBuffer, otherwise use LBuffer
+  // If the temporary buffer needed is larger than 500M, use MMAP, otherwise use DIRECT
   private static final long MMAP_SIZE_THRESHOLD = 500_000_000;
 
   private File _tempDir;
   private File _dataFile;
-  private DataOutputStream _dataOutputStream;
+  private BufferedOutputStream _outputStream;
 
   private Schema _schema;
+  private List<MetricFieldSpec> _metricFieldSpecs;
   private List<Integer> _dimensionsSplitOrder;
   private Set<Integer> _skipStarNodeCreationDimensions;
   private Set<Integer> _skipMaterializationDimensions;
@@ -134,25 +129,11 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   private final List<String> _metricNames = new ArrayList<>();
   private int _metricSize;
 
-  private long _docSize;
+  private long _docSizeLong;
   private int[] _sortOrder;
 
   // Store data tables that need to be closed in close()
-  private final List<StarTreeDataTable> _dataTablesToClose = new ArrayList<>();
-
-  private static final boolean NEED_FLIP_ENDIANNESS = ByteOrder.nativeOrder() != ByteOrder.BIG_ENDIAN;
-
-  /**
-   * Flip the endianness of an int if needed.
-   * <p>This is required to keep all the int as native order. (FileOutputStream always write int using BIG_ENDIAN)
-   */
-  private static int flipEndiannessIfNeeded(int value) {
-    if (NEED_FLIP_ENDIANNESS) {
-      return Integer.reverseBytes(value);
-    } else {
-      return value;
-    }
-  }
+  private final Set<StarTreeDataTable> _dataTablesToClose = new HashSet<>();
 
   /**
    * Helper class to represent a tree node.
@@ -177,9 +158,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     LOGGER.info("Star tree temporary directory: {}", _tempDir);
     _dataFile = new File(_tempDir, "star-tree.buf");
     LOGGER.info("Star tree data file: {}", _dataFile);
-    _dataOutputStream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(_dataFile)));
+    _outputStream = new BufferedOutputStream(new FileOutputStream(_dataFile));
 
     _schema = builderConfig.getSchema();
+    _metricFieldSpecs = _schema.getMetricFieldSpecs();
     _skipMaterializationCardinalityThreshold = builderConfig.getSkipMaterializationCardinalityThreshold();
     _maxNumLeafRecords = builderConfig.getMaxNumLeafRecords();
     _excludeSkipMaterializationDimensionsForStarTreeIndex =
@@ -193,10 +175,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
         _numDimensions++;
         _dimensionNames.add(dimensionName);
         _dimensionStarValues.add(fieldSpec.getDefaultNullValue());
-        _dimensionDictionaries.add(HashBiMap.<Object, Integer>create());
+        _dimensionDictionaries.add(HashBiMap.create());
       }
     }
-    _dimensionSize = _numDimensions * V1Constants.Numbers.INTEGER_SIZE;
+    _dimensionSize = _numDimensions * Integer.BYTES;
 
     // Convert string based config to index based config
     List<String> dimensionsSplitOrder = builderConfig.getDimensionsSplitOrder();
@@ -216,8 +198,8 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     }
 
     // Metric fields
-    // NOTE: the order of _metricNames should be the same as _schema.getMetricFieldSpecs()
-    for (MetricFieldSpec metricFieldSpec : _schema.getMetricFieldSpecs()) {
+    // NOTE: the order of _metricNames should be the same as _metricFieldSpecs
+    for (MetricFieldSpec metricFieldSpec : _metricFieldSpecs) {
       _numMetrics++;
       _metricNames.add(metricFieldSpec.getName());
       _metricSize += metricFieldSpec.getFieldSize();
@@ -226,7 +208,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     LOGGER.info("Dimension Names: {}", _dimensionNames);
     LOGGER.info("Metric Names: {}", _metricNames);
 
-    _docSize = _dimensionSize + _metricSize;
+    _docSizeLong = _dimensionSize + _metricSize;
 
     // Initialize the root node
     _rootNode = new TreeNode();
@@ -256,16 +238,15 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
         dictId = dimensionDictionary.size();
         dimensionDictionary.put(dimensionValue, dictId);
       }
-      dimensions.setDimension(i, dictId);
+      dimensions.setDictId(i, dictId);
     }
 
     // Metrics
     Object[] metricValues = new Object[_numMetrics];
-    List<MetricFieldSpec> metricFieldSpecs = _schema.getMetricFieldSpecs();
     for (int i = 0; i < _numMetrics; i++) {
       String metricName = _metricNames.get(i);
       Object metricValue = row.getValue(metricName);
-      if (metricFieldSpecs.get(i).getDerivedMetricType() == MetricFieldSpec.DerivedMetricType.HLL) {
+      if (_metricFieldSpecs.get(i).getDerivedMetricType() == MetricFieldSpec.DerivedMetricType.HLL) {
         // Convert HLL field from string format to HyperLogLog
         metricValues[i] = HllUtil.convertStringToHll((String) metricValue);
       } else {
@@ -273,7 +254,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
         metricValues[i] = metricValue;
       }
     }
-    MetricBuffer metrics = new MetricBuffer(metricValues, metricFieldSpecs);
+    MetricBuffer metrics = new MetricBuffer(metricValues, _metricFieldSpecs);
 
     appendToRawBuffer(dimensions, metrics);
   }
@@ -288,17 +269,15 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     _numAggregatedDocs++;
   }
 
-  private void appendToBuffer(DimensionBuffer dimensions, MetricBuffer metricHolder) throws IOException {
-    for (int i = 0; i < _numDimensions; i++) {
-      _dataOutputStream.writeInt(flipEndiannessIfNeeded(dimensions.getDimension(i)));
-    }
-    _dataOutputStream.write(metricHolder.toBytes(_metricSize));
+  private void appendToBuffer(DimensionBuffer dimensions, MetricBuffer metrics) throws IOException {
+    _outputStream.write(dimensions.toBytes(), 0, _dimensionSize);
+    _outputStream.write(metrics.toBytes(_metricSize), 0, _metricSize);
   }
 
   @Override
   public void build() throws IOException {
     // From this point, all raw documents have been appended
-    _dataOutputStream.flush();
+    _outputStream.flush();
 
     if (_skipMaterializationDimensions == null) {
       _skipMaterializationDimensions = computeDefaultDimensionsToSkipMaterialization();
@@ -316,23 +295,18 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     LOGGER.info("Skip Materialization Dimensions: {}", _skipMaterializationDimensions);
 
     // Compute the sort order
-    _sortOrder = new int[_dimensionNames.size()];
     // Add dimensions in the split order first
-    int index = 0;
-    for (int dimensionId : _dimensionsSplitOrder) {
-      _sortOrder[index++] = dimensionId;
-    }
+    List<Integer> sortOrderList = new ArrayList<>(_dimensionsSplitOrder);
     // Add dimensions that are not part of dimensionsSplitOrder or skipMaterializationForDimensions
     for (int i = 0; i < _numDimensions; i++) {
       if (!_dimensionsSplitOrder.contains(i) && !_skipMaterializationDimensions.contains(i)) {
-        _sortOrder[index++] = i;
+        sortOrderList.add(i);
       }
     }
-    // Add dimensions in the skipMaterializationForDimensions last
-    // The reason for this is that, after sorting and replacing the value for dimensions not materialized to ALL, the
-    // docs with same dimensions will be grouped together for aggregation
-    for (int dimensionId : _skipMaterializationDimensions) {
-      _sortOrder[index++] = dimensionId;
+    int numDimensionsInSortOrder = sortOrderList.size();
+    _sortOrder = new int[numDimensionsInSortOrder];
+    for (int i = 0; i < numDimensionsInSortOrder; i++) {
+      _sortOrder[i] = sortOrderList.get(i);
     }
 
     long start = System.currentTimeMillis();
@@ -343,10 +317,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       constructStarTree(_rootNode, _numRawDocs, _numRawDocs + _numAggregatedDocs, 0);
     } else {
       // Sort the documents
-      try (StarTreeDataTable dataTable = new StarTreeDataTable(new MMapBuffer(_dataFile, MMapMode.READ_WRITE),
-          _dimensionSize, _metricSize, 0, _numRawDocs)) {
+      try (StarTreeDataTable dataTable = new StarTreeDataTable(
+          PinotDataBuffer.mapFile(_dataFile, false, 0, _dataFile.length(), PinotDataBuffer.NATIVE_ORDER,
+              "OffHeapStarTreeBuilder#build: data buffer"), _dimensionSize, _metricSize, 0)) {
         dataTable.sort(0, _numRawDocs, _sortOrder);
-        dataTable.flush();
       }
       // Recursively construct the star tree
       constructStarTree(_rootNode, 0, _numRawDocs, 0);
@@ -363,22 +337,22 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   }
 
   private void removeSkipMaterializationDimensions() throws IOException {
-    try (StarTreeDataTable dataTable = new StarTreeDataTable(new MMapBuffer(_dataFile, MMapMode.READ_WRITE),
-        _dimensionSize, _metricSize, 0, _numRawDocs)) {
+    try (StarTreeDataTable dataTable = new StarTreeDataTable(
+        PinotDataBuffer.mapFile(_dataFile, false, 0, _dataFile.length(), PinotDataBuffer.NATIVE_ORDER,
+            "OffHeapStarTreeBuilder#removeSkipMaterializationDimensions: data buffer"), _dimensionSize, _metricSize,
+        0)) {
       dataTable.sort(0, _numRawDocs, _sortOrder);
-      dataTable.flush();
       Iterator<Pair<byte[], byte[]>> iterator = dataTable.iterator(0, _numRawDocs);
       DimensionBuffer currentDimensions = null;
       MetricBuffer currentMetrics = null;
       while (iterator.hasNext()) {
         Pair<byte[], byte[]> next = iterator.next();
         byte[] dimensionBytes = next.getLeft();
-        byte[] metricBytes = next.getRight();
         DimensionBuffer dimensions = DimensionBuffer.fromBytes(dimensionBytes);
-        MetricBuffer metrics = MetricBuffer.fromBytes(metricBytes, _schema.getMetricFieldSpecs());
+        MetricBuffer metrics = MetricBuffer.fromBytes(next.getRight(), _metricFieldSpecs);
         for (int i = 0; i < _numDimensions; i++) {
           if (_skipMaterializationDimensions.contains(i)) {
-            dimensions.setDimension(i, StarTreeNode.ALL);
+            dimensions.setDictId(i, StarTreeNode.ALL);
           }
         }
 
@@ -386,7 +360,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
           currentDimensions = dimensions;
           currentMetrics = metrics;
         } else {
-          if (dimensions.equals(currentDimensions)) {
+          if (currentDimensions.hasSameBytes(dimensionBytes)) {
             currentMetrics.aggregate(metrics);
           } else {
             appendToAggBuffer(currentDimensions, currentMetrics);
@@ -397,19 +371,20 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       }
       appendToAggBuffer(currentDimensions, currentMetrics);
     }
-    _dataOutputStream.flush();
+    _outputStream.flush();
   }
 
   private void createAggregatedDocForAllNodes() throws IOException {
-    try (StarTreeDataTable dataTable = new StarTreeDataTable(new MMapBuffer(_dataFile, MMapMode.READ_ONLY),
-        _dimensionSize, _metricSize, 0, _numRawDocs + _numAggregatedDocs)) {
+    try (StarTreeDataTable dataTable = new StarTreeDataTable(
+        PinotDataBuffer.mapFile(_dataFile, true, 0, _dataFile.length(), PinotDataBuffer.NATIVE_ORDER,
+            "OffHeapStarTreeBuilder#createAggregatedDocForAllNodes: data buffer"), _dimensionSize, _metricSize, 0)) {
       DimensionBuffer dimensions = new DimensionBuffer(_numDimensions);
       for (int i = 0; i < _numDimensions; i++) {
-        dimensions.setDimension(i, StarTreeNode.ALL);
+        dimensions.setDictId(i, StarTreeNode.ALL);
       }
       createAggregatedDocForAllNodesHelper(dataTable, _rootNode, dimensions);
     }
-    _dataOutputStream.flush();
+    _outputStream.flush();
   }
 
   private MetricBuffer createAggregatedDocForAllNodesHelper(StarTreeDataTable dataTable, TreeNode node,
@@ -420,10 +395,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
       Iterator<Pair<byte[], byte[]>> iterator = dataTable.iterator(node._startDocId, node._endDocId);
       Pair<byte[], byte[]> first = iterator.next();
-      aggregatedMetrics = MetricBuffer.fromBytes(first.getRight(), _schema.getMetricFieldSpecs());
+      aggregatedMetrics = MetricBuffer.fromBytes(first.getRight(), _metricFieldSpecs);
       while (iterator.hasNext()) {
         Pair<byte[], byte[]> next = iterator.next();
-        MetricBuffer metricBuffer = MetricBuffer.fromBytes(next.getRight(), _schema.getMetricFieldSpecs());
+        MetricBuffer metricBuffer = MetricBuffer.fromBytes(next.getRight(), _metricFieldSpecs);
         aggregatedMetrics.aggregate(metricBuffer);
       }
     } else {
@@ -433,7 +408,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       for (Map.Entry<Integer, TreeNode> entry : node._children.entrySet()) {
         int childDimensionValue = entry.getKey();
         TreeNode child = entry.getValue();
-        dimensions.setDimension(childDimensionId, childDimensionValue);
+        dimensions.setDictId(childDimensionId, childDimensionValue);
         MetricBuffer childAggregatedMetrics = createAggregatedDocForAllNodesHelper(dataTable, child, dimensions);
         // Skip star node value when computing aggregate for the parent
         if (childDimensionValue != StarTreeNode.ALL) {
@@ -444,7 +419,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
           }
         }
       }
-      dimensions.setDimension(childDimensionId, StarTreeNode.ALL);
+      dimensions.setDictId(childDimensionId, StarTreeNode.ALL);
     }
     node._aggregatedDocId = _numRawDocs + _numAggregatedDocs;
     appendToAggBuffer(dimensions, aggregatedMetrics);
@@ -465,10 +440,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     if (timeColumnName != null) {
       int timeColumnId = _dimensionNames.indexOf(timeColumnName);
       if (!_skipMaterializationDimensions.contains(timeColumnId) && !_dimensionsSplitOrder.contains(timeColumnId)) {
-        try (StarTreeDataTable dataTable = new StarTreeDataTable(new MMapBuffer(_dataFile, MMapMode.READ_WRITE),
-            _dimensionSize, _metricSize, 0, _numRawDocs + _numAggregatedDocs)) {
+        try (StarTreeDataTable dataTable = new StarTreeDataTable(
+            PinotDataBuffer.mapFile(_dataFile, false, 0, _dataFile.length(), PinotDataBuffer.NATIVE_ORDER,
+                "OffHeapStarTreeBuilder#splitLeafNodesOnTimeColumn: data buffer"), _dimensionSize, _metricSize, 0)) {
           splitLeafNodesOnTimeColumnHelper(dataTable, _rootNode, 0, timeColumnId);
-          dataTable.flush();
         }
       }
     }
@@ -550,12 +525,9 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
         defaultSplitOrder.add(i);
       }
     }
-    Collections.sort(defaultSplitOrder, new Comparator<Integer>() {
-      @Override
-      public int compare(Integer o1, Integer o2) {
-        // Descending order
-        return _dimensionDictionaries.get(o2).size() - _dimensionDictionaries.get(o1).size();
-      }
+    defaultSplitOrder.sort((o1, o2) -> {
+      // Descending order
+      return _dimensionDictionaries.get(o2).size() - _dimensionDictionaries.get(o1).size();
     });
 
     return defaultSplitOrder;
@@ -573,8 +545,9 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     int numDocs = endDocId - startDocId;
     Int2ObjectMap<IntPair> dimensionRangeMap;
     try (StarTreeDataTable dataTable = new StarTreeDataTable(
-        new MMapBuffer(_dataFile, startDocId * _docSize, numDocs * _docSize, MMapMode.READ_ONLY), _dimensionSize,
-        _metricSize, startDocId, endDocId)) {
+        PinotDataBuffer.mapFile(_dataFile, true, startDocId * _docSizeLong, numDocs * _docSizeLong,
+            PinotDataBuffer.NATIVE_ORDER, "OffHeapStarTreeBuilder#constructStarTree: data buffer"), _dimensionSize,
+        _metricSize, startDocId)) {
       dimensionRangeMap = dataTable.groupOnDimension(startDocId, endDocId, splitDimensionId);
     }
     LOGGER.debug("Group stats:{}", dimensionRangeMap);
@@ -622,7 +595,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       MetricBuffer metrics = next.getRight();
       appendToAggBuffer(dimensions, metrics);
     }
-    _dataOutputStream.flush();
+    _outputStream.flush();
     int starChildEndDocId = _numRawDocs + _numAggregatedDocs;
 
     starChild._startDocId = starChildStartDocId;
@@ -639,41 +612,29 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
    */
   private Iterator<Pair<DimensionBuffer, MetricBuffer>> getUniqueCombinations(final int startDocId, final int endDocId,
       int dimensionIdToRemove) throws IOException {
-    LBufferAPI tempBuffer = null;
-    int numDocs = endDocId - startDocId;
-    long tempBufferSize = numDocs * _docSize;
+    long tempBufferSize = (endDocId - startDocId) * _docSizeLong;
+
+    PinotDataBuffer tempBuffer;
     if (tempBufferSize > MMAP_SIZE_THRESHOLD) {
-      // Create a temporary file and use MMapBuffer
+      // MMAP
       File tempFile = new File(_tempDir, startDocId + "_" + endDocId + ".unique.tmp");
       try (FileChannel src = new RandomAccessFile(_dataFile, "r").getChannel();
           FileChannel dest = new RandomAccessFile(tempFile, "rw").getChannel()) {
-        long numBytesTransferred = src.transferTo(startDocId * _docSize, tempBufferSize, dest);
+        long numBytesTransferred = src.transferTo(startDocId * _docSizeLong, tempBufferSize, dest);
         Preconditions.checkState(numBytesTransferred == tempBufferSize,
             "Error transferring data from data file to temp file, transfer size mis-match");
         dest.force(false);
       }
-      tempBuffer = new MMapBuffer(tempFile, MMapMode.READ_WRITE);
+      tempBuffer = PinotDataBuffer.mapFile(tempFile, false, 0, tempBufferSize, PinotDataBuffer.NATIVE_ORDER,
+          "OffHeapStarTreeBuilder#getUniqueCombinations: temp buffer");
     } else {
-      // Use LBuffer (direct memory buffer)
-      MMapBuffer dataBuffer = null;
-      try {
-        tempBuffer = new LBuffer(tempBufferSize);
-        dataBuffer = new MMapBuffer(_dataFile, startDocId * _docSize, tempBufferSize, MMapMode.READ_ONLY);
-        dataBuffer.copyTo(0, tempBuffer, 0, tempBufferSize);
-      } catch (Exception e) {
-        if (tempBuffer != null) {
-          tempBuffer.release();
-        }
-        throw e;
-      } finally {
-        if (dataBuffer != null) {
-          dataBuffer.close();
-        }
-      }
+      // DIRECT
+      tempBuffer =
+          PinotDataBuffer.loadFile(_dataFile, startDocId * _docSizeLong, tempBufferSize, PinotDataBuffer.NATIVE_ORDER,
+              "OffHeapStarTreeBuilder#getUniqueCombinations: temp buffer");
     }
 
-    final StarTreeDataTable dataTable =
-        new StarTreeDataTable(tempBuffer, _dimensionSize, _metricSize, startDocId, endDocId);
+    final StarTreeDataTable dataTable = new StarTreeDataTable(tempBuffer, _dimensionSize, _metricSize, startDocId);
     _dataTablesToClose.add(dataTable);
 
     // Need to set skip materialization dimensions value to ALL before sorting
@@ -684,13 +645,12 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     }
     dataTable.setDimensionValue(dimensionIdToRemove, StarTreeNode.ALL);
     dataTable.sort(startDocId, endDocId, _sortOrder);
-    dataTable.flush();
 
     return new Iterator<Pair<DimensionBuffer, MetricBuffer>>() {
       final Iterator<Pair<byte[], byte[]>> _iterator = dataTable.iterator(startDocId, endDocId);
       DimensionBuffer _currentDimensions;
       MetricBuffer _currentMetrics;
-      boolean _hasNext = _iterator.hasNext();
+      boolean _hasNext = true;
 
       @Override
       public boolean hasNext() {
@@ -701,18 +661,18 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       public Pair<DimensionBuffer, MetricBuffer> next() {
         while (_iterator.hasNext()) {
           Pair<byte[], byte[]> next = _iterator.next();
-          DimensionBuffer dimensions = DimensionBuffer.fromBytes(next.getLeft());
-          MetricBuffer metrics = MetricBuffer.fromBytes(next.getRight(), _schema.getMetricFieldSpecs());
+          byte[] dimensionBytes = next.getLeft();
+          MetricBuffer metrics = MetricBuffer.fromBytes(next.getRight(), _metricFieldSpecs);
           if (_currentDimensions == null) {
-            _currentDimensions = dimensions;
+            _currentDimensions = DimensionBuffer.fromBytes(dimensionBytes);
             _currentMetrics = metrics;
           } else {
-            if (dimensions.equals(_currentDimensions)) {
+            if (_currentDimensions.hasSameBytes(dimensionBytes)) {
               _currentMetrics.aggregate(metrics);
             } else {
               ImmutablePair<DimensionBuffer, MetricBuffer> ret =
                   new ImmutablePair<>(_currentDimensions, _currentMetrics);
-              _currentDimensions = dimensions;
+              _currentDimensions = DimensionBuffer.fromBytes(dimensionBytes);
               _currentMetrics = metrics;
               return ret;
             }
@@ -732,10 +692,10 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
   @Override
   public Iterator<GenericRow> iterator(final int startDocId, final int endDocId) throws IOException {
-    int numDocs = endDocId - startDocId;
-    final StarTreeDataTable dataTable =
-        new StarTreeDataTable(new MMapBuffer(_dataFile, startDocId * _docSize, numDocs * _docSize, MMapMode.READ_ONLY),
-            _dimensionSize, _metricSize, startDocId, endDocId);
+    final StarTreeDataTable dataTable = new StarTreeDataTable(
+        PinotDataBuffer.mapFile(_dataFile, true, startDocId * _docSizeLong, (endDocId - startDocId) * _docSizeLong,
+            PinotDataBuffer.NATIVE_ORDER, "OffHeapStarTreeBuilder#iterator: data buffer"), _dimensionSize, _metricSize,
+        startDocId);
     _dataTablesToClose.add(dataTable);
 
     return new Iterator<GenericRow>() {
@@ -754,7 +714,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       public GenericRow next() {
         Pair<byte[], byte[]> pair = _iterator.next();
         DimensionBuffer dimensions = DimensionBuffer.fromBytes(pair.getLeft());
-        MetricBuffer metrics = MetricBuffer.fromBytes(pair.getRight(), _schema.getMetricFieldSpecs());
+        MetricBuffer metrics = MetricBuffer.fromBytes(pair.getRight(), _metricFieldSpecs);
         return toGenericRow(dimensions, metrics);
       }
 
@@ -779,7 +739,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     Map<String, Object> map = new HashMap<>();
     for (int i = 0; i < _numDimensions; i++) {
       String dimensionName = _dimensionNames.get(i);
-      int dictId = dimensions.getDimension(i);
+      int dictId = dimensions.getDictId(i);
       if (dictId == StarTreeNode.ALL) {
         map.put(dimensionName, _dimensionStarValues.get(i));
       } else {
@@ -854,17 +814,14 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
    */
   private void serializeTree(File starTreeFile) throws IOException {
     int headerSizeInBytes = computeHeaderSizeInBytes();
-    long totalSizeInBytes = headerSizeInBytes + _numNodes * OffHeapStarTreeNode.SERIALIZABLE_SIZE_IN_BYTES;
+    long totalSizeInBytes = headerSizeInBytes + (long) _numNodes * OffHeapStarTreeNode.SERIALIZABLE_SIZE_IN_BYTES;
 
-    MMapBuffer dataBuffer = new MMapBuffer(starTreeFile, 0, totalSizeInBytes, MMapMode.READ_WRITE);
-    try {
-      long offset = writeHeader(dataBuffer, headerSizeInBytes);
+    // Backward-compatible: star-tree file is always little-endian
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(starTreeFile, false, 0, totalSizeInBytes,
+        ByteOrder.LITTLE_ENDIAN, "OffHeapStarTreeBuilder#serializeTree: star-tree buffer")) {
+      long offset = writeHeader(buffer, headerSizeInBytes);
       Preconditions.checkState(offset == headerSizeInBytes, "Error writing Star Tree file, header size mis-match");
-
-      writeNodes(dataBuffer, offset);
-    } finally {
-      dataBuffer.flush();
-      dataBuffer.close();
+      writeNodes(buffer, offset);
     }
   }
 
@@ -886,50 +843,50 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     int headerSizeInBytes = 20;
 
     for (String dimension : _dimensionNames) {
-      headerSizeInBytes += V1Constants.Numbers.INTEGER_SIZE; // For dimension index
-      headerSizeInBytes += V1Constants.Numbers.INTEGER_SIZE; // For length of dimension name
+      headerSizeInBytes += Integer.BYTES; // For dimension index
+      headerSizeInBytes += Integer.BYTES; // For length of dimension name
       headerSizeInBytes += dimension.getBytes(UTF_8).length; // For dimension name
     }
 
-    headerSizeInBytes += V1Constants.Numbers.INTEGER_SIZE; // For number of nodes.
+    headerSizeInBytes += Integer.BYTES; // For number of nodes.
     return headerSizeInBytes;
   }
 
   /**
    * Helper method to write the header into the data buffer.
    */
-  private long writeHeader(MMapBuffer dataBuffer, int headerSizeInBytes) {
+  private long writeHeader(PinotDataBuffer dataBuffer, int headerSizeInBytes) {
     long offset = 0L;
 
     dataBuffer.putLong(offset, OffHeapStarTree.MAGIC_MARKER);
-    offset += V1Constants.Numbers.LONG_SIZE;
+    offset += Long.BYTES;
 
     dataBuffer.putInt(offset, OffHeapStarTree.VERSION);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, headerSizeInBytes);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, _numDimensions);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     for (int i = 0; i < _numDimensions; i++) {
       String dimensionName = _dimensionNames.get(i);
 
       dataBuffer.putInt(offset, i);
-      offset += V1Constants.Numbers.INTEGER_SIZE;
+      offset += Integer.BYTES;
 
       byte[] dimensionBytes = dimensionName.getBytes(UTF_8);
       int dimensionLength = dimensionBytes.length;
       dataBuffer.putInt(offset, dimensionLength);
-      offset += V1Constants.Numbers.INTEGER_SIZE;
+      offset += Integer.BYTES;
 
-      dataBuffer.readFrom(dimensionBytes, offset);
+      dataBuffer.readFrom(offset, dimensionBytes, 0, dimensionLength);
       offset += dimensionLength;
     }
 
     dataBuffer.putInt(offset, _numNodes);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     return offset;
   }
@@ -937,7 +894,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   /**
    * Helper method to write the star tree nodes into the data buffer.
    */
-  private void writeNodes(MMapBuffer dataBuffer, long offset) {
+  private void writeNodes(PinotDataBuffer dataBuffer, long offset) {
     int index = 0;
     Queue<TreeNode> queue = new LinkedList<>();
     queue.add(_rootNode);
@@ -955,12 +912,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
         // Get a list of children nodes sorted on the dimension value
         List<TreeNode> sortedChildren = new ArrayList<>(node._children.values());
-        Collections.sort(sortedChildren, new Comparator<TreeNode>() {
-          @Override
-          public int compare(TreeNode o1, TreeNode o2) {
-            return Integer.compare(o1._dimensionValue, o2._dimensionValue);
-          }
-        });
+        sortedChildren.sort((o1, o2) -> Integer.compare(o1._dimensionValue, o2._dimensionValue));
 
         int startChildrenIndex = index + queue.size() + 1;
         int endChildrenIndex = startChildrenIndex + sortedChildren.size() - 1;
@@ -976,28 +928,28 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   /**
    * Helper method to write one node into the data buffer.
    */
-  private static long writeNode(MMapBuffer dataBuffer, TreeNode node, long offset, int startChildrenIndex,
+  private static long writeNode(PinotDataBuffer dataBuffer, TreeNode node, long offset, int startChildrenIndex,
       int endChildrenIndex) {
     dataBuffer.putInt(offset, node._dimensionId);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, node._dimensionValue);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, node._startDocId);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, node._endDocId);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, node._aggregatedDocId);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, startChildrenIndex);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     dataBuffer.putInt(offset, endChildrenIndex);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     return offset;
   }
@@ -1042,7 +994,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
   @Override
   public void close() throws IOException {
-    _dataOutputStream.close();
+    _outputStream.close();
     for (StarTreeDataTable dataTable : _dataTablesToClose) {
       dataTable.close();
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeNode.java
@@ -15,9 +15,8 @@
  */
 package com.linkedin.pinot.core.startree;
 
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.util.Iterator;
-import xerial.larray.buffer.LBufferAPI;
 
 
 public class OffHeapStarTreeNode implements StarTreeNode {
@@ -25,9 +24,9 @@ public class OffHeapStarTreeNode implements StarTreeNode {
 
   // Number of fields and serializable size of the node
   public static final int NUM_SERIALIZABLE_FIELDS = 7;
-  public static final int SERIALIZABLE_SIZE_IN_BYTES = V1Constants.Numbers.INTEGER_SIZE * NUM_SERIALIZABLE_FIELDS;
+  public static final int SERIALIZABLE_SIZE_IN_BYTES = Integer.BYTES * NUM_SERIALIZABLE_FIELDS;
 
-  private final LBufferAPI _dataBuffer;
+  private final PinotDataBuffer _dataBuffer;
   private final int _dimensionId;
   private final int _dimensionValue;
   private final int _startDocId;
@@ -37,27 +36,27 @@ public class OffHeapStarTreeNode implements StarTreeNode {
   // Inclusive
   private final int _childrenEndIndex;
 
-  public OffHeapStarTreeNode(LBufferAPI dataBuffer, int nodeId) {
+  public OffHeapStarTreeNode(PinotDataBuffer dataBuffer, int nodeId) {
     _dataBuffer = dataBuffer;
     long offset = nodeId * SERIALIZABLE_SIZE_IN_BYTES;
 
     _dimensionId = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _dimensionValue = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _startDocId = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _endDocId = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _aggregatedDocId = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _childrenStartIndex = dataBuffer.getInt(offset);
-    offset += V1Constants.Numbers.INTEGER_SIZE;
+    offset += Integer.BYTES;
 
     _childrenEndIndex = dataBuffer.getInt(offset);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataTable.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataTable.java
@@ -15,8 +15,9 @@
  */
 package com.linkedin.pinot.core.startree;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.Pairs.IntPair;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import it.unimi.dsi.fastutil.Arrays;
 import it.unimi.dsi.fastutil.Swapper;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
@@ -24,27 +25,21 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Iterator;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import xerial.larray.buffer.LBuffer;
-import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.mmap.MMapBuffer;
 
 
 /**
- * The class <code>StarTreeDataTable</code> works on a LBufferAPI and provides the helper methods to build the
- * star-tree.
- * <p>Implemented to be able to handle the memory range greater than 2GB.
+ * The class <code>StarTreeDataTable</code> provides the helper methods to build the star-tree.
  */
 public class StarTreeDataTable implements Closeable {
-  private final LBufferAPI _dataBuffer;
+  private final PinotDataBuffer _dataBuffer;
   private final int _dimensionSize;
   private final int _metricSize;
-  private final long _docSize;
+  private final int _docSize;
+  private final long _docSizeLong;
   private final int _startDocId;
-  private final int _endDocId;
 
   /**
    * Constructor of the StarTreeDataTable.
@@ -53,30 +48,31 @@ public class StarTreeDataTable implements Closeable {
    * @param dimensionSize Size of all dimensions in bytes
    * @param metricSize Size of all metrics in bytes
    * @param startDocId Start document id of the data buffer
-   * @param startDocId End document id of the data buffer
    */
-  public StarTreeDataTable(LBufferAPI dataBuffer, int dimensionSize, int metricSize, int startDocId, int endDocId) {
+  public StarTreeDataTable(PinotDataBuffer dataBuffer, int dimensionSize, int metricSize, int startDocId) {
+    Preconditions.checkState(dataBuffer.size() > 0);
+
     _dataBuffer = dataBuffer;
     _dimensionSize = dimensionSize;
     _metricSize = metricSize;
     _docSize = dimensionSize + metricSize;
+    _docSizeLong = _docSize;
     _startDocId = startDocId;
-    // NOTE: number of documents cannot be derived from dataBuffer.size() because for MMapBuffer, dataBuffer.size()
-    // could be larger than the given length because of page alignment
-    _endDocId = endDocId;
   }
 
   /**
-   * Sort the documents inside the data buffer based on the sort order.
+   * Sorts the documents inside the data buffer based on the sort order.
    * <p>To reduce the number of swaps inside the data buffer, we first sort on an array which only read from the data
    * buffer, then re-arrange the actual document inside the data buffer based on the sorted array.
-   * <p>This method may change the data, call {@link #flush()} before closing the data table.
+   * <p>This method may change the data. Close data table to flush the changes to the disk.
    *
    * @param startDocId Start document id of the range to be sorted
    * @param endDocId End document id (exclusive) of the range to be sorted
    * @param sortOrder Sort order of dimensions
    */
   public void sort(int startDocId, int endDocId, final int[] sortOrder) {
+    Preconditions.checkState(startDocId < endDocId);
+
     // Get sorted doc ids
     int numDocs = endDocId - startDocId;
     int startDocIdOffset = startDocId - _startDocId;
@@ -85,21 +81,14 @@ public class StarTreeDataTable implements Closeable {
       sortedDocIds[i] = i + startDocIdOffset;
     }
 
-    final LBuffer dimensionBuffer1 = new LBuffer(_dimensionSize);
-    final LBuffer dimensionBuffer2 = new LBuffer(_dimensionSize);
-
     IntComparator comparator = new IntComparator() {
       @Override
       public int compare(int i1, int i2) {
-        long offset1 = sortedDocIds[i1] * _docSize;
-        long offset2 = sortedDocIds[i2] * _docSize;
-
-        _dataBuffer.copyTo(offset1, dimensionBuffer1, 0, _dimensionSize);
-        _dataBuffer.copyTo(offset2, dimensionBuffer2, 0, _dimensionSize);
-
+        long offset1 = sortedDocIds[i1] * _docSizeLong;
+        long offset2 = sortedDocIds[i2] * _docSizeLong;
         for (int index : sortOrder) {
-          int v1 = dimensionBuffer1.getInt(index * V1Constants.Numbers.INTEGER_SIZE);
-          int v2 = dimensionBuffer2.getInt(index * V1Constants.Numbers.INTEGER_SIZE);
+          int v1 = _dataBuffer.getInt(offset1 + index * Integer.BYTES);
+          int v2 = _dataBuffer.getInt(offset2 + index * Integer.BYTES);
           if (v1 != v2) {
             return v1 - v2;
           }
@@ -113,56 +102,43 @@ public class StarTreeDataTable implements Closeable {
       }
     };
 
-    Swapper swapper = new Swapper() {
-      @Override
-      public void swap(int i, int j) {
-        int temp = sortedDocIds[i];
-        sortedDocIds[i] = sortedDocIds[j];
-        sortedDocIds[j] = temp;
-      }
+    Swapper swapper = (i, j) -> {
+      int temp = sortedDocIds[i];
+      sortedDocIds[i] = sortedDocIds[j];
+      sortedDocIds[j] = temp;
     };
-
-    try {
-      Arrays.quickSort(0, numDocs, comparator, swapper);
-    } finally {
-      dimensionBuffer1.release();
-      dimensionBuffer2.release();
-    }
+    Arrays.quickSort(0, numDocs, comparator, swapper);
 
     // Re-arrange documents based on the sorted document ids
     // Each write places a document in it's proper location, so time complexity is O(n)
-    LBuffer docBuffer = new LBuffer(_docSize);
-    try {
-      for (int i = 0; i < numDocs; i++) {
-        int actualDocId = i + startDocIdOffset;
-        if (actualDocId != sortedDocIds[i]) {
-          // Copy the document at actualDocId into the first document buffer
-          _dataBuffer.copyTo(actualDocId * _docSize, docBuffer, 0, _docSize);
+    byte[] buffer = new byte[_docSize];
+    for (int i = 0; i < numDocs; i++) {
+      int actualDocId = i + startDocIdOffset;
+      if (actualDocId != sortedDocIds[i]) {
+        // Copy the document at actualDocId into the first document buffer
+        _dataBuffer.copyTo(actualDocId * _docSizeLong, buffer, 0, _docSize);
 
-          // The while loop will create a rotating cycle
-          int currentIndex = i;
-          int properDocId;
-          while (actualDocId != (properDocId = sortedDocIds[currentIndex])) {
-            // Put the document at properDocId into the currentDocId
-            int currentDocId = currentIndex + startDocIdOffset;
-            _dataBuffer.copyTo(properDocId * _docSize, _dataBuffer, currentDocId * _docSize, _docSize);
-            sortedDocIds[currentIndex] = currentDocId;
-            currentIndex = properDocId - startDocIdOffset;
-          }
-
-          // Put the document at actualDocId into the correct location (currentDocId)
+        // The while loop will create a rotating cycle
+        int currentIndex = i;
+        int properDocId;
+        while (actualDocId != (properDocId = sortedDocIds[currentIndex])) {
+          // Put the document at properDocId into the currentDocId
           int currentDocId = currentIndex + startDocIdOffset;
-          docBuffer.copyTo(0L, _dataBuffer, currentDocId * _docSize, _docSize);
+          _dataBuffer.copyTo(properDocId * _docSizeLong, _dataBuffer, currentDocId * _docSizeLong, _docSizeLong);
           sortedDocIds[currentIndex] = currentDocId;
+          currentIndex = properDocId - startDocIdOffset;
         }
+
+        // Put the document at actualDocId into the correct location (currentDocId)
+        int currentDocId = currentIndex + startDocIdOffset;
+        _dataBuffer.readFrom(currentDocId * _docSizeLong, buffer, 0, _docSize);
+        sortedDocIds[currentIndex] = currentDocId;
       }
-    } finally {
-      docBuffer.release();
     }
   }
 
   /**
-   * Group all documents based on a dimension's value.
+   * Groups all documents based on a dimension's value.
    *
    * @param startDocId Start document id of the range to be grouped
    * @param endDocId End document id (exclusive) of the range to be grouped
@@ -170,14 +146,16 @@ public class StarTreeDataTable implements Closeable {
    * @return Map from dimension value to a pair of start docId and end docId (exclusive)
    */
   public Int2ObjectMap<IntPair> groupOnDimension(int startDocId, int endDocId, int dimensionId) {
+    Preconditions.checkState(startDocId < endDocId);
+
     int startDocIdOffset = startDocId - _startDocId;
     int endDocIdOffset = endDocId - _startDocId;
     Int2ObjectMap<IntPair> rangeMap = new Int2ObjectLinkedOpenHashMap<>();
-    int dimensionOffset = dimensionId * V1Constants.Numbers.INTEGER_SIZE;
-    int currentValue = _dataBuffer.getInt(startDocIdOffset * _docSize + dimensionOffset);
+    int dimensionOffset = dimensionId * Integer.BYTES;
+    int currentValue = _dataBuffer.getInt(startDocIdOffset * _docSizeLong + dimensionOffset);
     int groupStartDocId = startDocId;
     for (int i = startDocIdOffset + 1; i < endDocIdOffset; i++) {
-      int value = _dataBuffer.getInt(i * _docSize + dimensionOffset);
+      int value = _dataBuffer.getInt(i * _docSizeLong + dimensionOffset);
       if (value != currentValue) {
         int groupEndDocId = i + _startDocId;
         rangeMap.put(currentValue, new IntPair(groupStartDocId, groupEndDocId));
@@ -190,13 +168,15 @@ public class StarTreeDataTable implements Closeable {
   }
 
   /**
-   * Get the iterator to iterate over the documents inside the data buffer.
+   * Gets the iterator to iterate over the documents inside the data buffer.
    *
    * @param startDocId Start document id of the range to iterate
    * @param endDocId End document id (exclusive) of the range to iterate
    * @return Iterator for pair of dimension bytes and metric bytes
    */
   public Iterator<Pair<byte[], byte[]>> iterator(int startDocId, int endDocId) {
+    Preconditions.checkState(startDocId < endDocId);
+
     final int startDocIdOffset = startDocId - _startDocId;
     final int endDocIdOffset = endDocId - _startDocId;
     return new Iterator<Pair<byte[], byte[]>>() {
@@ -211,9 +191,9 @@ public class StarTreeDataTable implements Closeable {
       public Pair<byte[], byte[]> next() {
         byte[] dimensionBytes = new byte[_dimensionSize];
         byte[] metricBytes = new byte[_metricSize];
-        ByteBuffer byteBuffer = _dataBuffer.toDirectByteBuffer(_currentIndex++ * _docSize, (int) _docSize);
-        byteBuffer.get(dimensionBytes);
-        byteBuffer.get(metricBytes);
+        long dimensionOffset = _currentIndex++ * _docSizeLong;
+        _dataBuffer.copyTo(dimensionOffset, dimensionBytes, 0, _dimensionSize);
+        _dataBuffer.copyTo(dimensionOffset + _dimensionSize, metricBytes, 0, _metricSize);
         return new ImmutablePair<>(dimensionBytes, metricBytes);
       }
 
@@ -225,34 +205,21 @@ public class StarTreeDataTable implements Closeable {
   }
 
   /**
-   * Set the value for each document at the specified index to the specified value.
-   * <p>This method may change the data, call {@link #flush()} before closing the data table.
+   * Sets the value for each document at the specified index to the specified value.
+   * <p>This method may change the data. Close data table to flush the changes to the disk.
    *
    * @param dimensionId Index of the dimension to set the value
    * @param value Value to be set
    */
   public void setDimensionValue(int dimensionId, int value) {
-    int numDocs = _endDocId - _startDocId;
+    int numDocs = (int) (_dataBuffer.size() / _docSizeLong);
     for (int i = 0; i < numDocs; i++) {
-      _dataBuffer.putInt(i * _docSize + dimensionId * V1Constants.Numbers.INTEGER_SIZE, value);
-    }
-  }
-
-  /**
-   * Flush any changes made to the data buffer to the disk if necessary (no-op if data buffer is LBuffer).
-   */
-  public void flush() {
-    if (_dataBuffer instanceof MMapBuffer) {
-      ((MMapBuffer) _dataBuffer).flush();
+      _dataBuffer.putInt(i * _docSizeLong + dimensionId * Integer.BYTES, value);
     }
   }
 
   @Override
   public void close() throws IOException {
-    if (_dataBuffer instanceof MMapBuffer) {
-      ((MMapBuffer) _dataBuffer).close();
-    } else {
-      _dataBuffer.release();
-    }
+    _dataBuffer.close();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
@@ -64,12 +64,16 @@ public class HllUtil {
     return b.toString();
   }
 
-  public static String convertHllToString(HyperLogLog hll) {
+  public static byte[] toBytes(HyperLogLog hll) {
     try {
-      return new String(SerializationConverter.byteArrayToChars(hll.getBytes()));
+      return hll.getBytes();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static String convertHllToString(HyperLogLog hll) {
+    return new String(SerializationConverter.byteArrayToChars(toBytes(hll)));
   }
 
   public static HyperLogLog convertStringToHll(String s) {


### PR DESCRIPTION
NOTE:
For temporary buffer, always use native order
For star-tree file, always use little-endian for backward compatibility