### PR TITLE
Add StreamMetadataProvider interface and SimpleStreamMetadataProvider implementation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -26,7 +26,7 @@ import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
-import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
+import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import java.util.List;
@@ -233,8 +233,9 @@ public class PinotTableIdealStateBuilder {
         throw new RuntimeException("Invalid value for " + Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST + ":'"
             + bootstrapHosts + "'");
       }
-      PinotStreamConsumerFactory pinotStreamConsumerFactory = PinotStreamConsumerFactory.create(_streamMetadata);
-      PinotStreamConsumer consumerWrapper = pinotStreamConsumerFactory.buildMetadataFetcher(
+      StreamConsumerFactory streamConsumerFactory = StreamConsumerFactory.create(_streamMetadata);
+      streamConsumerFactory.init(_streamMetadata);
+      PinotStreamConsumer consumerWrapper = streamConsumerFactory.buildMetadataFetcher(
           PinotTableIdealStateBuilder.class.getSimpleName() + "-" + kafkaTopicName, _streamMetadata);
       try {
         _partitionCount = consumerWrapper.getPartitionCount(kafkaTopicName, /*maxWaitTimeMs=*/5000L);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -54,7 +54,7 @@ import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.realtime.segment.ConsumingSegmentAssignmentStrategy;
 import com.linkedin.pinot.core.realtime.segment.RealtimeSegmentAssignmentStrategy;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
-import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
+import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -1325,14 +1325,15 @@ public class PinotLLCRealtimeSegmentManager {
 
     private Exception _exception = null;
     private long _offset = -1;
-    private PinotStreamConsumerFactory _pinotStreamConsumerFactory;
+    private StreamConsumerFactory _streamConsumerFactory;
     StreamMetadata _streamMetadata;
 
 
     private KafkaOffsetFetcher(final String offsetCriteria, int partitionId, StreamMetadata streamMetadata) {
       _offsetCriteria = offsetCriteria;
       _partitionId = partitionId;
-      _pinotStreamConsumerFactory = PinotStreamConsumerFactory.create(streamMetadata);
+      _streamConsumerFactory = StreamConsumerFactory.create(streamMetadata);
+      _streamConsumerFactory.init(streamMetadata);
       _streamMetadata = streamMetadata;
       _topicName = streamMetadata.getKafkaTopicName();
     }
@@ -1349,7 +1350,7 @@ public class PinotLLCRealtimeSegmentManager {
     public Boolean call() throws Exception {
 
       PinotStreamConsumer
-          streamConsumer = _pinotStreamConsumerFactory.buildConsumer("dummyClientId", _partitionId, _streamMetadata);
+          streamConsumer = _streamConsumerFactory.buildConsumer("dummyClientId", _partitionId, _streamMetadata);
       try {
         _offset = streamConsumer.fetchPartitionOffset(_offsetCriteria, STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
         if (_exception != null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -48,7 +48,7 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderCo
 import com.linkedin.pinot.core.realtime.stream.MessageBatch;
 import com.linkedin.pinot.core.realtime.stream.PermanentConsumerException;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
-import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
+import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamMessageDecoder;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
@@ -199,7 +199,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final SegmentVersion _segmentVersion;
   private final SegmentBuildTimeLeaseExtender _leaseExtender;
   private SegmentBuildDescriptor _segmentBuildDescriptor;
-  private PinotStreamConsumerFactory _pinotStreamConsumerFactory;
+  private StreamConsumerFactory _streamConsumerFactory;
 
   // Segment end criteria
   private volatile long _consumeEndTime = 0;
@@ -981,7 +981,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
     _streamMetadata = new StreamMetadata(indexingConfig.getStreamConfigs());
-    _pinotStreamConsumerFactory = PinotStreamConsumerFactory.create(_streamMetadata);
+    _streamConsumerFactory = StreamConsumerFactory.create(_streamMetadata);
+    _streamConsumerFactory.init(_streamMetadata);
     KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig = createStreamProviderConfig();
     kafkaStreamProviderConfig.init(tableConfig, instanceZKMetadata, schema);
     _streamBootstrapNodes = indexingConfig.getStreamConfigs()
@@ -1061,7 +1062,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setAggregateMetrics(indexingConfig.getAggregateMetrics());
 
     // Create message decoder
-    _messageDecoder = _pinotStreamConsumerFactory.getDecoder(kafkaStreamProviderConfig);
+    _messageDecoder = _streamConsumerFactory.getDecoder(kafkaStreamProviderConfig);
     _clientId = _streamPartitionId + "-" + NetUtil.getHostnameOrAddress();
 
     // Create field extractor
@@ -1136,7 +1137,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       }
     }
     segmentLogger.info("Creating new stream consumer wrapper, reason: {}", reason);
-    _consumerWrapper = _pinotStreamConsumerFactory.buildConsumer(_clientId, _streamPartitionId, _streamMetadata);
+    _consumerWrapper = _streamConsumerFactory.buildConsumer(_clientId, _streamPartitionId, _streamMetadata);
   }
 
   // This should be done during commit? We may not always commit when we build a segment....

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -91,6 +91,7 @@ public class KafkaConnectionHandler {
     }
   }
 
+  // TODO: change this constructor to accept only streamMetadata (and partition) after we have refactored SimpleConsumer
   public KafkaConnectionHandler(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
       String clientId, String topic, long connectTimeoutMillis) {
     _simpleConsumerFactory = simpleConsumerFactory;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaSimpleStreamMetadataProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaSimpleStreamMetadataProvider.java
@@ -15,21 +15,10 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-import kafka.api.PartitionOffsetRequestInfo;
-import kafka.common.TopicAndPartition;
-import kafka.javaapi.OffsetRequest;
-import kafka.javaapi.OffsetResponse;
-import kafka.javaapi.TopicMetadata;
-import kafka.javaapi.TopicMetadataRequest;
-import kafka.javaapi.TopicMetadataResponse;
-import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,78 +29,23 @@ import org.slf4j.LoggerFactory;
 public class KafkaSimpleStreamMetadataProvider extends KafkaConnectionHandler implements StreamMetadataProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSimpleStreamMetadataProvider.class);
 
-  public KafkaSimpleStreamMetadataProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
-      String clientId, String topic, int partition, long connectTimeoutMillis) {
-    super(simpleConsumerFactory, bootstrapNodes, clientId, topic, partition, connectTimeoutMillis);
+  public KafkaSimpleStreamMetadataProvider(StreamMetadata streamMetadata, int partition) {
+    super(new KafkaSimpleConsumerFactoryImpl(), streamMetadata.getBootstrapHosts(),
+        partition + "-" + NetUtil.getHostnameOrAddress(), streamMetadata.getKafkaTopicName(), partition,
+        streamMetadata.getKafkaConnectionTimeoutMillis());
   }
 
-  public KafkaSimpleStreamMetadataProvider(KafkaSimpleConsumerFactory simpleConsumerFactory, String bootstrapNodes,
-      String clientId, String topic, long connectTimeoutMillis) {
-    super(simpleConsumerFactory, bootstrapNodes, clientId, topic, connectTimeoutMillis);
+  public KafkaSimpleStreamMetadataProvider(StreamMetadata streamMetadata) {
+    super(new KafkaSimpleConsumerFactoryImpl(), streamMetadata.getBootstrapHosts(),
+        KafkaSimpleStreamMetadataProvider.class.getName() + "-" + streamMetadata.getKafkaTopicName(),
+        streamMetadata.getKafkaTopicName(), streamMetadata.getKafkaConnectionTimeoutMillis());
   }
 
   // TODO: this will replace metadata related methods called from SimpleConsumerWrapper
   // TODO: make sure this code is equivalent to the methods in SimpleConsumerWrapper before starting to use this
   @Override
   public synchronized int fetchPartitionCount(String topic, long timeoutMillis) {
-    int unknownTopicReplyCount = 0;
-    final int MAX_UNKNOWN_TOPIC_REPLY_COUNT = 10;
-    int kafkaErrorCount = 0;
-    final int MAX_KAFKA_ERROR_COUNT = 10;
-
-    final long endTime = System.currentTimeMillis() + timeoutMillis;
-
-    while (System.currentTimeMillis() < endTime) {
-      // Try to get into a state where we're connected to Kafka
-      while (!_currentState.isConnectedToKafkaBroker() && System.currentTimeMillis() < endTime) {
-        _currentState.process();
-      }
-
-      if (endTime <= System.currentTimeMillis() && !_currentState.isConnectedToKafkaBroker()) {
-        throw new TimeoutException(
-            "Failed to get the partition count for topic " + topic + " within " + timeoutMillis + " ms");
-      }
-
-      // Send the metadata request to Kafka
-      TopicMetadataResponse topicMetadataResponse = null;
-      try {
-        topicMetadataResponse = _simpleConsumer.send(new TopicMetadataRequest(Collections.singletonList(topic)));
-      } catch (Exception e) {
-        _currentState.handleConsumerException(e);
-        continue;
-      }
-
-      final TopicMetadata topicMetadata = topicMetadataResponse.topicsMetadata().get(0);
-      final short errorCode = topicMetadata.errorCode();
-
-      if (errorCode == Errors.NONE.code()) {
-        return topicMetadata.partitionsMetadata().size();
-      } else if (errorCode == Errors.LEADER_NOT_AVAILABLE.code()) {
-        // If there is no leader, it'll take some time for a new leader to be elected, wait 100 ms before retrying
-        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-      } else if (errorCode == Errors.INVALID_TOPIC_EXCEPTION.code()) {
-        throw new RuntimeException("Invalid topic name " + topic);
-      } else if (errorCode == Errors.UNKNOWN_TOPIC_OR_PARTITION.code()) {
-        if (MAX_UNKNOWN_TOPIC_REPLY_COUNT < unknownTopicReplyCount) {
-          throw new RuntimeException("Topic " + topic + " does not exist");
-        } else {
-          // Kafka topic creation can sometimes take some time, so we'll retry after a little bit
-          unknownTopicReplyCount++;
-          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-        }
-      } else {
-        // Retry after a short delay
-        kafkaErrorCount++;
-
-        if (MAX_KAFKA_ERROR_COUNT < kafkaErrorCount) {
-          throw exceptionForKafkaErrorCode(errorCode);
-        }
-
-        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-      }
-    }
-
-    throw new TimeoutException();
+    throw new UnsupportedOperationException();
   }
 
   /**
@@ -126,74 +60,7 @@ public class KafkaSimpleStreamMetadataProvider extends KafkaConnectionHandler im
   @Override
   public synchronized long fetchPartitionOffset(String requestedOffset, int timeoutMillis)
       throws java.util.concurrent.TimeoutException {
-    Preconditions.checkState(_isPartitionMetadata,
-        "Cannot fetch messages from a non partition specific SimpleConsumerWrapper");
-    Preconditions.checkNotNull(requestedOffset);
-
-    final long offsetRequestTime;
-    if (requestedOffset.equalsIgnoreCase("largest")) {
-      offsetRequestTime = kafka.api.OffsetRequest.LatestTime();
-    } else if (requestedOffset.equalsIgnoreCase("smallest")) {
-      offsetRequestTime = kafka.api.OffsetRequest.EarliestTime();
-    } else if (requestedOffset.equalsIgnoreCase("testDummy")) {
-      return -1L;
-    } else {
-      throw new IllegalArgumentException("Unknown initial offset value " + requestedOffset);
-    }
-
-    int kafkaErrorCount = 0;
-    final int MAX_KAFKA_ERROR_COUNT = 10;
-
-    final long endTime = System.currentTimeMillis() + timeoutMillis;
-
-    while (System.currentTimeMillis() < endTime) {
-      // Try to get into a state where we're connected to Kafka
-      while (_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER
-          && System.currentTimeMillis() < endTime) {
-        _currentState.process();
-      }
-
-      if (_currentState.getStateValue() != KafkaConnectionHandler.ConsumerState.CONNECTED_TO_PARTITION_LEADER
-          && endTime <= System.currentTimeMillis()) {
-        throw new TimeoutException();
-      }
-
-      // Send the offset request to Kafka
-      OffsetRequest request = new OffsetRequest(Collections.singletonMap(new TopicAndPartition(_topic, _partition),
-          new PartitionOffsetRequestInfo(offsetRequestTime, 1)), kafka.api.OffsetRequest.CurrentVersion(), _clientId);
-      OffsetResponse offsetResponse;
-      try {
-        offsetResponse = _simpleConsumer.getOffsetsBefore(request);
-      } catch (Exception e) {
-        _currentState.handleConsumerException(e);
-        continue;
-      }
-
-      final short errorCode = offsetResponse.errorCode(_topic, _partition);
-
-      if (errorCode == Errors.NONE.code()) {
-        long offset = offsetResponse.offsets(_topic, _partition)[0];
-        if (offset == 0L) {
-          LOGGER.warn("Fetched offset of 0 for topic {} and partition {}, is this a newly created topic?", _topic,
-              _partition);
-        }
-        return offset;
-      } else if (errorCode == Errors.LEADER_NOT_AVAILABLE.code()) {
-        // If there is no leader, it'll take some time for a new leader to be elected, wait 100 ms before retrying
-        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-      } else {
-        // Retry after a short delay
-        kafkaErrorCount++;
-
-        if (MAX_KAFKA_ERROR_COUNT < kafkaErrorCount) {
-          throw exceptionForKafkaErrorCode(errorCode);
-        }
-
-        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-      }
-    }
-
-    throw new TimeoutException();
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -18,19 +18,38 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
 import javax.annotation.Nonnull;
 
 
 public class SimpleConsumerFactory extends PinotStreamConsumerFactory {
+  @Override
   public PinotStreamConsumer buildConsumer(String clientId, int partition, StreamMetadata streamMetadata) {
     KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
-    return new SimpleConsumerWrapper(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
-        clientId, streamMetadata.getKafkaTopicName(), partition, streamMetadata.getKafkaConnectionTimeoutMillis());
+    return new SimpleConsumerWrapper(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(), clientId,
+        streamMetadata.getKafkaTopicName(), partition, streamMetadata.getKafkaConnectionTimeoutMillis());
   }
 
+  @Override
   public PinotStreamConsumer buildMetadataFetcher(@Nonnull String clientId, StreamMetadata streamMetadata) {
     KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
-    return new SimpleConsumerWrapper(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
-        clientId, streamMetadata.getKafkaConnectionTimeoutMillis());
+    return new SimpleConsumerWrapper(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(), clientId,
+        streamMetadata.getKafkaTopicName(), streamMetadata.getKafkaConnectionTimeoutMillis());
+  }
+
+  @Override
+  public StreamMetadataProvider createPartitionMetadataProvider(@Nonnull String clientId, int partition,
+      StreamMetadata streamMetadata) {
+    KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
+    return new KafkaSimpleStreamMetadataProvider(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
+        clientId, streamMetadata.getKafkaTopicName(), partition,
+        streamMetadata.getKafkaConnectionTimeoutMillis());
+  }
+
+  @Override
+  public StreamMetadataProvider createStreamMetadataProvider(@Nonnull String clientId, StreamMetadata streamMetadata) {
+    KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
+    return new KafkaSimpleStreamMetadataProvider(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
+        clientId, streamMetadata.getKafkaTopicName(), streamMetadata.getKafkaConnectionTimeoutMillis());
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -23,6 +23,8 @@ import javax.annotation.Nonnull;
 
 
 public class SimpleConsumerFactory extends PinotStreamConsumerFactory {
+  // TODO: once we introduce init for this factory, the parameters of these methods will change
+
   @Override
   public PinotStreamConsumer buildConsumer(String clientId, int partition, StreamMetadata streamMetadata) {
     KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -15,15 +15,14 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
+import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
 import javax.annotation.Nonnull;
 
 
-public class SimpleConsumerFactory extends PinotStreamConsumerFactory {
-  // TODO: once we introduce init for this factory, the parameters of these methods will change
+public class SimpleConsumerFactory extends StreamConsumerFactory {
 
   @Override
   public PinotStreamConsumer buildConsumer(String clientId, int partition, StreamMetadata streamMetadata) {
@@ -40,18 +39,12 @@ public class SimpleConsumerFactory extends PinotStreamConsumerFactory {
   }
 
   @Override
-  public StreamMetadataProvider createPartitionMetadataProvider(@Nonnull String clientId, int partition,
-      StreamMetadata streamMetadata) {
-    KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
-    return new KafkaSimpleStreamMetadataProvider(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
-        clientId, streamMetadata.getKafkaTopicName(), partition,
-        streamMetadata.getKafkaConnectionTimeoutMillis());
+  public StreamMetadataProvider createPartitionMetadataProvider(int partition) {
+    return new KafkaSimpleStreamMetadataProvider(_streamMetadata, partition);
   }
 
   @Override
-  public StreamMetadataProvider createStreamMetadataProvider(@Nonnull String clientId, StreamMetadata streamMetadata) {
-    KafkaSimpleConsumerFactoryImpl kafkaSimpleConsumerFactory = new KafkaSimpleConsumerFactoryImpl();
-    return new KafkaSimpleStreamMetadataProvider(kafkaSimpleConsumerFactory, streamMetadata.getBootstrapHosts(),
-        clientId, streamMetadata.getKafkaTopicName(), streamMetadata.getKafkaConnectionTimeoutMillis());
+  public StreamMetadataProvider createStreamMetadataProvider() {
+    return new KafkaSimpleStreamMetadataProvider(_streamMetadata);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PinotStreamConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PinotStreamConsumerFactory.java
@@ -31,9 +31,33 @@ public abstract class PinotStreamConsumerFactory {
     return factory;
   }
 
-  public abstract PinotStreamConsumer buildConsumer(@Nonnull String clientId, int partition, StreamMetadata streamMetadata);
+  // TODO: introduce init which takes stream config, helix config and server config.
 
+  public abstract PinotStreamConsumer buildConsumer(@Nonnull String clientId, int partition,
+      StreamMetadata streamMetadata);
+
+  // TODO: start using createMetadataProvider instead of buildMetadataFetcher once StreamMetadataProvider impl is done
   public abstract PinotStreamConsumer buildMetadataFetcher(@Nonnull String clientId, StreamMetadata streamMetadata);
+
+  /**
+   * Creates a metadata provider which provides partition specific metadata
+   * @param clientId
+   * @param partition
+   * @param streamMetadata
+   * @return
+   */
+  // TODO: start using createMetadataProvider instead of buildMetadataFetcher once StreamMetadataProvider impl is done
+  public abstract StreamMetadataProvider createPartitionMetadataProvider(@Nonnull String clientId, int partition,
+      StreamMetadata streamMetadata);
+
+  /**
+   * Creates a metadata provider which provides stream specific metadata
+   * @param clientId
+   * @param streamMetadata
+   * @return
+   */
+  public abstract StreamMetadataProvider createStreamMetadataProvider(@Nonnull String clientId,
+      StreamMetadata streamMetadata);
 
   // TODO First split KafkaLowLevelStreamProviderConfig to be kafka agnostic and kafka-specific and then rename.
   public StreamMessageDecoder getDecoder(KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig) throws Exception {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
@@ -20,18 +20,22 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderCo
 import javax.annotation.Nonnull;
 
 
-public abstract class PinotStreamConsumerFactory {
-  public static PinotStreamConsumerFactory create(StreamMetadata streamMetadata) {
-    PinotStreamConsumerFactory factory = null;
+public abstract class StreamConsumerFactory {
+  protected StreamMetadata _streamMetadata;
+
+  public static StreamConsumerFactory create(StreamMetadata streamMetadata) {
+    StreamConsumerFactory factory = null;
     try {
-      factory = (PinotStreamConsumerFactory) Class.forName(streamMetadata.getConsumerFactoryName()).newInstance();
+      factory = (StreamConsumerFactory) Class.forName(streamMetadata.getConsumerFactoryName()).newInstance();
     } catch (Exception e) {
       Utils.rethrowException(e);
     }
     return factory;
   }
 
-  // TODO: introduce init which takes stream config, helix config and server config.
+  public void init(StreamMetadata streamMetadata) {
+    _streamMetadata = streamMetadata;
+  }
 
   public abstract PinotStreamConsumer buildConsumer(@Nonnull String clientId, int partition,
       StreamMetadata streamMetadata);
@@ -41,23 +45,16 @@ public abstract class PinotStreamConsumerFactory {
 
   /**
    * Creates a metadata provider which provides partition specific metadata
-   * @param clientId
    * @param partition
-   * @param streamMetadata
    * @return
    */
-  // TODO: start using createMetadataProvider instead of buildMetadataFetcher once StreamMetadataProvider impl is done
-  public abstract StreamMetadataProvider createPartitionMetadataProvider(@Nonnull String clientId, int partition,
-      StreamMetadata streamMetadata);
+  public abstract StreamMetadataProvider createPartitionMetadataProvider(int partition);
 
   /**
    * Creates a metadata provider which provides stream specific metadata
-   * @param clientId
-   * @param streamMetadata
    * @return
    */
-  public abstract StreamMetadataProvider createStreamMetadataProvider(@Nonnull String clientId,
-      StreamMetadata streamMetadata);
+  public abstract StreamMetadataProvider createStreamMetadataProvider();
 
   // TODO First split KafkaLowLevelStreamProviderConfig to be kafka agnostic and kafka-specific and then rename.
   public StreamMessageDecoder getDecoder(KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig) throws Exception {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamMetadataProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamMetadataProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.stream;
+
+import java.io.Closeable;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Interface for provider of stream metadata
+ */
+public interface StreamMetadataProvider extends Closeable {
+  /**
+   * Fetches the number of partitions for a topic given the stream configs
+   * @param  topic
+   * @param timeoutMillis
+   * @return
+   */
+  int fetchPartitionCount(String topic, long timeoutMillis);
+
+  /**
+   * Fetches the offset for a given partition and offset criteria
+   * @param requestedOffset
+   * @param timeoutMillis
+   * @return
+   * @throws java.util.concurrent.TimeoutException
+   */
+  long fetchPartitionOffset(@Nonnull String requestedOffset, int timeoutMillis)
+      throws java.util.concurrent.TimeoutException;
+
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/kafka/SimpleConsumerWrapperTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/kafka/SimpleConsumerWrapperTest.java
@@ -16,11 +16,8 @@
 package com.linkedin.pinot.core.realtime.kafka;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactory;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
-
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import kafka.api.FetchRequest;
@@ -41,12 +38,11 @@ import org.apache.kafka.common.protocol.Errors;
 import org.testng.annotations.Test;
 import scala.Some;
 import scala.Tuple2;
-import scala.collection.Iterable;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 import scala.collection.immutable.List;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 
 /**
@@ -223,7 +219,7 @@ public class SimpleConsumerWrapperTest {
         "theTopic"
     );
     SimpleConsumerWrapper consumerWrapper = new SimpleConsumerWrapper(
-        simpleConsumerFactory, "abcd:1234,bcde:2345", "clientId", 10000L);
+        simpleConsumerFactory, "abcd:1234,bcde:2345", "clientId", "theTopic", 10000L);
     assertEquals(consumerWrapper.getPartitionCount("theTopic", 10000L), 2);
   }
 


### PR DESCRIPTION
As part of https://github.com/linkedin/pinot/issues/2583, separating the metadata fetcher from the consumer. This PR introduces the StreamMetadataProvider. The next step will be to start using it and deprecate the buildMetadataFetcher path from the StreamConsumerFactory