### PR TITLE
Make DistinctCountHLL, PercentileEst and PercentileTDigest work on both value and serialized bytes

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -53,6 +53,10 @@ public class AggregationFunctionFactory {
           // PercentileEstMV
           return new PercentileEstMVAggregationFunction(
               parsePercentile(remainingFunctionName.substring(3, remainingFunctionName.length() - 2)));
+        } else if (remainingFunctionName.matches("TDIGEST\\d+MV")) {
+          // PercentileTDigestMV
+          return new PercentileTDigestMVAggregationFunction(
+              parsePercentile(remainingFunctionName.substring(7, remainingFunctionName.length() - 2)));
         } else {
           throw new IllegalArgumentException();
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionType.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionType.java
@@ -43,7 +43,8 @@ public enum AggregationFunctionType {
   DISTINCTCOUNTMV("distinctCountMV"),
   DISTINCTCOUNTHLLMV("distinctCountHLLMV"),
   PERCENTILEMV("percentileMV"),
-  PERCENTILEESTMV("percentileEstMV");
+  PERCENTILEESTMV("percentileEstMV"),
+  PERCENTILETDIGESTMV("percentileTDigestMV");
 
   private final String _name;
 
@@ -84,6 +85,8 @@ public enum AggregationFunctionType {
           return PERCENTILEMV;
         } else if (remainingFunctionName.matches("EST\\d+MV")) {
           return PERCENTILEESTMV;
+        } else if (remainingFunctionName.matches("TDIGEST\\d+MV")) {
+          return PERCENTILETDIGESTMV;
         } else {
           throw new IllegalArgumentException();
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -40,11 +40,7 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
-    IntOpenHashSet valueSet = aggregationResultHolder.getResult();
-    if (valueSet == null) {
-      valueSet = new IntOpenHashSet();
-      aggregationResultHolder.setValue(valueSet);
-    }
+    IntOpenHashSet valueSet = getValueSet(aggregationResultHolder);
 
     FieldSpec.DataType valueType = blockValSets[0].getValueType();
     switch (valueType) {
@@ -56,7 +52,6 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
           }
         }
         break;
-
       case LONG:
         long[][] longValues = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
@@ -65,7 +60,6 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
           }
         }
         break;
-
       case FLOAT:
         float[][] floatValues = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
@@ -73,7 +67,6 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
             valueSet.add(Float.hashCode(value));
           }
         }
-
       case DOUBLE:
         double[][] doubleValues = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
@@ -82,7 +75,6 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
           }
         }
         break;
-
       case STRING:
         String[][] stringValues = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
@@ -91,9 +83,8 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
           }
         }
         break;
-
       default:
-        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
+        throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_MV aggregation function: " + valueType);
     }
   }
 
@@ -105,55 +96,50 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
       case INT:
         int[][] intValues = blockValSets[0].getIntValuesMV();
         for (int i = 0; i < length; i++) {
-          IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKeyArray[i]);
+          IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKeyArray[i]);
           for (int value : intValues[i]) {
             valueSet.add(value);
           }
         }
         break;
-
       case LONG:
         long[][] longValues = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
-          IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKeyArray[i]);
+          IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKeyArray[i]);
           for (long value : longValues[i]) {
             valueSet.add(Long.hashCode(value));
           }
         }
         break;
-
       case FLOAT:
         float[][] floatValues = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
-          IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKeyArray[i]);
+          IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKeyArray[i]);
           for (float value : floatValues[i]) {
             valueSet.add(Float.hashCode(value));
           }
         }
         break;
-
       case DOUBLE:
         double[][] doubleValues = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
-          IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKeyArray[i]);
+          IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKeyArray[i]);
           for (double value : doubleValues[i]) {
             valueSet.add(Double.hashCode(value));
           }
         }
         break;
-
       case STRING:
         String[][] stringValues = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
-          IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKeyArray[i]);
+          IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKeyArray[i]);
           for (String value : stringValues[i]) {
             valueSet.add(value.hashCode());
           }
         }
         break;
-
       default:
-        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
+        throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_MV aggregation function: " + valueType);
     }
   }
 
@@ -166,80 +152,59 @@ public class DistinctCountMVAggregationFunction extends DistinctCountAggregation
         int[][] intValues = blockValSets[0].getIntValuesMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKey);
+            IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKey);
             for (int value : intValues[i]) {
               valueSet.add(value);
             }
           }
         }
         break;
-
       case LONG:
         long[][] longValues = blockValSets[0].getLongValuesMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKey);
+            IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKey);
             for (long value : longValues[i]) {
               valueSet.add(Long.hashCode(value));
             }
           }
         }
         break;
-
       case FLOAT:
         float[][] floatValues = blockValSets[0].getFloatValuesMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKey);
+            IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKey);
             for (float value : floatValues[i]) {
               valueSet.add(Float.hashCode(value));
             }
           }
         }
         break;
-
       case DOUBLE:
         double[][] doubleValues = blockValSets[0].getDoubleValuesMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKey);
+            IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKey);
             for (double value : doubleValues[i]) {
               valueSet.add(Double.hashCode(value));
             }
           }
         }
         break;
-
       case STRING:
         String[][] stringValues = blockValSets[0].getStringValuesMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            IntOpenHashSet valueSet = getOrCreateHashSetForGroupKey(groupByResultHolder, groupKey);
+            IntOpenHashSet valueSet = getValueSet(groupByResultHolder, groupKey);
             for (String value : stringValues[i]) {
               valueSet.add(value.hashCode());
             }
           }
         }
         break;
-
       default:
-        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
+        throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_MV aggregation function: " + valueType);
     }
