### PR TITLE
Print message in TableSizeReader only when num of errors > 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ pinot-dashboard/dist
 pinot-dashboard/pinotui.egg-info
 *.log
 .doppelganger
+*.ipr
+*.iws

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -193,8 +193,8 @@ public class TableSizeReader {
       }
       // after iterating over all servers update summary reported and estimated size of the segment
       if (errors != segmentSizes.serverInfo.size()) {
+        // at least one server reported size for this segment
         if (errors > 0) {
-          // at least one server reported size for this segment
           LOGGER.info("Could not get size for segment {} from {} servers. Using segmentLevelMax {} to estimate the size",
               segmentEntry.getKey(), errors, segmentLevelMax);
         }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -193,9 +193,11 @@ public class TableSizeReader {
       }
       // after iterating over all servers update summary reported and estimated size of the segment
       if (errors != segmentSizes.serverInfo.size()) {
-        // atleast one server reported size for this segment
-        LOGGER.info("Could not get size for segment {} from {} servers. Using segmentLevelMax {} to estimate the size",
-            segmentEntry.getKey(), errors, segmentLevelMax);
+        if (errors > 0) {
+          // at least one server reported size for this segment
+          LOGGER.info("Could not get size for segment {} from {} servers. Using segmentLevelMax {} to estimate the size",
+              segmentEntry.getKey(), errors, segmentLevelMax);
+        }
         segmentSizes.estimatedSizeInBytes = segmentSizes.reportedSizeInBytes + errors * segmentLevelMax;
         tableLevelMax = Math.max(tableLevelMax, segmentLevelMax);
         subTypeSizeDetails.reportedSizeInBytes += segmentSizes.reportedSizeInBytes;


### PR DESCRIPTION
Currently it prints the message even when there's no error. 
Adding this if statement can help reduce most of the noises in controller log.
 