### PR TITLE
Don't allow default column update in V3 format

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/V1DefaultColumnHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/V1DefaultColumnHandler.java
@@ -33,16 +33,16 @@ public class V1DefaultColumnHandler extends BaseDefaultColumnHandler {
    * {@inheritDoc}
    */
   @Override
-  protected void updateDefaultColumn(String column, DefaultColumnAction action)
-      throws Exception {
+  protected void updateDefaultColumn(String column, DefaultColumnAction action) throws Exception {
     LOGGER.info("Starting default column action: {} on column: {}", action, column);
 
-    // Delete existing dictionary and forward index for the column.
-    removeColumnV1Indices(column);
+    // For UPDATE and REMOVE action, delete existing dictionary and forward index, and remove column metadata
+    if (action.isUpdateAction() || action.isRemoveAction()) {
+      removeColumnV1Indices(column);
+    }
 
-    // Now we finished all the work needed for REMOVE action.
-    // For ADD and UPDATE action, need to create new dictionary and forward index, and update column metadata.
-    if (!action.isRemoveAction()) {
+    // For ADD and UPDATE action, create new dictionary and forward index, and update column metadata
+    if (action.isAddAction() || action.isUpdateAction()) {
       createColumnV1Indices(column);
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
@@ -41,38 +41,31 @@ public class V3DefaultColumnHandler extends BaseDefaultColumnHandler {
   }
 
   @Override
-  protected void updateDefaultColumn(String column, DefaultColumnAction action)
-      throws Exception {
+  protected void updateDefaultColumn(String column, DefaultColumnAction action) throws Exception {
     LOGGER.info("Starting default column action: {} on column: {}", action, column);
 
-    // Column indices cannot be removed for segment format V3.
-    // Throw exception to drop and re-download the segment.
-    if (action.isRemoveAction()) {
+    // For V3 segment format, only support ADD action
+    // For UPDATE and REMOVE action, throw exception to drop and re-download the segment
+    if (!action.isAddAction()) {
       throw new V3RemoveIndexException(
           "Default value indices for column: " + column + " cannot be removed for V3 format segment.");
     }
 
-    // Delete existing dictionary and forward index for the column. For V3, this is for error handling.
-    removeColumnV1Indices(column);
+    // Create new dictionary and forward index, and update column metadata
+    createColumnV1Indices(column);
 
-    // Now we finished all the work needed for REMOVE action.
-    // For ADD and UPDATE action, need to create new dictionary and forward index, and update column metadata.
-    if (!action.isRemoveAction()) {
-      createColumnV1Indices(column);
-
-      // Write index to V3 format.
-      FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
-      Preconditions.checkNotNull(fieldSpec);
-      boolean isSingleValue = fieldSpec.isSingleValueField();
-      File dictionaryFile = new File(_indexDir, column + V1Constants.Dict.FILE_EXTENSION);
-      File forwardIndexFile;
-      if (isSingleValue) {
-        forwardIndexFile = new File(_indexDir, column + V1Constants.Indexes.SORTED_SV_FORWARD_INDEX_FILE_EXTENSION);
-      } else {
-        forwardIndexFile = new File(_indexDir, column + V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
-      }
-      LoaderUtils.writeIndexToV3Format(_segmentWriter, column, dictionaryFile, ColumnIndexType.DICTIONARY);
-      LoaderUtils.writeIndexToV3Format(_segmentWriter, column, forwardIndexFile, ColumnIndexType.FORWARD_INDEX);
+    // Write index to V3 format.
+    FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
+    Preconditions.checkNotNull(fieldSpec);
+    boolean isSingleValue = fieldSpec.isSingleValueField();
+    File dictionaryFile = new File(_indexDir, column + V1Constants.Dict.FILE_EXTENSION);
+    File forwardIndexFile;
+    if (isSingleValue) {
+      forwardIndexFile = new File(_indexDir, column + V1Constants.Indexes.SORTED_SV_FORWARD_INDEX_FILE_EXTENSION);
+    } else {
+      forwardIndexFile = new File(_indexDir, column + V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
     }
+    LoaderUtils.writeIndexToV3Format(_segmentWriter, column, dictionaryFile, ColumnIndexType.DICTIONARY);
+    LoaderUtils.writeIndexToV3Format(_segmentWriter, column, forwardIndexFile, ColumnIndexType.FORWARD_INDEX);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/SegmentPreProcessorTest.java
@@ -260,22 +260,6 @@ public class SegmentPreProcessorTest {
     }
   }
 
-  @Test
-  public void testV3UpdateDefaultColumns() throws Exception {
-    constructV3Segment();
-    checkUpdateDefaultColumns();
-
-    // Try to use the third schema and update default value again.
-    // For the third schema, we changed the default value for column 'newStringMVDimension' to 'notSameLength', which
-    // is not the same length as before. This should throw exception for segment format v3.
-    try (SegmentPreProcessor processor = new SegmentPreProcessor(_indexDir, _indexLoadingConfig, _newColumnsSchema3)) {
-      processor.process();
-      Assert.fail("For segment format v3, should throw exception when trying to update with different length index");
-    } catch (Exception e) {
-      // PASS.
-    }
-  }
-
   private void checkUpdateDefaultColumns() throws Exception {
     // Update default value.
     try (SegmentPreProcessor processor = new SegmentPreProcessor(_indexDir, _indexLoadingConfig, _newColumnsSchema1)) {


### PR DESCRIPTION
The reason for this is that, updating default column in V3 format requires changing the existing index
We should avoid this because in HEAP mode this has no effect to the original file
In case of V3 format default column change, drop the segment and download a new one to add the default column