### PR TITLE
Move kafka connection provider code to a separate class

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -38,8 +38,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides the kafka connection after ensuring that we're connected to the appropriate broker for consumption.
  */
-public class KafkaConnectionProvider {
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectionProvider.class);
+public class KafkaConnectionHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectionHandler.class);
   private static final int SOCKET_TIMEOUT_MILLIS = 10000;
   private static final int SOCKET_BUFFER_SIZE = 512000;
 
@@ -91,7 +91,7 @@ public class KafkaConnectionProvider {
     }
   }
 
-  public KafkaConnectionProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
+  public KafkaConnectionHandler(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
       String clientId, long connectTimeoutMillis) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
@@ -107,7 +107,7 @@ public class KafkaConnectionProvider {
     setCurrentState(new ConnectingToBootstrapNode());
   }
 
-  public KafkaConnectionProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
+  public KafkaConnectionHandler(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
       String clientId, String topic, int partition, long connectTimeoutMillis) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionProvider.java
@@ -1,0 +1,411 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.kafka;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.core.realtime.stream.PermanentConsumerException;
+import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import kafka.javaapi.PartitionMetadata;
+import kafka.javaapi.TopicMetadataRequest;
+import kafka.javaapi.TopicMetadataResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Provides the kafka connection after ensuring that we're connected to the appropriate broker for consumption.
+ */
+public class KafkaConnectionProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConnectionProvider.class);
+  private static final int SOCKET_TIMEOUT_MILLIS = 10000;
+  private static final int SOCKET_BUFFER_SIZE = 512000;
+
+  enum ConsumerState {
+    CONNECTING_TO_BOOTSTRAP_NODE,
+    CONNECTED_TO_BOOTSTRAP_NODE,
+    FETCHING_LEADER_INFORMATION,
+    CONNECTING_TO_PARTITION_LEADER,
+    CONNECTED_TO_PARTITION_LEADER
+  }
+
+  State _currentState;
+
+  final String _clientId;
+  final String _topic;
+  final int _partition;
+  final long _connectTimeoutMillis;
+
+  String[] _bootstrapHosts;
+  int[] _bootstrapPorts;
+  KafkaBrokerWrapper _leader;
+  String _currentHost;
+  int _currentPort;
+
+  final KafkaSimpleConsumerFactory _simpleConsumerFactory;
+  SimpleConsumer _simpleConsumer;
+
+  final Random _random = new Random();
+
+  boolean _metadataOnlyConsumer;
+
+  /**
+   * A Kafka protocol error that indicates a situation that is not likely to clear up by retrying the request (for
+   * example, no such topic or offset out of range).
+   */
+  private class KafkaPermanentConsumerException extends RuntimeException {
+    public KafkaPermanentConsumerException(Errors error) {
+      super(error.exception());
+    }
+  }
+
+  /**
+   * A Kafka protocol error that indicates a situation that is likely to be transient (for example, network error or
+   * broker not available).
+   */
+  private class KafkaTransientConsumerException extends RuntimeException {
+    public KafkaTransientConsumerException(Errors error) {
+      super(error.exception());
+    }
+  }
+
+  public KafkaConnectionProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
+      String clientId, long connectTimeoutMillis) {
+    _simpleConsumerFactory = simpleConsumerFactory;
+    _clientId = clientId;
+    _connectTimeoutMillis = connectTimeoutMillis;
+    _simpleConsumer = null;
+
+    // Topic and partition are ignored for metadata-only consumers
+    _topic = null;
+    _partition = Integer.MIN_VALUE;
+    _metadataOnlyConsumer = true;
+
+    initializeBootstrapNodeList(bootstrapNodes);
+    setCurrentState(new ConnectingToBootstrapNode());
+  }
+
+  public KafkaConnectionProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
+      String clientId, String topic, int partition, long connectTimeoutMillis) {
+    _simpleConsumerFactory = simpleConsumerFactory;
+    _clientId = clientId;
+    _topic = topic;
+    _partition = partition;
+    _connectTimeoutMillis = connectTimeoutMillis;
+    _metadataOnlyConsumer = false;
+    _simpleConsumer = null;
+
+    initializeBootstrapNodeList(bootstrapNodes);
+    setCurrentState(new ConnectingToBootstrapNode());
+  }
+
+  void initializeBootstrapNodeList(String bootstrapNodes) {
+    ArrayList<String> hostsAndPorts =
+        Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(bootstrapNodes));
+
+    final int bootstrapHostCount = hostsAndPorts.size();
+
+    if (bootstrapHostCount < 1) {
+      throw new IllegalArgumentException("Need at least one bootstrap host");
+    }
+
+    _bootstrapHosts = new String[bootstrapHostCount];
+    _bootstrapPorts = new int[bootstrapHostCount];
+
+    for (int i = 0; i < bootstrapHostCount; i++) {
+      String hostAndPort = hostsAndPorts.get(i);
+      String[] splittedHostAndPort = hostAndPort.split(":");
+
+      if (splittedHostAndPort.length != 2) {
+        throw new IllegalArgumentException("Unable to parse host:port combination for " + hostAndPort);
+      }
+
+      _bootstrapHosts[i] = splittedHostAndPort[0];
+
+      try {
+        _bootstrapPorts[i] = Integer.parseInt(splittedHostAndPort[1]);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Could not parse port number " + splittedHostAndPort[1] + " for host:port combination " + hostAndPort);
+      }
+    }
+  }
+
+  abstract class State {
+    private ConsumerState stateValue;
+
+    protected State(ConsumerState stateValue) {
+      this.stateValue = stateValue;
+    }
+
+    abstract void process();
+
+    abstract boolean isConnectedToKafkaBroker();
+
+    void handleConsumerException(Exception e) {
+      // By default, just log the exception and switch back to CONNECTING_TO_BOOTSTRAP_NODE (which will take care of
+      // closing the connection if it exists)
+      LOGGER.warn("Caught Kafka consumer exception while in state {}, disconnecting and trying again for topic {}",
+          _currentState.getStateValue(), _topic, e);
+
+      Uninterruptibles.sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+
+      setCurrentState(new ConnectingToBootstrapNode());
+    }
+
+    ConsumerState getStateValue() {
+      return stateValue;
+    }
+  }
+
+  private class ConnectingToBootstrapNode extends State {
+    public ConnectingToBootstrapNode() {
+      super(ConsumerState.CONNECTING_TO_BOOTSTRAP_NODE);
+    }
+
+    @Override
+    public void process() {
+      // Connect to a random bootstrap node
+      if (_simpleConsumer != null) {
+        try {
+          _simpleConsumer.close();
+        } catch (Exception e) {
+          LOGGER.warn("Caught exception while closing consumer for topic {}, ignoring", _topic, e);
+        }
+      }
+
+      int randomHostIndex = _random.nextInt(_bootstrapHosts.length);
+      _currentHost = _bootstrapHosts[randomHostIndex];
+      _currentPort = _bootstrapPorts[randomHostIndex];
+
+      try {
+        LOGGER.info("Connecting to bootstrap host {}:{} for topic {}", _currentHost, _currentPort, _topic);
+        _simpleConsumer = _simpleConsumerFactory.buildSimpleConsumer(_currentHost, _currentPort, SOCKET_TIMEOUT_MILLIS,
+            SOCKET_BUFFER_SIZE, _clientId);
+        setCurrentState(new ConnectedToBootstrapNode());
+      } catch (Exception e) {
+        handleConsumerException(e);
+      }
+    }
+
+    @Override
+    boolean isConnectedToKafkaBroker() {
+      return false;
+    }
+  }
+
+  private class ConnectedToBootstrapNode extends State {
+    protected ConnectedToBootstrapNode() {
+      super(ConsumerState.CONNECTED_TO_BOOTSTRAP_NODE);
+    }
+
+    @Override
+    void process() {
+      if (_metadataOnlyConsumer) {
+        // Nothing to do
+      } else {
+        // If we're consuming from a partition, we need to find the leader so that we can consume from it. By design,
+        // Kafka only allows consumption from the leader and not one of the in-sync replicas.
+        setCurrentState(new FetchingLeaderInformation());
+      }
+    }
+
+    @Override
+    boolean isConnectedToKafkaBroker() {
+      return true;
+    }
+  }
+
+  private class FetchingLeaderInformation extends State {
+    public FetchingLeaderInformation() {
+      super(ConsumerState.FETCHING_LEADER_INFORMATION);
+    }
+
+    @Override
+    void process() {
+      // Fetch leader information
+      try {
+        TopicMetadataResponse response =
+            _simpleConsumer.send(new TopicMetadataRequest(Collections.singletonList(_topic)));
+        try {
+          _leader = null;
+          List<PartitionMetadata> pMetaList = response.topicsMetadata().get(0).partitionsMetadata();
+          for (PartitionMetadata pMeta : pMetaList) {
+            if (pMeta.partitionId() == _partition) {
+              _leader = new KafkaBrokerWrapper(pMeta.leader());
+              break;
+            }
+          }
+
+          // If we've located a broker
+          if (_leader != null) {
+            LOGGER.info("Located leader broker {} for topic {}, connecting to it.", _leader, _topic);
+            setCurrentState(new ConnectingToPartitionLeader());
+          } else {
+            // Failed to get the leader broker. There could be a leader election at the moment, so retry after a little
+            // bit.
+            LOGGER.warn("Leader broker is null for topic {}, retrying leader fetch in 100ms", _topic);
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+          }
+        } catch (Exception e) {
+          // Failed to get the leader broker. There could be a leader election at the moment, so retry after a little
+          // bit.
+          LOGGER.warn("Failed to get the leader broker for topic {} due to exception, retrying in 100ms", _topic, e);
+          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+        }
+      } catch (Exception e) {
+        handleConsumerException(e);
+      }
+    }
+
+    @Override
+    boolean isConnectedToKafkaBroker() {
+      return true;
+    }
+  }
+
+  private class ConnectingToPartitionLeader extends State {
+    public ConnectingToPartitionLeader() {
+      super(ConsumerState.CONNECTING_TO_PARTITION_LEADER);
+    }
+
+    @Override
+    void process() {
+      // If we're already connected to the leader broker, don't disconnect and reconnect
+      LOGGER.info("Trying to fetch leader host and port: {}:{} for topic {}", _leader.host(), _leader.port(), _topic);
+      if (_leader.host().equals(_currentHost) && _leader.port() == _currentPort) {
+        setCurrentState(new ConnectedToPartitionLeader());
+        return;
+      }
+
+      // Disconnect from current broker
+      if (_simpleConsumer != null) {
+        try {
+          _simpleConsumer.close();
+          _simpleConsumer = null;
+        } catch (Exception e) {
+          handleConsumerException(e);
+          return;
+        }
+      }
+
+      // Connect to the partition leader
+      try {
+        _simpleConsumer =
+            _simpleConsumerFactory.buildSimpleConsumer(_leader.host(), _leader.port(), SOCKET_TIMEOUT_MILLIS,
+                SOCKET_BUFFER_SIZE, _clientId);
+
+        setCurrentState(new ConnectedToPartitionLeader());
+      } catch (Exception e) {
+        handleConsumerException(e);
+      }
+    }
+
+    @Override
+    boolean isConnectedToKafkaBroker() {
+      return false;
+    }
+  }
+
+  private class ConnectedToPartitionLeader extends State {
+    public ConnectedToPartitionLeader() {
+      super(ConsumerState.CONNECTED_TO_PARTITION_LEADER);
+    }
+
+    @Override
+    void process() {
+      // Nothing to do
+    }
+
+    @Override
+    boolean isConnectedToKafkaBroker() {
+      return true;
+    }
+  }
+
+  private void setCurrentState(State newState) {
+    if (_currentState != null) {
+      LOGGER.info("Switching from state {} to state {} for topic {}", _currentState.getStateValue(),
+          newState.getStateValue(), _topic);
+    }
+
+    _currentState = newState;
+  }
+
+  RuntimeException exceptionForKafkaErrorCode(short kafkaErrorCode) {
+    final Errors kafkaError = Errors.forCode(kafkaErrorCode);
+    switch (kafkaError) {
+      case UNKNOWN:
+      case OFFSET_OUT_OF_RANGE:
+      case CORRUPT_MESSAGE:
+      case MESSAGE_TOO_LARGE:
+      case OFFSET_METADATA_TOO_LARGE:
+      case INVALID_TOPIC_EXCEPTION:
+      case RECORD_LIST_TOO_LARGE:
+      case INVALID_REQUIRED_ACKS:
+      case ILLEGAL_GENERATION:
+      case INCONSISTENT_GROUP_PROTOCOL:
+      case INVALID_GROUP_ID:
+      case UNKNOWN_MEMBER_ID:
+      case INVALID_SESSION_TIMEOUT:
+      case INVALID_COMMIT_OFFSET_SIZE:
+        return new PermanentConsumerException(new KafkaPermanentConsumerException(kafkaError));
+      case UNKNOWN_TOPIC_OR_PARTITION:
+      case LEADER_NOT_AVAILABLE:
+      case NOT_LEADER_FOR_PARTITION:
+      case REQUEST_TIMED_OUT:
+      case BROKER_NOT_AVAILABLE:
+      case REPLICA_NOT_AVAILABLE:
+      case STALE_CONTROLLER_EPOCH:
+      case NETWORK_EXCEPTION:
+      case GROUP_LOAD_IN_PROGRESS:
+      case GROUP_COORDINATOR_NOT_AVAILABLE:
+      case NOT_COORDINATOR_FOR_GROUP:
+      case NOT_ENOUGH_REPLICAS:
+      case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
+      case REBALANCE_IN_PROGRESS:
+      case TOPIC_AUTHORIZATION_FAILED:
+      case GROUP_AUTHORIZATION_FAILED:
+      case CLUSTER_AUTHORIZATION_FAILED:
+        return new TransientConsumerException(new KafkaTransientConsumerException(kafkaError));
+      case NONE:
+      default:
+        return new RuntimeException("Unhandled error " + kafkaError);
+    }
+  }
+
+  void close() throws IOException {
+    boolean needToCloseConsumer = _currentState.isConnectedToKafkaBroker() && _simpleConsumer != null;
+
+    // Reset the state machine
+    setCurrentState(new ConnectingToBootstrapNode());
+
+    // Close the consumer if needed
+    if (needToCloseConsumer) {
+      _simpleConsumer.close();
+      _simpleConsumer = null;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionProvider.java
@@ -126,7 +126,6 @@ public class KafkaConnectionProvider {
         Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(bootstrapNodes));
 
     final int bootstrapHostCount = hostsAndPorts.size();
-
     if (bootstrapHostCount < 1) {
       throw new IllegalArgumentException("Need at least one bootstrap host");
     }
@@ -136,19 +135,18 @@ public class KafkaConnectionProvider {
 
     for (int i = 0; i < bootstrapHostCount; i++) {
       String hostAndPort = hostsAndPorts.get(i);
-      String[] splittedHostAndPort = hostAndPort.split(":");
-
-      if (splittedHostAndPort.length != 2) {
+      String[] splitHostAndPort = hostAndPort.split(":");
+      if (splitHostAndPort.length != 2) {
         throw new IllegalArgumentException("Unable to parse host:port combination for " + hostAndPort);
       }
 
-      _bootstrapHosts[i] = splittedHostAndPort[0];
+      _bootstrapHosts[i] = splitHostAndPort[0];
 
       try {
-        _bootstrapPorts[i] = Integer.parseInt(splittedHostAndPort[1]);
+        _bootstrapPorts[i] = Integer.parseInt(splitHostAndPort[1]);
       } catch (NumberFormatException e) {
         throw new IllegalArgumentException(
-            "Could not parse port number " + splittedHostAndPort[1] + " for host:port combination " + hostAndPort);
+            "Could not parse port number " + splitHostAndPort[1] + " for host:port combination " + hostAndPort);
       }
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Wrapper for Kafka's SimpleConsumer which ensures that we're connected to the appropriate broker for consumption.
  */
-public class SimpleConsumerWrapper extends KafkaConnectionProvider implements PinotStreamConsumer {
+public class SimpleConsumerWrapper extends KafkaConnectionHandler implements PinotStreamConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleConsumerWrapper.class);
 
   public SimpleConsumerWrapper(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
@@ -136,11 +136,11 @@ public class SimpleConsumerWrapper extends KafkaConnectionProvider implements Pi
     // TODO Improve error handling
 
     final long connectEndTime = System.currentTimeMillis() + _connectTimeoutMillis;
-    while(_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+    while(_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
         System.currentTimeMillis() < connectEndTime) {
       _currentState.process();
     }
-    if (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+    if (_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
         connectEndTime <= System.currentTimeMillis()) {
       throw new java.util.concurrent.TimeoutException();
     }
@@ -193,12 +193,12 @@ public class SimpleConsumerWrapper extends KafkaConnectionProvider implements Pi
 
     while(System.currentTimeMillis() < endTime) {
       // Try to get into a state where we're connected to Kafka
-      while (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+      while (_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
           System.currentTimeMillis() < endTime) {
         _currentState.process();
       }
 
-      if (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+      if (_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
           endTime <= System.currentTimeMillis()) {
         throw new TimeoutException();
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
@@ -17,19 +17,12 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.core.realtime.stream.MessageBatch;
-import com.linkedin.pinot.core.realtime.stream.PermanentConsumerException;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
-import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import kafka.api.FetchRequestBuilder;
@@ -38,11 +31,9 @@ import kafka.common.TopicAndPartition;
 import kafka.javaapi.FetchResponse;
 import kafka.javaapi.OffsetRequest;
 import kafka.javaapi.OffsetResponse;
-import kafka.javaapi.PartitionMetadata;
 import kafka.javaapi.TopicMetadata;
 import kafka.javaapi.TopicMetadataRequest;
 import kafka.javaapi.TopicMetadataResponse;
-import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -54,313 +45,17 @@ import org.slf4j.LoggerFactory;
 /**
  * Wrapper for Kafka's SimpleConsumer which ensures that we're connected to the appropriate broker for consumption.
  */
-public class SimpleConsumerWrapper implements PinotStreamConsumer {
+public class SimpleConsumerWrapper extends KafkaConnectionProvider implements PinotStreamConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleConsumerWrapper.class);
-  private static final int SOCKET_TIMEOUT_MILLIS = 10000;
-  private static final int SOCKET_BUFFER_SIZE = 512000;
 
-  private enum ConsumerState {
-    CONNECTING_TO_BOOTSTRAP_NODE,
-    CONNECTED_TO_BOOTSTRAP_NODE,
-    FETCHING_LEADER_INFORMATION,
-    CONNECTING_TO_PARTITION_LEADER,
-    CONNECTED_TO_PARTITION_LEADER
-  }
-
-  private State _currentState;
-
-  private final String _clientId;
-  private final boolean _metadataOnlyConsumer;
-  private final String _topic;
-  private final int _partition;
-  private final long _connectTimeoutMillis;
-  private final KafkaSimpleConsumerFactory _simpleConsumerFactory;
-  private String[] _bootstrapHosts;
-  private int[] _bootstrapPorts;
-  private SimpleConsumer _simpleConsumer;
-  private final Random _random = new Random();
-  private KafkaBrokerWrapper _leader;
-  private String _currentHost;
-  private int _currentPort;
-
-  /**
-   * A Kafka protocol error that indicates a situation that is not likely to clear up by retrying the request (for
-   * example, no such topic or offset out of range).
-   */
-  private class KafkaPermanentConsumerException extends RuntimeException {
-    public KafkaPermanentConsumerException(Errors error) {
-      super(error.exception());
-    }
-  }
-
-  /**
-   * A Kafka protocol error that indicates a situation that is likely to be transient (for example, network error or
-   * broker not available).
-   */
-  private class KafkaTransientConsumerException extends RuntimeException {
-    public KafkaTransientConsumerException(Errors error) {
-      super(error.exception());
-    }
-  }
   public SimpleConsumerWrapper(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
       String clientId, long connectTimeoutMillis) {
-    _simpleConsumerFactory = simpleConsumerFactory;
-    _clientId = clientId;
-    _connectTimeoutMillis = connectTimeoutMillis;
-    _metadataOnlyConsumer = true;
-    _simpleConsumer = null;
-
-    // Topic and partition are ignored for metadata-only consumers
-    _topic = null;
-    _partition = Integer.MIN_VALUE;
-
-    initializeBootstrapNodeList(bootstrapNodes);
-    setCurrentState(new ConnectingToBootstrapNode());
+    super(simpleConsumerFactory, bootstrapNodes, clientId, connectTimeoutMillis);
   }
 
   public SimpleConsumerWrapper(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
       String clientId, String topic, int partition, long connectTimeoutMillis) {
-    _simpleConsumerFactory = simpleConsumerFactory;
-    _clientId = clientId;
-    _topic = topic;
-    _partition = partition;
-    _connectTimeoutMillis = connectTimeoutMillis;
-    _metadataOnlyConsumer = false;
-    _simpleConsumer = null;
-
-    initializeBootstrapNodeList(bootstrapNodes);
-    setCurrentState(new ConnectingToBootstrapNode());
-  }
-
-  private void initializeBootstrapNodeList(String bootstrapNodes) {
-    ArrayList<String> hostsAndPorts =
-        Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(bootstrapNodes));
-
-    final int bootstrapHostCount = hostsAndPorts.size();
-
-    if (bootstrapHostCount < 1) {
-      throw new IllegalArgumentException("Need at least one bootstrap host");
-    }
-
-    _bootstrapHosts = new String[bootstrapHostCount];
-    _bootstrapPorts = new int[bootstrapHostCount];
-
-    for (int i = 0; i < bootstrapHostCount; i++) {
-      String hostAndPort = hostsAndPorts.get(i);
-      String[] splittedHostAndPort = hostAndPort.split(":");
-
-      if (splittedHostAndPort.length != 2) {
-        throw new IllegalArgumentException("Unable to parse host:port combination for " + hostAndPort);
-      }
-
-      _bootstrapHosts[i] = splittedHostAndPort[0];
-
-      try {
-        _bootstrapPorts[i] = Integer.parseInt(splittedHostAndPort[1]);
-      } catch (NumberFormatException e) {
-        throw new IllegalArgumentException("Could not parse port number " + splittedHostAndPort[1] + " for host:port combination " +  hostAndPort);
-      }
-    }
-  }
-
-  private abstract class State {
-    private ConsumerState stateValue;
-
-    protected State(ConsumerState stateValue) {
-      this.stateValue = stateValue;
-    }
-
-    abstract void process();
-
-    abstract boolean isConnectedToKafkaBroker();
-
-    void handleConsumerException(Exception e) {
-      // By default, just log the exception and switch back to CONNECTING_TO_BOOTSTRAP_NODE (which will take care of
-      // closing the connection if it exists)
-      LOGGER.warn("Caught Kafka consumer exception while in state {}, disconnecting and trying again for topic {}",
-          _currentState.getStateValue(), _topic, e);
-
-      Uninterruptibles.sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
-
-      setCurrentState(new ConnectingToBootstrapNode());
-    }
-
-    ConsumerState getStateValue() {
-      return stateValue;
-    }
-  }
-
-  private class ConnectingToBootstrapNode extends State {
-    public ConnectingToBootstrapNode() {
-      super(ConsumerState.CONNECTING_TO_BOOTSTRAP_NODE);
-    }
-
-    @Override
-    public void process() {
-      // Connect to a random bootstrap node
-      if (_simpleConsumer != null) {
-        try {
-          _simpleConsumer.close();
-        } catch (Exception e) {
-          LOGGER.warn("Caught exception while closing consumer for topic {}, ignoring", _topic, e);
-        }
-      }
-
-      int randomHostIndex = _random.nextInt(_bootstrapHosts.length);
-      _currentHost = _bootstrapHosts[randomHostIndex];
-      _currentPort = _bootstrapPorts[randomHostIndex];
-
-      try {
-        LOGGER.info("Connecting to bootstrap host {}:{} for topic {}", _currentHost, _currentPort, _topic);
-        _simpleConsumer = _simpleConsumerFactory.buildSimpleConsumer(_currentHost, _currentPort, SOCKET_TIMEOUT_MILLIS,
-            SOCKET_BUFFER_SIZE, _clientId);
-        setCurrentState(new ConnectedToBootstrapNode());
-      } catch (Exception e) {
-        handleConsumerException(e);
-      }
-    }
-
-    @Override
-    boolean isConnectedToKafkaBroker() {
-      return false;
-    }
-  }
-
-  private class ConnectedToBootstrapNode extends State {
-    protected ConnectedToBootstrapNode() {
-      super(ConsumerState.CONNECTED_TO_BOOTSTRAP_NODE);
-    }
-
-    @Override
-    void process() {
-      if (_metadataOnlyConsumer) {
-        // Nothing to do
-      } else {
-        // If we're consuming from a partition, we need to find the leader so that we can consume from it. By design,
-        // Kafka only allows consumption from the leader and not one of the in-sync replicas.
-        setCurrentState(new FetchingLeaderInformation());
-      }
-    }
-
-    @Override
-    boolean isConnectedToKafkaBroker() {
-      return true;
-    }
-  }
-
-  private class FetchingLeaderInformation extends State {
-    public FetchingLeaderInformation() {
-      super(ConsumerState.FETCHING_LEADER_INFORMATION);
-    }
-
-    @Override
-    void process() {
-      // Fetch leader information
-      try {
-        TopicMetadataResponse response = _simpleConsumer.send(new TopicMetadataRequest(Collections.singletonList(_topic)));
-        try {
-          _leader = null;
-          List<PartitionMetadata> pMetaList = response.topicsMetadata().get(0).partitionsMetadata();
-          for (PartitionMetadata pMeta : pMetaList) {
-            if (pMeta.partitionId() == _partition) {
-              _leader = new KafkaBrokerWrapper(pMeta.leader());
-              break;
-            }
-          }
-
-          // If we've located a broker
-          if (_leader != null) {
-            LOGGER.info("Located leader broker {} for topic {}, connecting to it.", _leader, _topic);
-            setCurrentState(new ConnectingToPartitionLeader());
-          } else {
-            // Failed to get the leader broker. There could be a leader election at the moment, so retry after a little
-            // bit.
-            LOGGER.warn("Leader broker is null for topic {}, retrying leader fetch in 100ms", _topic);
-            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-          }
-        } catch (Exception e) {
-          // Failed to get the leader broker. There could be a leader election at the moment, so retry after a little
-          // bit.
-          LOGGER.warn("Failed to get the leader broker for topic {} due to exception, retrying in 100ms", _topic, e);
-          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-        }
-      } catch (Exception e) {
-        handleConsumerException(e);
-      }
-    }
-
-    @Override
-    boolean isConnectedToKafkaBroker() {
-      return true;
-    }
-  }
-
-  private class ConnectingToPartitionLeader extends State {
-    public ConnectingToPartitionLeader() {
-      super(ConsumerState.CONNECTING_TO_PARTITION_LEADER);
-    }
-
-    @Override
-    void process() {
-      // If we're already connected to the leader broker, don't disconnect and reconnect
-      LOGGER.info("Trying to fetch leader host and port: {}:{} for topic {}", _leader.host(), _leader.port(), _topic);
-      if (_leader.host().equals(_currentHost) && _leader.port() == _currentPort) {
-        setCurrentState(new ConnectedToPartitionLeader());
-        return;
-      }
-
-      // Disconnect from current broker
-      if(_simpleConsumer != null) {
-        try {
-          _simpleConsumer.close();
-          _simpleConsumer = null;
-        } catch (Exception e) {
-          handleConsumerException(e);
-          return;
-        }
-      }
-
-      // Connect to the partition leader
-      try {
-        _simpleConsumer =
-            _simpleConsumerFactory.buildSimpleConsumer(_leader.host(), _leader.port(), SOCKET_TIMEOUT_MILLIS,
-                SOCKET_BUFFER_SIZE, _clientId);
-
-        setCurrentState(new ConnectedToPartitionLeader());
-      } catch (Exception e) {
-        handleConsumerException(e);
-      }
-    }
-
-    @Override
-    boolean isConnectedToKafkaBroker() {
-      return false;
-    }
-  }
-
-  private class ConnectedToPartitionLeader extends State {
-    public ConnectedToPartitionLeader() {
-      super(ConsumerState.CONNECTED_TO_PARTITION_LEADER);
-    }
-
-    @Override
-    void process() {
-      // Nothing to do
-    }
-
-    @Override
-    boolean isConnectedToKafkaBroker() {
-      return true;
-    }
-  }
-
-  private void setCurrentState(State newState) {
-    if (_currentState != null) {
-      LOGGER.info("Switching from state {} to state {} for topic {}",
-          _currentState.getStateValue(), newState.getStateValue(), _topic);
-    }
-
-    _currentState = newState;
+    super(simpleConsumerFactory, bootstrapNodes, clientId, topic, partition, connectTimeoutMillis);
   }
 
   public synchronized int getPartitionCount(String topic, long timeoutMillis) {
@@ -441,11 +136,11 @@ public class SimpleConsumerWrapper implements PinotStreamConsumer {
     // TODO Improve error handling
 
     final long connectEndTime = System.currentTimeMillis() + _connectTimeoutMillis;
-    while(_currentState.getStateValue() != ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+    while(_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
         System.currentTimeMillis() < connectEndTime) {
       _currentState.process();
     }
-    if (_currentState.getStateValue() != ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+    if (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
         connectEndTime <= System.currentTimeMillis()) {
       throw new java.util.concurrent.TimeoutException();
     }
@@ -464,48 +159,6 @@ public class SimpleConsumerWrapper implements PinotStreamConsumer {
       return new SimpleConsumerMessageBatch(messageAndOffsetIterable);
     } else {
       throw exceptionForKafkaErrorCode(fetchResponse.errorCode(_topic, _partition));
-    }
-  }
-
-  private RuntimeException exceptionForKafkaErrorCode(short kafkaErrorCode) {
-    final Errors kafkaError = Errors.forCode(kafkaErrorCode);
-    switch (kafkaError) {
-      case UNKNOWN:
-      case OFFSET_OUT_OF_RANGE:
-      case CORRUPT_MESSAGE:
-      case MESSAGE_TOO_LARGE:
-      case OFFSET_METADATA_TOO_LARGE:
-      case INVALID_TOPIC_EXCEPTION:
-      case RECORD_LIST_TOO_LARGE:
-      case INVALID_REQUIRED_ACKS:
-      case ILLEGAL_GENERATION:
-      case INCONSISTENT_GROUP_PROTOCOL:
-      case INVALID_GROUP_ID:
-      case UNKNOWN_MEMBER_ID:
-      case INVALID_SESSION_TIMEOUT:
-      case INVALID_COMMIT_OFFSET_SIZE:
-        return new PermanentConsumerException(new KafkaPermanentConsumerException(kafkaError));
-      case UNKNOWN_TOPIC_OR_PARTITION:
-      case LEADER_NOT_AVAILABLE:
-      case NOT_LEADER_FOR_PARTITION:
-      case REQUEST_TIMED_OUT:
-      case BROKER_NOT_AVAILABLE:
-      case REPLICA_NOT_AVAILABLE:
-      case STALE_CONTROLLER_EPOCH:
-      case NETWORK_EXCEPTION:
-      case GROUP_LOAD_IN_PROGRESS:
-      case GROUP_COORDINATOR_NOT_AVAILABLE:
-      case NOT_COORDINATOR_FOR_GROUP:
-      case NOT_ENOUGH_REPLICAS:
-      case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
-      case REBALANCE_IN_PROGRESS:
-      case TOPIC_AUTHORIZATION_FAILED:
-      case GROUP_AUTHORIZATION_FAILED:
-      case CLUSTER_AUTHORIZATION_FAILED:
-        return new TransientConsumerException(new KafkaTransientConsumerException(kafkaError));
-      case NONE:
-      default:
-        return new RuntimeException("Unhandled error " + kafkaError);
     }
   }
 
@@ -540,12 +193,12 @@ public class SimpleConsumerWrapper implements PinotStreamConsumer {
 
     while(System.currentTimeMillis() < endTime) {
       // Try to get into a state where we're connected to Kafka
-      while (_currentState.getStateValue() != ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+      while (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
           System.currentTimeMillis() < endTime) {
         _currentState.process();
       }
 
-      if (_currentState.getStateValue() != ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
+      if (_currentState.getStateValue() != KafkaConnectionProvider.ConsumerState.CONNECTED_TO_PARTITION_LEADER &&
           endTime <= System.currentTimeMillis()) {
         throw new TimeoutException();
       }
@@ -614,15 +267,6 @@ public class SimpleConsumerWrapper implements PinotStreamConsumer {
    * Closes this consumer.
    */
   public void close() throws IOException {
-    boolean needToCloseConsumer = _currentState.isConnectedToKafkaBroker() && _simpleConsumer != null;
-
-    // Reset the state machine
-    setCurrentState(new ConnectingToBootstrapNode());
-
-    // Close the consumer if needed
-    if (needToCloseConsumer) {
-      _simpleConsumer.close();
-      _simpleConsumer = null;
-    }
+    super.close();
   }
 }


### PR DESCRIPTION
We plan to separate the StreamMetadataProvider and StreamConsumer. In order to achieve that, we would be extracting out SimpleMetadataProvider from SimpleConsumerWrapper. 
This change attempts to take out the code related to kafka connection that would be shared across the two SimpleWrappers, into a common class