### PR TITLE
Changed server api end points to return string instead of java objects

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/ResourceUtils.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/ResourceUtils.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.server.api.resources;
+
+import java.io.IOException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Util class for server APIs.
+ */
+public class ResourceUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtils.class);
+
+  private ResourceUtils() {
+  }
+
+  public static String convertToJsonString(Object object) {
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+    } catch (IOException e) {
+      LOGGER.error("Failed to convert json into string: ", e);
+      throw new WebApplicationException("Failed to convert json into string.", Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TableSizeResource.java
@@ -60,7 +60,7 @@ public class TableSizeResource {
       @ApiResponse(code = 500, message = "Internal server error"),
       @ApiResponse(code = 404, message = "Table not found")
   })
-  public TableSizeInfo getTableSize(
+  public String getTableSize(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
       throws WebApplicationException {
@@ -102,7 +102,7 @@ public class TableSizeResource {
       }
     }
     //invalid to use the segmentDataManagers below
-    return tableSizeInfo;
+    return ResourceUtils.convertToJsonString(tableSizeInfo);
   }
 
   // same as above but with /tables (plural) path for consistency.
@@ -117,7 +117,7 @@ public class TableSizeResource {
       @ApiResponse(code = 404, message = "Table not found")
   })
   @Deprecated
-  public TableSizeInfo getTableSizeOld(
+  public String getTableSizeOld(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
       throws WebApplicationException {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/TablesResource.java
@@ -44,7 +44,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,14 +66,14 @@ public class TablesResource {
       @ApiResponse(code = 200, message = "Success", response = TablesList.class),
       @ApiResponse(code = 500, message = "Server initialization error", response = ErrorInfo.class)
   })
-  public TablesList listTables() {
+  public String listTables() {
     InstanceDataManager dataManager = checkGetInstanceDataManager();
     Collection<TableDataManager> tableDataManagers = dataManager.getTableDataManagers();
     List<String> tables = new ArrayList<>(tableDataManagers.size());
     for (TableDataManager tableDataManager : tableDataManagers) {
       tables.add(tableDataManager.getTableName());
     }
-    return new TablesList(tables);
+    return ResourceUtils.convertToJsonString(new TablesList(tables));
   }
 
   private InstanceDataManager checkGetInstanceDataManager() {
@@ -106,7 +105,7 @@ public class TablesResource {
       @ApiResponse(code = 200, message = "Success", response = TableSegments.class),
       @ApiResponse(code = 500, message = "Server initialization error", response = ErrorInfo.class)
   })
-  public TableSegments listTableSegments(
+  public String listTableSegments(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE") @PathParam("tableName") String tableName) {
     TableDataManager tableDataManager = checkGetTableDataManager(tableName);
     List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
@@ -115,7 +114,7 @@ public class TablesResource {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         segments.add(segmentDataManager.getSegmentName());
       }
-      return new TableSegments(segments);
+      return ResourceUtils.convertToJsonString(new TableSegments(segments));
     } finally {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         tableDataManager.releaseSegment(segmentDataManager);
@@ -182,8 +181,7 @@ public class TablesResource {
             (SegmentMetadataImpl) segmentDataManager.getSegment().getSegmentMetadata();
         segmentCrcForTable.put(segmentDataManager.getSegmentName(), segmentMetadata.getCrc());
       }
-      ObjectMapper mapper = new ObjectMapper();
-      return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(segmentCrcForTable);
+      return ResourceUtils.convertToJsonString(segmentCrcForTable);
     } catch (Exception e) {
       throw new WebApplicationException("Failed to convert crc information to json",
           Response.Status.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Server side APIs for the internal release are broken due to denpendency
issues. Returning string value instead of java object for jersey API
resolves the issue.