-  }
-
-  /**
-   * Returns the hash-set for the given group-key. Creates and returns one, if it does not exist.
-   *
-   * @param groupByResultHolder Result Holder
-   * @param groupKey Group key for which to get the hash set.
-   * @return Hash-set for the group key
-   */
-  private IntOpenHashSet getOrCreateHashSetForGroupKey(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
-    IntOpenHashSet valueSet = groupByResultHolder.getResult(groupKey);
-    if (valueSet == null) {
-      valueSet = new IntOpenHashSet();
-      groupByResultHolder.setValueForKey(groupKey, valueSet);
-    }
-    return valueSet;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -67,14 +67,10 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
+    DoubleArrayList valueList = getValueList(aggregationResultHolder);
     double[] valueArray = blockValSets[0].getDoubleValuesSV();
-    DoubleArrayList doubleArrayList = aggregationResultHolder.getResult();
-    if (doubleArrayList == null) {
-      doubleArrayList = new DoubleArrayList();
-      aggregationResultHolder.setValue(doubleArrayList);
-    }
     for (int i = 0; i < length; i++) {
-      doubleArrayList.add(valueArray[i]);
+      valueList.add(valueArray[i]);
     }
   }
 
@@ -83,13 +79,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
     double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
-      if (doubleArrayList == null) {
-        doubleArrayList = new DoubleArrayList();
-        groupByResultHolder.setValueForKey(groupKey, doubleArrayList);
-      }
-      doubleArrayList.add(valueArray[i]);
+      DoubleArrayList valueList = getValueList(groupByResultHolder, groupKeyArray[i]);
+      valueList.add(valueArray[i]);
     }
   }
 
@@ -100,12 +91,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {
-        DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
-        if (doubleArrayList == null) {
-          doubleArrayList = new DoubleArrayList();
-          groupByResultHolder.setValueForKey(groupKey, doubleArrayList);
-        }
-        doubleArrayList.add(value);
+        DoubleArrayList valueList = getValueList(groupByResultHolder, groupKey);
+        valueList.add(value);
       }
     }
   }
@@ -159,7 +146,42 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
       return DEFAULT_FINAL_RESULT;
     } else {
       Collections.sort(intermediateResult);
-      return intermediateResult.get((int) ((long) intermediateResult.size() * _percentile / 100));
+      if (_percentile == 100) {
+        return intermediateResult.get(size - 1);
+      } else {
+        return intermediateResult.get((int) ((long) size * _percentile / 100));
+      }
     }
+  }
+
+  /**
+   * Returns the value list from the result holder or creates a new one if it does not exist.
+   *
+   * @param aggregationResultHolder Result holder
+   * @return Value list from the result holder
+   */
+  protected static DoubleArrayList getValueList(@Nonnull AggregationResultHolder aggregationResultHolder) {
+    DoubleArrayList valueList = aggregationResultHolder.getResult();
+    if (valueList == null) {
+      valueList = new DoubleArrayList();
+      aggregationResultHolder.setValue(valueList);
+    }
+    return valueList;
+  }
+
+  /**
+   * Returns the value list for the given group key. If one does not exist, creates a new one and returns that.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group key for which to return the value list
+   * @return Value list for the group key
+   */
+  protected static DoubleArrayList getValueList(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
+    DoubleArrayList valueList = groupByResultHolder.getResult(groupKey);
+    if (valueList == null) {
+      valueList = new DoubleArrayList();
+      groupByResultHolder.setValueForKey(groupKey, valueList);
+    }
+    return valueList;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
@@ -66,46 +67,101 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
-    QuantileDigest quantileDigest = aggregationResultHolder.getResult();
-    if (quantileDigest == null) {
-      quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
-      aggregationResultHolder.setValue(quantileDigest);
-    }
-    for (int i = 0; i < length; i++) {
-      quantileDigest.add((long) valueArray[i]);
+    QuantileDigest quantileDigest = getQuantileDigest(aggregationResultHolder);
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          quantileDigest.add((long) valueArray[i]);
+        }
+        break;
+      case BYTES:
+        // Serialized QuantileDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        try {
+          for (int i = 0; i < length; i++) {
+            quantileDigest.merge(QuantileDigest.Builder.build(bytesValues[i]));
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while aggregating QuantileDigest", e);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_EST aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
-      if (quantileDigest == null) {
-        quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
-        groupByResultHolder.setValueForKey(groupKey, quantileDigest);
-      }
-      quantileDigest.add((long) valueArray[i]);
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKeyArray[i]);
+          quantileDigest.add((long) valueArray[i]);
+        }
+        break;
+      case BYTES:
+        // Serialized QuantileDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        try {
+          for (int i = 0; i < length; i++) {
+            QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKeyArray[i]);
+            quantileDigest.merge(QuantileDigest.Builder.build(bytesValues[i]));
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while aggregating QuantileDigest", e);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_EST aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
-    double[] valueArray = blockValSets[0].getDoubleValuesSV();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      for (int groupKey : groupKeysArray[i]) {
-        QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
-        if (quantileDigest == null) {
-          quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
-          groupByResultHolder.setValueForKey(groupKey, quantileDigest);
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          double value = valueArray[i];
+          for (int groupKey : groupKeysArray[i]) {
+            QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKey);
+            quantileDigest.add((long) value);
+          }
         }
-        quantileDigest.add((long) value);
-      }
+      case BYTES:
+        // Serialized QuantileDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        try {
+          for (int i = 0; i < length; i++) {
+            QuantileDigest value = QuantileDigest.Builder.build(bytesValues[i]);
+            for (int groupKey : groupKeysArray[i]) {
+              QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKey);
+              quantileDigest.merge(value);
+            }
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while aggregating QuantileDigest", e);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_EST aggregation function: " + valueType);
     }
   }
 
