### PR TITLE
In GroupBy, always use expressions (remove all usage of getColumns)

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/FunctionCallAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/FunctionCallAstNode.java
@@ -82,19 +82,7 @@ public class FunctionCallAstNode extends BaseAstNode {
       if (children == null || children.size() != 1) {
         throw new Pql2CompilationException("Aggregation function expects exact 1 argument");
       }
-      AstNode astNode = children.get(0);
-      if (astNode instanceof IdentifierAstNode) {
-        // Column name
-        expression = ((IdentifierAstNode) astNode).getName();
-      } else if (astNode instanceof FunctionCallAstNode) {
-        // UDF
-        expression = TransformExpressionTree.standardizeExpression(((FunctionCallAstNode) astNode).getExpression());
-      } else if (astNode instanceof StringLiteralAstNode) {
-        // Try to parse string as expression
-        expression = TransformExpressionTree.standardizeExpression(((StringLiteralAstNode) astNode).getText());
-      } else {
-        throw new Pql2CompilationException("Aggregation function argument is not a column or UDF");
-      }
+      expression = TransformExpressionTree.getStandardExpression(children.get(0));
     }
 
     AggregationInfo aggregationInfo = new AggregationInfo();

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
@@ -28,22 +28,8 @@ public class GroupByAstNode extends BaseAstNode {
   @Override
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
     GroupBy groupBy = new GroupBy();
-    for (AstNode astNode : getChildren()) {
-      if (astNode instanceof IdentifierAstNode) {
-        IdentifierAstNode node = (IdentifierAstNode) astNode;
-        groupBy.addToColumns(node.getName());
-
-        // List of expression contains columns as well as expressions to maintain ordering of group by columns.
-        groupBy.addToExpressions(node.getExpression());
-      } else {
-        // Standardize the expression string
-        // NOTE: the purpose is to ensure the function expression is valid, and stored in standard format.
-        // E.g. "  foo\t  ( bar  ('a'\t ,foobar(  b,  'c'\t, 123)  )   ,d  )\t" -> "foo(bar('a',foobar(b,'c','123')),d)"
-        // The standard format expressions will be used as "groupByColumns" in the broker response.
-        String expression =
-            TransformExpressionTree.standardizeExpression(((FunctionCallAstNode) astNode).getExpression());
-        groupBy.addToExpressions(expression);
-      }
+    for (AstNode child : getChildren()) {
+      groupBy.addToExpressions(TransformExpressionTree.getStandardExpression(child));
     }
     brokerRequest.setGroupBy(groupBy);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/TransformBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/TransformBlock.java
@@ -46,7 +46,7 @@ public class TransformBlock implements Block {
   }
 
   public BlockValSet getBlockValueSet(TransformExpressionTree expression) {
-    if (expression.getExpressionType() == TransformExpressionTree.ExpressionType.IDENTIFIER) {
+    if (expression.isColumn()) {
       return _projectionBlock.getBlockValueSet(expression.getValue());
     } else {
       return new TransformBlockValSet(_projectionBlock, _transformFunctionMap.get(expression));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -189,8 +189,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     if (functionType.isOfType(AggregationFunctionType.MIN, AggregationFunctionType.MAX,
         AggregationFunctionType.MINMAXRANGE)) {
       String expression = AggregationFunctionUtils.getColumn(aggregationInfo);
-      if (TransformExpressionTree.compileToExpressionTree(expression).getExpressionType()
-          == TransformExpressionTree.ExpressionType.IDENTIFIER) {
+      if (TransformExpressionTree.compileToExpressionTree(expression).isColumn()) {
         Dictionary dictionary = indexSegment.getDataSource(expression).getDictionary();
         return dictionary != null && dictionary.isSorted();
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/ScanBasedQueryProcessor.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/ScanBasedQueryProcessor.java
@@ -69,7 +69,7 @@ public class ScanBasedQueryProcessor implements Cloneable {
     List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
     if (aggregationsInfo != null) {
       GroupBy groupBy = brokerRequest.getGroupBy();
-      groupByColumns = (brokerRequest.isSetGroupBy()) ? groupBy.getColumns() : null;
+      groupByColumns = (brokerRequest.isSetGroupBy()) ? groupBy.getExpressions() : null;
       long topN = (groupByColumns != null) ? groupBy.getTopN() : 10;
       aggregation = new Aggregation(brokerRequest.getAggregationsInfo(), groupByColumns, topN);
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/SegmentQueryProcessor.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/SegmentQueryProcessor.java
@@ -103,7 +103,7 @@ class SegmentQueryProcessor {
         GroupBy groupBy = brokerRequest.getGroupBy();
         Aggregation aggregation =
             new Aggregation(_immutableSegment, _metadata, filteredDocIds, brokerRequest.getAggregationsInfo(),
-                groupBy.getColumns(), groupBy.getTopN());
+                groupBy.getExpressions(), groupBy.getTopN());
         result = aggregation.run();
       }
     } else {// Only Selection
@@ -154,7 +154,7 @@ class SegmentQueryProcessor {
 
         GroupBy groupBy = brokerRequest.getGroupBy();
         if (groupBy != null) {
-          for (String column : groupBy.getColumns()) {
+          for (String column : groupBy.getExpressions()) {
             if (!allColumns.contains(column)) {
               LOGGER.debug("Skipping segment '{}', as it does not have column '{}'", _metadata.getName(), column);
               return true;


### PR DESCRIPTION
Use the same way to compile aggregation expression and group-by expression
For backward-compatibility, allow string literal column in aggregation and group-by