### PR TITLE
Reducing garbage when indexing multi-value columns

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/MultiValueForwardIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/MultiValueForwardIndexCreator.java
@@ -17,5 +17,11 @@ package com.linkedin.pinot.core.segment.creator;
 
 
 public interface MultiValueForwardIndexCreator extends ForwardIndexCreator {
+  /**
+   * Add the multi-value dictionary IDs to the doc.
+   *
+   * @param docId of the doc to add
+   * @param dictionaryIndices Sorted dictionary indices
+   */
   void index(int docId, int[] dictionaryIndices);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
@@ -262,6 +262,7 @@ public class SegmentDictionaryCreator implements Closeable {
         throw new UnsupportedOperationException("Unsupported data type : " + _fieldSpec.getDataType());
     }
 
+    Arrays.sort(indexes);
     return indexes;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/fwd/MultiValueUnsortedForwardIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/fwd/MultiValueUnsortedForwardIndexCreator.java
@@ -22,7 +22,6 @@ import com.linkedin.pinot.core.segment.creator.MultiValueForwardIndexCreator;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 
 
@@ -44,9 +43,7 @@ public class MultiValueUnsortedForwardIndexCreator implements MultiValueForwardI
 
   @Override
   public void index(int docId, int[] dictionaryIndices) {
-    final int[] entries = Arrays.copyOf(dictionaryIndices, dictionaryIndices.length);
-    Arrays.sort(entries);
-    mVWriter.setIntArray(docId, entries);
+    mVWriter.setIntArray(docId, dictionaryIndices);
   }
 
   @Override


### PR DESCRIPTION
The dictionary ID of multi-valued columns need to be in sorted order for any given docId in the fwd index.
In the dictionary creator, when adding the multi-value field, we already create a new array. It makes
sense to sort the values right there, and assume that the values coming into the fwd index builder
are always sorted. This way, we avoid creating another array for multi-valued columns during
segment creation.

Verified that there are no other callers to te fwd index builder, and also updated javadoc to reflect
the new expectation of the input.