@@ -154,5 +210,36 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   @Override
   public Long extractFinalResult(@Nonnull QuantileDigest intermediateResult) {
     return intermediateResult.getQuantile(_percentile / 100.0);
+  }
+
+  /**
+   * Returns the QuantileDigest from the result holder or creates a new one if it does not exist.
+   *
+   * @param aggregationResultHolder Result holder
+   * @return QuantileDigest from the result holder
+   */
+  protected static QuantileDigest getQuantileDigest(@Nonnull AggregationResultHolder aggregationResultHolder) {
+    QuantileDigest quantileDigest = aggregationResultHolder.getResult();
+    if (quantileDigest == null) {
+      quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
+      aggregationResultHolder.setValue(quantileDigest);
+    }
+    return quantileDigest;
+  }
+
+  /**
+   * Returns the QuantileDigest for the given group key. If one does not exist, creates a new one and returns that.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group key for which to return the QuantileDigest
+   * @return QuantileDigest for the group key
+   */
+  protected static QuantileDigest getQuantileDigest(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
+    QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
+    if (quantileDigest == null) {
+      quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
+      groupByResultHolder.setValueForKey(groupKey, quantileDigest);
+    }
+    return quantileDigest;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -44,14 +44,10 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
-    DoubleArrayList doubleArrayList = aggregationResultHolder.getResult();
-    if (doubleArrayList == null) {
-      doubleArrayList = new DoubleArrayList();
-      aggregationResultHolder.setValue(doubleArrayList);
-    }
+    DoubleArrayList valueList = getValueList(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
-        doubleArrayList.add(value);
+        valueList.add(value);
       }
     }
   }
@@ -61,14 +57,9 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
-      if (doubleArrayList == null) {
-        doubleArrayList = new DoubleArrayList();
-        groupByResultHolder.setValueForKey(groupKey, doubleArrayList);
-      }
+      DoubleArrayList valueList = getValueList(groupByResultHolder, groupKeyArray[i]);
       for (double value : valuesArray[i]) {
-        doubleArrayList.add(value);
+        valueList.add(value);
       }
     }
   }
@@ -80,13 +71,9 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {
-        DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
-        if (doubleArrayList == null) {
-          doubleArrayList = new DoubleArrayList();
-          groupByResultHolder.setValueForKey(groupKey, doubleArrayList);
-        }
+        DoubleArrayList valueList = getValueList(groupByResultHolder, groupKey);
         for (double value : values) {
-          doubleArrayList.add(value);
+          valueList.add(value);
         }
       }
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.quantile.TDigest;
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
@@ -23,6 +24,7 @@ import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import java.nio.ByteBuffer;
+import java.util.Random;
 import javax.annotation.Nonnull;
 
 
@@ -32,7 +34,7 @@ import javax.annotation.Nonnull;
 public class PercentileTDigestAggregationFunction implements AggregationFunction<TDigest, Double> {
   public static final int DEFAULT_TDIGEST_COMPRESSION = 100;
 
-  private final int _percentile;
+  protected final int _percentile;
 
   public PercentileTDigestAggregationFunction(int percentile) {
     _percentile = percentile;
@@ -70,53 +72,89 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
-    byte[][] valueArray = blockValSets[0].getBytesValuesSV();
-    TDigest tDigest = aggregationResultHolder.getResult();
-    if (tDigest == null) {
-      tDigest = new TDigest(DEFAULT_TDIGEST_COMPRESSION);
-      aggregationResultHolder.setValue(tDigest);
-    }
+    TDigest tDigest = getTDigest(aggregationResultHolder);
 
-    for (int i = 0; i < length; i++) {
-      tDigest.add(TDigest.fromBytes(ByteBuffer.wrap(valueArray[i])));
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          tDigest.add(valueArray[i]);
+        }
+        break;
+      case BYTES:
+        // Serialized TDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          tDigest.add(TDigest.fromBytes(ByteBuffer.wrap(bytesValues[i])));
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
-    byte[][] valueArray = blockValSets[0].getBytesValuesSV();
-
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-
-      TDigest tDigest = groupByResultHolder.getResult(groupKey);
-      if (tDigest == null) {
-        tDigest = new TDigest(DEFAULT_TDIGEST_COMPRESSION);
-        groupByResultHolder.setValueForKey(groupKey, tDigest);
-      }
-
-      tDigest.add(TDigest.fromBytes(ByteBuffer.wrap(valueArray[i])));
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
+          tDigest.add(valueArray[i]);
+        }
+        break;
+      case BYTES:
+        // Serialized TDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
+          tDigest.add(TDigest.fromBytes(ByteBuffer.wrap(bytesValues[i])));
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
-    byte[][] valueArray = blockValSets[0].getBytesValuesSV();
-
-    for (int i = 0; i < length; i++) {
-      byte[] value = valueArray[i];
-
-      for (int groupKey : groupKeysArray[i]) {
-        TDigest tDigest = groupByResultHolder.getResult(groupKey);
-        if (tDigest == null) {
-          tDigest = new TDigest(DEFAULT_TDIGEST_COMPRESSION);
-          groupByResultHolder.setValueForKey(groupKey, tDigest);
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        double[] valueArray = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          double value = valueArray[i];
+          for (int groupKey : groupKeysArray[i]) {
+            TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
+            tDigest.add(value);
+          }
         }
-
-        tDigest.add(TDigest.fromBytes(ByteBuffer.wrap(value)));
-      }
+      case BYTES:
+        // Serialized QuantileDigest
+        byte[][] bytesValues = blockValSets[0].getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          TDigest value = TDigest.fromBytes(ByteBuffer.wrap(bytesValues[i]));
+          for (int groupKey : groupKeysArray[i]) {
+            TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
+            tDigest.add(value);
+          }
+        }
+        break;
+      default:
+        throw new IllegalStateException("Illegal data type for PERCENTILE_TDIGEST aggregation function: " + valueType);
     }
   }
 
