### PR TITLE
Fix segment reload path error handling

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -153,7 +153,9 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
           _instanceDataManager.reloadSegment(_tableNameWithType, _segmentName);
         }
         helixTaskResult.setSuccess(true);
-      } catch (Exception e) {
+      } catch (Throwable e) {
+        // catch all Errors and Exceptions: if we only catch Exception, Errors go completely unhandled
+        // (without any corresponding logs to indicate failure!) in the callable path
         throw new RuntimeException(
             "Caught exception while reloading segment: " + _segmentName + " in table: " + _tableNameWithType, e);
       } finally {


### PR DESCRIPTION
If we encounter an "Error" (ie, OutOfMemoryError or the like) in the segment reload path, the callable just terminates without any trace of the error in the logs (either in the .log or .out file). Update the handler to catch all Throwables in this case.