### PR TITLE
[PINOT-6736] Fix min size for hash-set in In/NotIn predicate impl

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/HashUtil.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/HashUtil.java
@@ -20,6 +20,22 @@ import java.nio.IntBuffer;
 
 
 public class HashUtil {
+
+  /** Tests show that even for smaller set sizes, setting the hash size to this min value
+   * improves performance at an insignificant increase of memory footprint.
+   */
+  public static int MIN_FASTUTIL_HASHSET_SIZE = 25;
+
+  /**
+   * Returns the min size for the fast-util hash-set given the expected size of
+   * values stored in the hash-set.
+   * @param expected the expected/actual number of values to be stored
+   * @return the optimal min value
+   */
+  public static int getMinHashSetSize(int expected) {
+    return Math.min(MIN_FASTUTIL_HASHSET_SIZE, expected);
+  }
+
   public static long compute(IntBuffer buff) {
     buff.rewind();
     ByteBuffer bBuff = ByteBuffer.allocate(buff.array().length * 4);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.filter.predicate;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.HashUtil;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.common.predicate.InPredicate;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
@@ -82,7 +83,7 @@ public class InPredicateEvaluatorFactory {
 
     DictionaryBasedInPredicateEvaluator(InPredicate inPredicate, Dictionary dictionary) {
       String[] values = inPredicate.getValues();
-      _matchingDictIdSet = new IntOpenHashSet();
+      _matchingDictIdSet = new IntOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         int dictId = dictionary.indexOf(value);
         if (dictId >= 0) {
@@ -120,7 +121,7 @@ public class InPredicateEvaluatorFactory {
 
     IntRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
       String[] values = inPredicate.getValues();
-      _matchingValues = new IntOpenHashSet(values.length);
+      _matchingValues = new IntOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _matchingValues.add(Integer.parseInt(value));
       }
@@ -142,7 +143,7 @@ public class InPredicateEvaluatorFactory {
 
     LongRawValueBasedInPredicateEvaluator(InPredicate predicate) {
       String[] values = predicate.getValues();
-      _matchingValues = new LongOpenHashSet(values.length);
+      _matchingValues = new LongOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _matchingValues.add(Long.parseLong(value));
       }
@@ -164,7 +165,7 @@ public class InPredicateEvaluatorFactory {
 
     FloatRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
       String[] values = inPredicate.getValues();
-      _matchingValues = new FloatOpenHashSet(values.length);
+      _matchingValues = new FloatOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _matchingValues.add(Float.parseFloat(value));
       }
@@ -186,7 +187,7 @@ public class InPredicateEvaluatorFactory {
 
     DoubleRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
       String[] values = inPredicate.getValues();
-      _matchingValues = new DoubleOpenHashSet(values.length);
+      _matchingValues = new DoubleOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _matchingValues.add(Double.parseDouble(value));
       }
@@ -208,7 +209,7 @@ public class InPredicateEvaluatorFactory {
 
     StringRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
       String[] values = inPredicate.getValues();
-      _matchingValues = new HashSet<>(values.length);
+      _matchingValues = new HashSet<>(HashUtil.getMinHashSetSize(values.length));
       Collections.addAll(_matchingValues, values);
     }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.filter.predicate;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.HashUtil;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.common.predicate.NotInPredicate;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
@@ -84,7 +85,7 @@ public class NotInPredicateEvaluatorFactory {
 
     DictionaryBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Dictionary dictionary) {
       String[] values = notInPredicate.getValues();
-      _nonMatchingDictIdSet = new IntOpenHashSet(values.length);
+      _nonMatchingDictIdSet = new IntOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         int dictId = dictionary.indexOf(value);
         if (dictId >= 0) {
@@ -138,7 +139,7 @@ public class NotInPredicateEvaluatorFactory {
 
     IntRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
       String[] values = notInPredicate.getValues();
-      _nonMatchingValues = new IntOpenHashSet(values.length);
+      _nonMatchingValues = new IntOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _nonMatchingValues.add(Integer.parseInt(value));
       }
@@ -182,7 +183,7 @@ public class NotInPredicateEvaluatorFactory {
 
     FloatRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
       String[] values = notInPredicate.getValues();
-      _nonMatchingValues = new FloatOpenHashSet(values.length);
+      _nonMatchingValues = new FloatOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _nonMatchingValues.add(Float.parseFloat(value));
       }
@@ -204,7 +205,7 @@ public class NotInPredicateEvaluatorFactory {
 
     DoubleRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
       String[] values = notInPredicate.getValues();
-      _nonMatchingValues = new DoubleOpenHashSet(values.length);
+      _nonMatchingValues = new DoubleOpenHashSet(HashUtil.getMinHashSetSize(values.length));
       for (String value : values) {
         _nonMatchingValues.add(Double.parseDouble(value));
       }
@@ -226,7 +227,7 @@ public class NotInPredicateEvaluatorFactory {
 
     StringRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
       String[] values = notInPredicate.getValues();
-      _nonMatchingValues = new HashSet<>(values.length);
+      _nonMatchingValues = new HashSet<>(HashUtil.getMinHashSetSize(values.length));
       Collections.addAll(_nonMatchingValues, values);
     }
 


### PR DESCRIPTION
In/NotIn predicate implementations typically use small hash sets. Profiling shows non-trivial amount of time spent in hash-set contains() calls. Testing showed that fixing a min hash set size improves the performance at little extra memory overhead. for one of the queries we see in production which averages about 580ms, this change reduced the latency down to 430ms.