@@ -164,5 +202,36 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   @Override
   public Double extractFinalResult(@Nonnull TDigest intermediateResult) {
     return intermediateResult.quantile(_percentile / 100.0);
+  }
+
+  /**
+   * Returns the TDigest from the result holder or creates a new one if it does not exist.
+   *
+   * @param aggregationResultHolder Result holder
+   * @return TDigest from the result holder
+   */
+  protected static TDigest getTDigest(@Nonnull AggregationResultHolder aggregationResultHolder) {
+    TDigest tDigest = aggregationResultHolder.getResult();
+    if (tDigest == null) {
+      tDigest = new TDigest(DEFAULT_TDIGEST_COMPRESSION);
+      aggregationResultHolder.setValue(tDigest);
+    }
+    return tDigest;
+  }
+
+  /**
+   * Returns the TDigest for the given group key. If one does not exist, creates a new one and returns that.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group key for which to return the TDigest
+   * @return TDigest for the group key
+   */
+  protected static TDigest getTDigest(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
+    TDigest tDigest = groupByResultHolder.getResult(groupKey);
+    if (tDigest == null) {
+      tDigest = new TDigest(DEFAULT_TDIGEST_COMPRESSION);
+      groupByResultHolder.setValueForKey(groupKey, tDigest);
+    }
+    return tDigest;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -15,39 +15,39 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
+import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
-import com.linkedin.pinot.core.query.aggregation.function.customobject.QuantileDigest;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import javax.annotation.Nonnull;
 
 
-public class PercentileEstMVAggregationFunction extends PercentileEstAggregationFunction {
+public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAggregationFunction {
 
-  public PercentileEstMVAggregationFunction(int percentile) {
+  public PercentileTDigestMVAggregationFunction(int percentile) {
     super(percentile);
   }
 
   @Nonnull
   @Override
   public AggregationFunctionType getType() {
-    return AggregationFunctionType.PERCENTILEESTMV;
+    return AggregationFunctionType.PERCENTILETDIGESTMV;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + columns[0];
+    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + columns[0];
   }
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
       @Nonnull BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
-    QuantileDigest quantileDigest = getQuantileDigest(aggregationResultHolder);
+    TDigest tDigest = getTDigest(aggregationResultHolder);
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
-        quantileDigest.add((long) value);
+        tDigest.add(value);
       }
     }
   }
@@ -57,9 +57,9 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
       @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
     double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
-      QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKeyArray[i]);
+      TDigest tDigest = getTDigest(groupByResultHolder, groupKeyArray[i]);
       for (double value : valuesArray[i]) {
-        quantileDigest.add((long) value);
+        tDigest.add(value);
       }
     }
   }
@@ -71,9 +71,9 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {
-        QuantileDigest quantileDigest = getQuantileDigest(groupByResultHolder, groupKey);
+        TDigest tDigest = getTDigest(groupByResultHolder, groupKey);
         for (double value : values) {
-          quantileDigest.add((long) value);
+          tDigest.add(value);
         }
       }
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -20,58 +20,125 @@ import org.testng.annotations.Test;
 
 
 public class AggregationFunctionFactoryTest {
+  private static final String[] COLUMNS = {"column"};
 
   @Test
   public void testGetAggregationFunction() {
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("CoUnT") instanceof CountAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("MiN") instanceof MinAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("MaX") instanceof MaxAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("SuM") instanceof SumAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("AvG") instanceof AvgAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("MiNmAxRaNgE") instanceof MinMaxRangeAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("DiStInCtCoUnT") instanceof DistinctCountAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "DiStInCtCoUnThLl") instanceof DistinctCountHLLAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("FaStHlL") instanceof FastHLLAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe5") instanceof PercentileAggregationFunction);
-    Assert.assertEquals(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe5").getColumnName(new String[]{"column"}),
-        "percentile5_column");
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "PeRcEnTiLeEsT50") instanceof PercentileEstAggregationFunction);
-    Assert.assertEquals(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeEsT50").getColumnName(new String[]{"column"}),
-        "percentileEst50_column");
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "PeRcEnTiLeTdIgEsT99") instanceof PercentileTDigestAggregationFunction);
-    Assert.assertEquals(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeTdIgEsT99").getColumnName(new String[]{"column"}),
-        "percentileTDigest99_column");
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("CoUnTMv") instanceof CountMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("MiNmV") instanceof MinMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("MaXmV") instanceof MaxMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("SuMmV") instanceof SumMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction("AvGmV") instanceof AvgMVAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("MiNmAxRaNgEmV") instanceof MinMaxRangeMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "DiStInCtCoUnTmV") instanceof DistinctCountMVAggregationFunction);
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "DiStInCtCoUnThLlMv") instanceof DistinctCountHLLMVAggregationFunction);
-    Assert.assertTrue(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe10Mv") instanceof PercentileMVAggregationFunction);
-    Assert.assertEquals(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe10Mv").getColumnName(new String[]{"column"}),
-        "percentile10MV_column");
-    Assert.assertTrue(AggregationFunctionFactory.getAggregationFunction(
-        "PeRcEnTiLeEsT95mV") instanceof PercentileEstMVAggregationFunction);
-    Assert.assertEquals(
-        AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeEsT95mV").getColumnName(new String[]{"column"}),
-        "percentileEst95MV_column");
+    AggregationFunction aggregationFunction;
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("CoUnT");
+    Assert.assertTrue(aggregationFunction instanceof CountAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "count_star");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MiN");
+    Assert.assertTrue(aggregationFunction instanceof MinAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "min_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MaX");
+    Assert.assertTrue(aggregationFunction instanceof MaxAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "max_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("SuM");
+    Assert.assertTrue(aggregationFunction instanceof SumAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "sum_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("AvG");
+    Assert.assertTrue(aggregationFunction instanceof AvgAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "avg_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MiNmAxRaNgE");
+    Assert.assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "minMaxRange_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("DiStInCtCoUnT");
+    Assert.assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "distinctCount_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("DiStInCtCoUnThLl");
+    Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "distinctCountHLL_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("FaStHlL");
+    Assert.assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "fastHLL_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe5");
+    Assert.assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentile5_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeEsT50");
+    Assert.assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentileEst50_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeTdIgEsT99");
+    Assert.assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentileTDigest99_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("CoUnTmV");
+    Assert.assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "countMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MiNmV");
+    Assert.assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "minMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MaXmV");
+    Assert.assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "maxMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("SuMmV");
+    Assert.assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "sumMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("AvGmV");
+    Assert.assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "avgMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("MiNmAxRaNgEmV");
+    Assert.assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "minMaxRangeMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("DiStInCtCoUnTmV");
+    Assert.assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "distinctCountMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("DiStInCtCoUnThLlMv");
+    Assert.assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "distinctCountHLLMV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLe10Mv");
+    Assert.assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentile10MV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeEsT90mV");
+    Assert.assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentileEst90MV_column");
+
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction("PeRcEnTiLeTdIgEsT95mV");
+    Assert.assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
+    Assert.assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
+    Assert.assertEquals(aggregationFunction.getColumnName(COLUMNS), "percentileTDigest95MV_column");
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionTypeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionTypeTest.java
@@ -54,7 +54,9 @@ public class AggregationFunctionTypeTest {
         AggregationFunctionType.DISTINCTCOUNTHLLMV);
     Assert.assertEquals(AggregationFunctionType.getAggregationFunctionType("PeRcEnTiLe10Mv"),
         AggregationFunctionType.PERCENTILEMV);
