### PR TITLE
Adding a base class for multiple segments conversion minion tasks

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/MinionConstants.java
@@ -25,6 +25,8 @@ public class MinionConstants {
   public static final String SEGMENT_NAME_KEY = "segmentName";
   public static final String DOWNLOAD_URL_KEY = "downloadURL";
   public static final String UPLOAD_URL_KEY = "uploadURL";
+  public static final String URL_SEPARATOR = ",";
+
   /**
    * When minion downloads a segment to do work on, we will save that CRC. We will send that to the controller in an
    * If-Match header when we upload the segment to ensure that the minion-completed segment hasn't been replaced by

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionContext.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionContext.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.minion;
 import com.linkedin.pinot.core.minion.SegmentPurger;
 import com.linkedin.pinot.minion.metrics.MinionMetrics;
 import java.io.File;
+import javax.net.ssl.SSLContext;
 
 
 /**
@@ -36,6 +37,9 @@ public class MinionContext {
   private File _dataDir;
   private MinionMetrics _minionMetrics;
   private String _minionVersion;
+
+  // For segment upload
+  private SSLContext _sslContext;
 
   // For PurgeTask
   private SegmentPurger.RecordPurgerFactory _recordPurgerFactory;
@@ -63,6 +67,14 @@ public class MinionContext {
 
   public void setMinionVersion(String minionVersion) {
     _minionVersion = minionVersion;
+  }
+
+  public SSLContext getSSLContext() {
+    return _sslContext;
+  }
+
+  public void setSSLContext(SSLContext sslContext) {
+    _sslContext = sslContext;
   }
 
   public SegmentPurger.RecordPurgerFactory getRecordPurgerFactory() {

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
@@ -19,12 +19,12 @@ import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.metrics.MetricsHelper;
 import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import com.linkedin.pinot.common.utils.ClientSSLContextGenerator;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.minion.events.EventObserverFactoryRegistry;
 import com.linkedin.pinot.minion.events.MinionEventObserverFactory;
-import com.linkedin.pinot.minion.executor.BaseSegmentConversionExecutor;
 import com.linkedin.pinot.minion.executor.PinotTaskExecutorFactory;
 import com.linkedin.pinot.minion.executor.TaskExecutorFactoryRegistry;
 import com.linkedin.pinot.minion.metrics.MinionMeter;
@@ -33,6 +33,7 @@ import com.linkedin.pinot.minion.taskfactory.TaskFactoryRegistry;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import javax.annotation.Nonnull;
+import javax.net.ssl.SSLContext;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -50,6 +51,9 @@ import org.slf4j.LoggerFactory;
  */
 public class MinionStarter {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinionStarter.class);
+
+  private static final String HTTPS_PROTOCOL = "https";
+  private static final String HTTPS_ENABLED = "enabled";
 
   private final String _helixClusterName;
   private final Configuration _config;
@@ -125,13 +129,20 @@ public class MinionStarter {
     // TODO: set the correct minion version
     minionContext.setMinionVersion("1.0");
 
-    LOGGER.info("initializing segment fetchers for all protocols");
+    LOGGER.info("Initializing segment fetchers for all protocols");
     SegmentFetcherFactory.getInstance()
         .init(_config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY));
 
     // Need to do this before we start receiving state transitions.
-    LOGGER.info("Initializing segment conversion executor");
-    BaseSegmentConversionExecutor.init(_config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
+    LOGGER.info("Initializing ssl context for segment uploader");
+    Configuration httpsConfig =
+        _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER).subset(HTTPS_PROTOCOL);
+    if (httpsConfig.getBoolean(HTTPS_ENABLED, false)) {
+      SSLContext sslContext =
+          new ClientSSLContextGenerator(httpsConfig.subset(CommonConstants.PREFIX_OF_SSL_SUBSET)).generate();
+      minionContext.setSSLContext(sslContext);
+    }
+
     // Join the Helix cluster
     LOGGER.info("Joining the Helix cluster");
     _helixManager.getStateMachineEngine()

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseMultipleSegmentsConversionExecutor.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.minion.executor;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.config.PinotTaskConfig;
+import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.minion.exception.TaskCancelledException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Base class which provides a framework for N -> M segment conversion tasks.
+ * <p> This class handles segment download and upload
+ *
+ * {@link BaseMultipleSegmentsConversionExecutor} assumes that output segments are new segments derived from input
+ * segments. So, we do not check crc or modify zk metadata when uploading segments. In case of modifying the existing
+ * segments, {@link BaseSingleSegmentConversionExecutor} has to be used.
+ */
+public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseMultipleSegmentsConversionExecutor.class);
+
+  /**
+   * Converts the segment based on the given {@link PinotTaskConfig}.
+   *
+   * @param pinotTaskConfig Task config
+   * @param originalIndexDir Index directory for the original segment
+   * @param workingDir Working directory for the converted segment
+   * @return a list of segment conversion result
+   * @throws Exception
+   */
+  protected abstract List<SegmentConversionResult> convert(@Nonnull PinotTaskConfig pinotTaskConfig,
+      @Nonnull List<File> originalIndexDir, @Nonnull File workingDir) throws Exception;
+
+  @Override
+  public List<SegmentConversionResult> executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) throws Exception {
+    String taskType = pinotTaskConfig.getTaskType();
+    Map<String, String> configs = pinotTaskConfig.getConfigs();
+    String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
+    String inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
+    String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
+    String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
+    String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
+
+    LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
+        tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
+
+    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + System.nanoTime());
+    Preconditions.checkState(tempDataDir.mkdirs());
+
+    try {
+      List<File> inputSegmentFiles = new ArrayList<>();
+      for (int i = 0; i < downloadURLs.length; i++) {
+        // Download the segment file
+        File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile_" + i);
+        SegmentFetcherFactory.getInstance()
+            .getSegmentFetcherBasedOnURI(downloadURLs[i])
+            .fetchSegmentToLocal(downloadURLs[i], tarredSegmentFile);
+
+        // Un-tar the segment file
+        File segmentDir = new File(tempDataDir, "segmentDir_" + i);
+        TarGzCompressionUtils.unTar(tarredSegmentFile, segmentDir);
+        File[] files = segmentDir.listFiles();
+        Preconditions.checkState(files != null && files.length == 1);
+        File indexDir = files[0];
+        inputSegmentFiles.add(indexDir);
+      }
+
+      // Convert the segments
+      File workingDir = new File(tempDataDir, "workingDir");
+      Preconditions.checkState(workingDir.mkdir());
+      List<SegmentConversionResult> segmentConversionResults = convert(pinotTaskConfig, inputSegmentFiles, workingDir);
+
+      // Create a directory for converted tarred segment files
+      File convertedTarredSegmentDir = new File(tempDataDir, "convertedTarredSegmentDir");
+      Preconditions.checkState(convertedTarredSegmentDir.mkdir());
+
+      int numOutputSegments = segmentConversionResults.size();
+      List<File> tarredSegmentFiles = new ArrayList<>(numOutputSegments);
+      for (int i = 0; i < numOutputSegments; i++) {
+        // Tar the converted segment
+        SegmentConversionResult segmentConversionResult = segmentConversionResults.get(i);
+        File convertedIndexDir = segmentConversionResult.getFile();
+        File convertedTarredSegmentFile = new File(
+            TarGzCompressionUtils.createTarGzOfDirectory(convertedIndexDir.getPath(),
+                new File(convertedTarredSegmentDir, segmentConversionResult.getSegmentName()).getPath()));
+        tarredSegmentFiles.add(convertedTarredSegmentFile);
+      }
+
+      // Check whether the task get cancelled before uploading the segment
+      if (_cancelled) {
+        LOGGER.info("{} on table: {}, segments: {} got cancelled", taskType, tableNameWithType, inputSegmentNames);
+        throw new TaskCancelledException(
+            taskType + " on table: " + tableNameWithType + ", segments: " + inputSegmentNames + " got cancelled");
+      }
+
+      // Upload the tarred segments
+      for (int i = 0; i < numOutputSegments; i++) {
+        File convertedTarredSegmentFile = tarredSegmentFiles.get(i);
+        String resultSegmentName = segmentConversionResults.get(i).getSegmentName();
+
+        // Set parameters for upload request
+        List<NameValuePair> parameters = Collections.singletonList(
+            new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION, "true"));
+
+        SegmentConversionUtils.uploadSegment(configs, null, parameters, tableNameWithType, resultSegmentName, uploadURL,
+            convertedTarredSegmentFile);
+      }
+
+      String outputSegmentNames = segmentConversionResults.stream()
+          .map(SegmentConversionResult::getSegmentName)
+          .collect(Collectors.joining(","));
+      LOGGER.info("Done executing {} on table: {}, input segments: {}, output segments: {}", taskType,
+          tableNameWithType, inputSegmentNames, outputSegmentNames);
+
+      return segmentConversionResults;
+    } finally {
+      FileUtils.deleteQuietly(tempDataDir);
+    }
+  }
+}

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 
-public class ConvertToRawIndexTaskExecutor extends BaseSegmentConversionExecutor {
+public class ConvertToRawIndexTaskExecutor extends BaseSingleSegmentConversionExecutor {
 
   @Override
   protected SegmentConversionResult convert(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull File originalIndexDir,

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/PurgeTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/PurgeTaskExecutor.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 
-public class PurgeTaskExecutor extends BaseSegmentConversionExecutor {
+public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
   public static final String RECORD_PURGER_KEY = "recordPurger";
   public static final String RECORD_MODIFIER_KEY = "recordModifier";
   public static final String NUM_RECORDS_PURGED_KEY = "numRecordsPurged";

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/SegmentConversionResult.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/SegmentConversionResult.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 /**
  * The class <code>SegmentConversionResult</code> wraps the result of
- * {@link BaseSegmentConversionExecutor#convert(PinotTaskConfig, File, File)}.
+ * {@link BaseSingleSegmentConversionExecutor#convert(PinotTaskConfig, File, File)}.
  */
 public class SegmentConversionResult {
   private final File _file;

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/SegmentConversionUtils.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/SegmentConversionUtils.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.minion.executor;
+import com.linkedin.pinot.common.exception.HttpErrorStatusException;
+import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
+import com.linkedin.pinot.common.utils.SimpleHttpResponse;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import com.linkedin.pinot.common.utils.retry.RetryPolicy;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.minion.MinionContext;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Util class for segment conversion tasks
+ */
+public class SegmentConversionUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentConversionUtils.class);
+
+  private static final int DEFAULT_MAX_NUM_ATTEMPTS = 5;
+  private static final long DEFAULT_INITIAL_RETRY_DELAY_MS = 1000L; // 1 second
+  private static final double DEFAULT_RETRY_SCALE_FACTOR = 2.0;
+
+  private SegmentConversionUtils() {
+  }
+
+  public static void uploadSegment(Map<String, String> configs, List<Header> httpHeaders,
+      List<NameValuePair> parameters, String tableNameWithType, String segmentName, String uploadURL, File fileToUpload)
+      throws Exception {
+    // Generate retry policy based on the config
+    String maxNumAttemptsConfig = configs.get(MinionConstants.MAX_NUM_ATTEMPTS_KEY);
+    int maxNumAttempts =
+        maxNumAttemptsConfig != null ? Integer.parseInt(maxNumAttemptsConfig) : DEFAULT_MAX_NUM_ATTEMPTS;
+    String initialRetryDelayMsConfig = configs.get(MinionConstants.INITIAL_RETRY_DELAY_MS_KEY);
+    long initialRetryDelayMs =
+        initialRetryDelayMsConfig != null ? Long.parseLong(initialRetryDelayMsConfig) : DEFAULT_INITIAL_RETRY_DELAY_MS;
+    String retryScaleFactorConfig = configs.get(MinionConstants.RETRY_SCALE_FACTOR_KEY);
+    double retryScaleFactor =
+        retryScaleFactorConfig != null ? Double.parseDouble(retryScaleFactorConfig) : DEFAULT_RETRY_SCALE_FACTOR;
+    RetryPolicy retryPolicy =
+        RetryPolicies.exponentialBackoffRetryPolicy(maxNumAttempts, initialRetryDelayMs, retryScaleFactor);
+
+    // Upload the segment with retry policy
+    SSLContext sslContext = MinionContext.getInstance().getSSLContext();
+    try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient(sslContext)) {
+      retryPolicy.attempt(() -> {
+        try {
+          SimpleHttpResponse response =
+              fileUploadDownloadClient.uploadSegment(new URI(uploadURL), segmentName, fileToUpload, httpHeaders,
+                  parameters, FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
+          LOGGER.info("Got response {}: {} while uploading table: {}, segment: {} with uploadURL: {}",
+              response.getStatusCode(), response.getResponse(), tableNameWithType, segmentName, uploadURL);
+          return true;
+        } catch (HttpErrorStatusException e) {
+          int statusCode = e.getStatusCode();
+          if (statusCode == HttpStatus.SC_CONFLICT || statusCode >= 500) {
+            // Temporary exception
+            LOGGER.warn("Caught temporary exception while uploading segment: {}, will retry", segmentName, e);
+            return false;
+          } else {
+            // Permanent exception
+            LOGGER.error("Caught permanent exception while uploading segment: {}, won't retry", segmentName, e);
+            throw e;
+          }
+        } catch (Exception e) {
+          LOGGER.warn("Caught temporary exception while uploading segment: {}, will retry", segmentName, e);
+          return false;
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
Current implementation of base segment conversion executor only supports
1 to 1 segment conversion while segment merge and roll-up task involves
in n to m segment conversion. This PR adds the base framework for n to m
segment conversion minion tasks.