### PR TITLE
Verify table type when deleting table

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -238,6 +238,17 @@ public class PinotTableRestletResource {
   public SuccessResponse deleteTable(
       @ApiParam(value = "Name of the table to delete", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "realtime|offline", required = false) @QueryParam("type") String tableTypeStr) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    if (tableType != null) {
+      if (tableTypeStr == null) {
+        tableTypeStr = tableType.name();
+      } else if (!tableTypeStr.equalsIgnoreCase(tableType.name())) {
+        String message =
+            String.format("Table types don't match! Table name: %s, Input table type: %s", tableName, tableTypeStr);
+        throw new ControllerApplicationException(LOGGER, message, Response.Status.BAD_REQUEST);
+      }
+    }
+
     List<String> tablesDeleted = new LinkedList<>();
     try {
       if (tableTypeStr == null || tableTypeStr.equalsIgnoreCase(CommonConstants.Helix.TableType.OFFLINE.name())) {


### PR DESCRIPTION
Since the param `tableName` may contain table type as suffix, this PR adds logic to check whether this case exists. 
++++++++
Use case 1:
tableName: TestTable, tableTypeStr: null
Both `deleteOfflineTable` and `deleteRealtimeTable ` will be called.

Use case 2:
tableName: TestTable_OFFLINE, tableTypeStr: null
Only `deleteOfflineTable` will be called.

Use case 3:
tableName: TestTable_OFFLINE, tableTypeStr: OFFLINE
Only `deleteOfflineTable` will be called.

Use case 4:
tableName: TestTable_OFFLINE, tableTypeStr: REALTIME
Throws 400 exception.

Use case 5:
tableName: TestTable, tableTypeStr: OFFLINE
Only `deleteOfflineTable` will be called.