-    Assert.assertEquals(AggregationFunctionType.getAggregationFunctionType("PeRcEnTiLeEsT95mV"),
+    Assert.assertEquals(AggregationFunctionType.getAggregationFunctionType("PeRcEnTiLeEsT90mV"),
         AggregationFunctionType.PERCENTILEESTMV);
+    Assert.assertEquals(AggregationFunctionType.getAggregationFunctionType("PeRcEnTiLeTdIgEsT95mV"),
+        AggregationFunctionType.PERCENTILETDIGESTMV);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestMVQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestMVQueriesTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.queries;
+
+import com.clearspring.analytics.stream.quantile.TDigest;
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.GenericRowRecordReader;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+
+/**
+ * Tests for PERCENTILE_TDIGEST and PERCENTILE_TDIGEST_MV aggregation functions.
+ *
+ * <ul>
+ *   <li>Generates a segment with a double multi-valued column, a TDigest column and a group-by column</li>
+ *   <li>Runs aggregation and group-by queries on the generated segment</li>
+ *   <li>
+ *     Compares the results for PERCENTILE_TDIGEST_MV on double multi-valued column, PERCENTILE_TDIGEST on TDigest
+ *     column with results for PERCENTILE_MV on double multi-valued column
+ *   </li>
+ * </ul>
+ */
+public class PercentileTDigestMVQueriesTest extends PercentileTDigestQueriesTest {
+  private static final int MAX_NUM_MULTI_VALUES = 10;
+
+  @Override
+  protected void buildSegment() throws Exception {
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      HashMap<String, Object> valueMap = new HashMap<>();
+
+      int numMultiValues = RANDOM.nextInt(MAX_NUM_MULTI_VALUES) + 1;
+      Double[] values = new Double[numMultiValues];
+      TDigest tDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+      for (int j = 0; j < numMultiValues; j++) {
+        double value = RANDOM.nextDouble() * VALUE_RANGE;
+        values[j] = value;
+        tDigest.add(value);
+      }
+      valueMap.put(DOUBLE_COLUMN, values);
+      ByteBuffer byteBuffer = ByteBuffer.allocate(tDigest.byteSize());
+      tDigest.asBytes(byteBuffer);
+      valueMap.put(TDIGEST_COLUMN, byteBuffer.array());
+
+      String group = GROUPS[RANDOM.nextInt(GROUPS.length)];
+      valueMap.put(GROUP_BY_COLUMN, group);
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(valueMap);
+      rows.add(genericRow);
+    }
+
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE, false));
+    schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
+    schema.addField(new DimensionFieldSpec(GROUP_BY_COLUMN, FieldSpec.DataType.STRING, true));
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+    config.setRawIndexCreationColumns(Collections.singletonList(TDIGEST_COLUMN));
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+  }
+
+  @Override
+  protected String getAggregationQuery(int percentile) {
+    return String.format("SELECT PERCENTILE%dMV(%s), PERCENTILETDIGEST%dMV(%s), PERCENTILETDIGEST%d(%s) FROM %s",
+        percentile, DOUBLE_COLUMN, percentile, DOUBLE_COLUMN, percentile, TDIGEST_COLUMN, TABLE_NAME);
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -22,11 +22,8 @@ import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.response.broker.AggregationResult;
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
+import com.linkedin.pinot.common.response.broker.GroupByResult;
 import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.common.utils.DataSchema;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
-import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.manager.SegmentDataManager;
 import com.linkedin.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
@@ -36,25 +33,15 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
-import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
-import com.linkedin.pinot.core.operator.DocIdSetOperator;
-import com.linkedin.pinot.core.operator.ProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
-import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
-import com.linkedin.pinot.core.operator.filter.MatchEntireSegmentOperator;
 import com.linkedin.pinot.core.operator.query.AggregationGroupByOperator;
 import com.linkedin.pinot.core.operator.query.AggregationOperator;
-import com.linkedin.pinot.core.operator.query.SelectionOrderByOperator;
-import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
-import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
-import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import com.linkedin.pinot.core.segment.store.SegmentDirectory;
+import it.unimi.dsi.fastutil.doubles.DoubleList;
 import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,7 +51,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -73,38 +59,35 @@ import org.testng.annotations.Test;
 
 
 /**
- * Test for PercentileEst aggregation feature.
+ * Tests for PERCENTILE_TDIGEST aggregation function.
  *
  * <ul>
- *   <li> Generates a segment with a TDigest column and a Group-by column. </li>
- *   <li> Runs aggregation and group-by queries on the generated segment. </li>
- *   <li> Asserts that results of queries are as expected. </li>
+ *   <li>Generates a segment with a double column, a TDigest column and a group-by column</li>
+ *   <li>Runs aggregation and group-by queries on the generated segment</li>
+ *   <li>
+ *     Compares the results for PERCENTILE_TDIGEST on double column and TDigest column with results for PERCENTILE on
+ *     double column
+ *   </li>
  * </ul>
- *
  */
 public class PercentileTDigestQueriesTest extends BaseQueriesTest {
-  private static final int NUM_ROWS = 100; // With TDigest compression of 100, test becomes brittle with large num rows.
+  protected static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "PercentileTDigestQueriesTest");
+  protected static final String TABLE_NAME = "testTable";
+  protected static final String SEGMENT_NAME = "testSegment";
 
-  private static final String SEGMENT_DIR_NAME =
-      System.getProperty("java.io.tmpdir") + File.separator + "tDigestSegTest";
-  private static final String SEGMENT_NAME = "testSegment";
+  protected static final int NUM_ROWS = 1000;
+  protected static final double VALUE_RANGE = Integer.MAX_VALUE;
+  protected static final double DELTA = 0.1 * VALUE_RANGE; // Allow 10% quantile error
+  protected static final String DOUBLE_COLUMN = "doubleColumn";
+  protected static final String TDIGEST_COLUMN = "tDigestColumn";
+  protected static final String GROUP_BY_COLUMN = "groupByColumn";
+  protected static final String[] GROUPS = new String[]{"G1", "G2", "G3", "G4", "G5"};
+  protected static final long RANDOM_SEED = System.nanoTime();
+  protected static final Random RANDOM = new Random(RANDOM_SEED);
+  protected static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
 
-  private static final String TDIGEST_COLUMN = "tDigestColumn";
-  private static final String GROUPBY_COLUMN = "groupByColumn";
-  private static final String TABLE_NAME = "TDIGEST_TABLE";
-
-  private static final String[] groups = new String[]{"abc", "def", "ghij", "klmno", "pqrst"};
-  private static final String GROUP_BY_CLAUSE = " group by " + GROUPBY_COLUMN + " TOP " + groups.length;
-  private static final int[] PERCENTILES_TO_COMPUTE = new int[]{5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 99};
-  private static final long RANDOM_SEED = System.nanoTime();
-
-  private Random _random;
-  private RecordReader _recordReader;
-  private ImmutableSegment _segment;
-  private TDigest _expectedTDigest;
+  private ImmutableSegment _indexSegment;
   private List<SegmentDataManager> _segmentDataManagers;
-  private HashMap<String, TDigest> _expectedGroupBy;
-  private List<String> _expectedSelectionTDigests;
 
   @Override
   protected String getFilter() {
@@ -113,7 +96,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
 
   @Override
   protected IndexSegment getIndexSegment() {
-    return _segment;
+    return _indexSegment;
   }
 
   @Override
@@ -121,232 +104,158 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     return _segmentDataManagers;
   }
 
-  /**
-   * Setup to build a segment with raw indexes (no-dictionary) of various data types.
-   *
-   * @throws Exception
-   */
   @BeforeClass
-  public void setup()
-      throws Exception {
+  public void setUp() throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
 
-    Schema schema = new Schema();
-    schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
-    schema.addField(new DimensionFieldSpec(GROUPBY_COLUMN, FieldSpec.DataType.STRING, true));
-
-    _random = new Random(RANDOM_SEED);
-    _recordReader = buildIndex(schema);
-    _segment = ImmutableSegmentLoader.load(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), ReadMode.heap);
+    buildSegment();
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
     _segmentDataManagers =
-        Arrays.asList(new ImmutableSegmentDataManager(_segment), new ImmutableSegmentDataManager(_segment));
+        Arrays.asList(new ImmutableSegmentDataManager(_indexSegment), new ImmutableSegmentDataManager(_indexSegment));
   }
 
-  /**
-   * Clean up after test
-   */
-  @AfterClass
-  public void cleanup()
-      throws IOException {
-    _recordReader.close();
-    _segment.destroy();
-    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
-  }
-
-  /**
-   * Unit test for {@link PercentileTDigestAggregationFunction}.
-   */
-  @Test
-  public void testAggregationFunction() {
-    Map<String, DataSource> dataSourceMap = new HashMap<>();
-    dataSourceMap.put(TDIGEST_COLUMN, _segment.getDataSource(TDIGEST_COLUMN));
-
-    MatchEntireSegmentOperator matchEntireSegmentOperator =
-        new MatchEntireSegmentOperator(_segment.getSegmentMetadata().getTotalRawDocs());
-    DocIdSetOperator docIdSetOperator =
-        new DocIdSetOperator(matchEntireSegmentOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL);
-    ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
-
-    ProjectionBlock projectionBlock = projectionOperator.nextBlock();
-
-    for (int percentile : PERCENTILES_TO_COMPUTE) {
-      PercentileTDigestAggregationFunction aggregationFunction = new PercentileTDigestAggregationFunction(percentile);
-      BlockValSet blockValueSet = projectionBlock.getBlockValueSet(TDIGEST_COLUMN);
-
-      AggregationResultHolder resultHolder = new ObjectAggregationResultHolder();
-      aggregationFunction.aggregate(NUM_ROWS, resultHolder, blockValueSet);
-      TDigest tDigest = aggregationFunction.extractAggregationResult(resultHolder);
-
-      double actual = aggregationFunction.extractFinalResult(tDigest);
-      double expected = _expectedTDigest.quantile(((double) percentile) / 100.0);
-
-      Assert.assertEquals(actual, expected, 1e-5,
-          "Failed for percentile: " + percentile + ". Random seed: " + RANDOM_SEED);
-    }
-  }
-
-  /**
-   * Test for selection queries.
-   */
-  @Test
-  public void testSelectionQueries() {
-    String query = "select * from " + TABLE_NAME + " order by " + TDIGEST_COLUMN + " LIMIT " + NUM_ROWS;
-
-    SelectionOrderByOperator selectionOnlyOperator = getOperatorForQuery(query);
-    IntermediateResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
-
-    DataSchema dataSchema = resultsBlock.getSelectionDataSchema();
-    int colIndex = Collections.singletonList(dataSchema.getColumnName(0)).indexOf(TDIGEST_COLUMN);
-
-    List<String> _actualSelectedTDigests = resultsBlock.getSelectionResult()
-        .stream()
-        .map(selections -> (String) selections[colIndex])
-        .sorted()
-        .collect(Collectors.toList());
-
-    Collections.sort(_expectedSelectionTDigests);
-
-    Assert.assertEquals(_actualSelectedTDigests.size(), NUM_ROWS);
-    Assert.assertEquals(_actualSelectedTDigests, _expectedSelectionTDigests);
-  }
-
-  /**
-   * Test for aggregation queries.
-   */
-  @Test
-  public void testAggregationQueries() {
-    for (int percentile : PERCENTILES_TO_COMPUTE) {
-      String query = buildBaseQuery(percentile);
-
-      // Server side aggregation test:
-      AggregationOperator aggregationOperator = getOperatorForQuery(query);
-      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
-
-      double q = ((double) percentile) / 100.0;
-      for (Object result : resultsBlock.getAggregationResult()) {
-        TDigest actual = (TDigest) result;
-        Assert.assertEquals(actual.quantile(q), _expectedTDigest.quantile(q), 1e-5);
-      }
-
-      // Broker side aggregation test:
-      BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
-      AggregationResult aggregationResult = brokerResponse.getAggregationResults().get(0);
-      double actual = Double.parseDouble((String) aggregationResult.getValue());
-
-      // Expected result is as there were 2 servers with 2 segments each (see BaseQueriesTest).
-      TDigest expected = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
-      for (int i = 0; i < 4; i++) {
-        expected.add(_expectedTDigest);
-      }
-      Assert.assertEquals(actual, expected.quantile(q), 1e-5);
-    }
-  }
-
-  /**
-   * Test for group-by queries.
-   */
-  @Test
-  public void testGroupByQueries() {
-    for (int percentile : PERCENTILES_TO_COMPUTE) {
-      String query = buildBaseQuery(percentile) + GROUP_BY_CLAUSE;
-
-      AggregationGroupByOperator aggregationOperator = getOperatorForQuery(query);
-      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
-
-      AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
-      Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
-
-      int numGroups = 0;
-      while (groupKeyIterator.hasNext()) {
-        GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-        TDigest actual = (TDigest) groupByResult.getResultForKey(groupKey, 0);
-        double q = ((double) percentile) / 100.0;
-        Assert.assertEquals(actual.quantile(q), _expectedGroupBy.get(groupKey._stringKey).quantile(q), 1e-5);
-        numGroups++;
-      }
-
-      Assert.assertEquals(numGroups, groups.length);
-    }
-  }
-
-  /**
-   * Helper method to build a segment containing a single valued string column with RAW (no-dictionary) index.
-   *
-   * @return Array of string values for the rows in the generated index.
-   * @throws Exception
-   */
-
-  private RecordReader buildIndex(Schema schema)
-      throws Exception {
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
-
-    config.setOutDir(SEGMENT_DIR_NAME);
-    config.setSegmentName(SEGMENT_NAME);
-    config.setTableName(TABLE_NAME);
-    config.setRawIndexCreationColumns(Arrays.asList(TDIGEST_COLUMN));
-
+  protected void buildSegment() throws Exception {
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
-    _expectedTDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
-
-    _expectedGroupBy = new HashMap<>();
-    _expectedSelectionTDigests = new ArrayList<>(NUM_ROWS);
-
     for (int i = 0; i < NUM_ROWS; i++) {
-      HashMap<String, Object> map = new HashMap<>();
+      HashMap<String, Object> valueMap = new HashMap<>();
 
-      // Set the value for fixed-byte sorted column.
-      double value = _random.nextDouble();
+      double value = RANDOM.nextDouble() * VALUE_RANGE;
+      valueMap.put(DOUBLE_COLUMN, value);
+
       TDigest tDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
       tDigest.add(value);
-      _expectedTDigest.add(tDigest);
-
       ByteBuffer byteBuffer = ByteBuffer.allocate(tDigest.byteSize());
       tDigest.asBytes(byteBuffer);
-      _expectedSelectionTDigests.add(ByteArray.toHexString(byteBuffer.array()));
+      valueMap.put(TDIGEST_COLUMN, byteBuffer.array());
 
-      // Add the TDigest column.
-      byte[] bytes = byteBuffer.array();
-      map.put(TDIGEST_COLUMN, bytes);
-
-      // Add the GroupBy column.
-      String group = groups[_random.nextInt(groups.length)];
-      map.put(GROUPBY_COLUMN, group);
-
-      // Generate the groups.
-      TDigest groupTDigest = _expectedGroupBy.get(group);
-      if (groupTDigest == null) {
-        _expectedGroupBy.put(group, tDigest);
-      } else {
-        groupTDigest.add(tDigest);
-      }
+      String group = GROUPS[RANDOM.nextInt(GROUPS.length)];
+      valueMap.put(GROUP_BY_COLUMN, group);
 
       GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
+      genericRow.init(valueMap);
       rows.add(genericRow);
     }
 
-    RecordReader recordReader = new GenericRowRecordReader(rows, schema);
+    Schema schema = new Schema();
+    schema.addField(new MetricFieldSpec(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE));
+    schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
+    schema.addField(new DimensionFieldSpec(GROUP_BY_COLUMN, FieldSpec.DataType.STRING, true));
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+    config.setRawIndexCreationColumns(Collections.singletonList(TDIGEST_COLUMN));
+
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(config, recordReader);
-    driver.build();
-
-    SegmentDirectory.createFromLocalFS(driver.getOutputDirectory(), ReadMode.mmap);
-    recordReader.rewind();
-
-    TDigest actual = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
-    GenericRow reuse = new GenericRow();
-    while (recordReader.hasNext()) {
-      reuse = recordReader.next(reuse);
-      actual.add(TDigest.fromBytes(ByteBuffer.wrap((byte[]) reuse.getValue(TDIGEST_COLUMN))));
+    try (RecordReader recordReader = new GenericRowRecordReader(rows, schema)) {
+      driver.init(config, recordReader);
+      driver.build();
     }
-    return recordReader;
   }
 
-  private String buildBaseQuery(int percentile) {
-    return "select percentiletdigest" + percentile +
-        "(" +
-        TDIGEST_COLUMN +
-        ")" +
-        " from " +
-        TABLE_NAME;
+  @Test
+  public void testInnerSegmentAggregation() {
+    for (int percentile = 0; percentile <= 100; percentile++) {
+      AggregationOperator aggregationOperator = getOperatorForQuery(getAggregationQuery(percentile));
+      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      Assert.assertNotNull(aggregationResult);
+      Assert.assertEquals(aggregationResult.size(), 3);
+      DoubleList doubleList = (DoubleList) aggregationResult.get(0);
+      Collections.sort(doubleList);
+      double expected;
+      if (percentile == 100) {
+        expected = doubleList.getDouble(doubleList.size() - 1);
+      } else {
+        expected = doubleList.getDouble(doubleList.size() * percentile / 100);
+      }
+      TDigest tDigestForDoubleColumn = (TDigest) aggregationResult.get(1);
+      Assert.assertEquals(tDigestForDoubleColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+      TDigest tDigestForTDigestColumn = (TDigest) aggregationResult.get(2);
+      Assert.assertEquals(tDigestForTDigestColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+    }
+  }
+
+  @Test
+  public void testInterSegmentAggregation() {
+    for (int percentile = 0; percentile <= 100; percentile++) {
+      BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getAggregationQuery(percentile));
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertNotNull(aggregationResults);
+      Assert.assertEquals(aggregationResults.size(), 3);
+      double expected = Double.parseDouble((String) aggregationResults.get(0).getValue());
+      double resultForDoubleColumn = Double.parseDouble((String) aggregationResults.get(1).getValue());
+      Assert.assertEquals(resultForDoubleColumn, expected, DELTA, ERROR_MESSAGE);
+      double resultForTDigestColumn = Double.parseDouble((String) aggregationResults.get(2).getValue());
+      Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+    }
+  }
+
+  @Test
+  public void testInnerSegmentGroupBy() {
+    for (int percentile = 0; percentile <= 100; percentile++) {
+      AggregationGroupByOperator groupByOperator = getOperatorForQuery(getGroupByQuery(percentile));
+      IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+      AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
+      Assert.assertNotNull(groupByResult);
+      Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+      while (groupKeyIterator.hasNext()) {
+        GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+        DoubleList doubleList = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
+        Collections.sort(doubleList);
+        double expected;
+        if (percentile == 100) {
+          expected = doubleList.getDouble(doubleList.size() - 1);
+        } else {
+          expected = doubleList.getDouble(doubleList.size() * percentile / 100);
+        }
+        TDigest tDigestForDoubleColumn = (TDigest) groupByResult.getResultForKey(groupKey, 1);
+        Assert.assertEquals(tDigestForDoubleColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+        TDigest tDigestForTDigestColumn = (TDigest) groupByResult.getResultForKey(groupKey, 2);
+        Assert.assertEquals(tDigestForTDigestColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+      }
+    }
+  }
+
+  @Test
+  public void testInterSegmentGroupBy() {
+    for (int percentile = 0; percentile <= 100; percentile++) {
+      BrokerResponseNative brokerResponse = getBrokerResponseForQuery(getGroupByQuery(percentile));
+      List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+      Assert.assertNotNull(aggregationResults);
+      Assert.assertEquals(aggregationResults.size(), 3);
+      Map<String, Double> expectedValues = new HashMap<>();
+      for (GroupByResult groupByResult : aggregationResults.get(0).getGroupByResult()) {
+        expectedValues.put(groupByResult.getGroup().get(0), Double.parseDouble((String) groupByResult.getValue()));
+      }
+      for (GroupByResult groupByResult : aggregationResults.get(1).getGroupByResult()) {
+        String group = groupByResult.getGroup().get(0);
+        double expected = expectedValues.get(group);
+        double resultForDoubleColumn = Double.parseDouble((String) groupByResult.getValue());
+        Assert.assertEquals(resultForDoubleColumn, expected, DELTA, ERROR_MESSAGE);
+      }
+      for (GroupByResult groupByResult : aggregationResults.get(2).getGroupByResult()) {
+        String group = groupByResult.getGroup().get(0);
+        double expected = expectedValues.get(group);
+        double resultForTDigestColumn = Double.parseDouble((String) groupByResult.getValue());
+        Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+      }
+    }
+  }
+
+  protected String getAggregationQuery(int percentile) {
+    return String.format("SELECT PERCENTILE%d(%s), PERCENTILETDIGEST%d(%s), PERCENTILETDIGEST%d(%s) FROM %s",
+        percentile, DOUBLE_COLUMN, percentile, DOUBLE_COLUMN, percentile, TDIGEST_COLUMN, TABLE_NAME);
+  }
+
+  private String getGroupByQuery(int percentile) {
+    return String.format("%s GROUP BY %s", getAggregationQuery(percentile), GROUP_BY_COLUMN);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
   }
 }


### PR DESCRIPTION
Pre-requisite for star-tree
Whether the value is original value or serialized bytes from star-tree should be transparent to users:
- For the same aggregation (DistinctCountHLL, PercentileEst or PercentileTDigest), we should return the same result regardless of whether there is star-tree
- User should have no knowledge about whether the segment has star-tree index or not, the only observation should be the query latency drops drastically
- User should not use special type of aggregation function (such as FastHLL over DistinctCountHLL) to explicitly choose to use star-tree

Also add PercentileTDigestMV aggregation function to work on multi-valued numeric columns