### PR TITLE
[PINOT-6696] Remove http connection pool in table-size api path

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 import javax.annotation.Nonnull;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,19 +72,13 @@ public class MultiGetRequest {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiGetRequest.class);
 
   Executor executor;
-  HttpConnectionManager connectionManager;
 
   /**
    * @param executor executor service to use for making parallel requests
-   * @param connectionManager http connection manager to use.
    */
-  public MultiGetRequest(@Nonnull Executor executor,
-      @Nonnull HttpConnectionManager connectionManager) {
+  public MultiGetRequest(@Nonnull Executor executor) {
     Preconditions.checkNotNull(executor);
-    Preconditions.checkNotNull(connectionManager);
-
     this.executor = executor;
-    this.connectionManager = connectionManager;
   }
 
   /**
@@ -105,7 +98,7 @@ public class MultiGetRequest {
         @Override
         public GetMethod call()
             throws Exception {
-          HttpClient client = new HttpClient(connectionManager);
+          HttpClient client = new HttpClient();
           GetMethod getMethod = new GetMethod(url);
           getMethod.getParams().setSoTimeout(timeoutMs);
           // if all connections in the connection manager are busy this will wait to retrieve a connection

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,8 +106,7 @@ public class MultiGetRequestTest {
 
   @Test
   public void testMultiGet() {
-    MultiGetRequest mget = new MultiGetRequest(Executors.newCachedThreadPool(),
-        new MultiThreadedHttpConnectionManager());
+    MultiGetRequest mget = new MultiGetRequest(Executors.newCachedThreadPool());
     List<String> urls = Arrays.asList("http://localhost:" + String.valueOf(portStart) + URI_PATH,
         "http://localhost:" + String.valueOf(portStart + 1) + URI_PATH,
         "http://localhost:" + String.valueOf(portStart + 2) + URI_PATH,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -46,8 +46,6 @@ import java.io.OutputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.httpclient.HttpConnectionManager;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.task.TaskDriver;
@@ -184,8 +182,6 @@ public class ControllerStarter {
 
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");
-    final MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
-    connectionManager.getParams().setConnectionTimeout(_config.getServerAdminRequestTimeoutSeconds() * 1000);
     // register all the controller objects for injection to jersey resources
     _adminApp.registerBinder(new AbstractBinder() {
       @Override
@@ -194,7 +190,6 @@ public class ControllerStarter {
         bind(_helixResourceManager).to(PinotHelixResourceManager.class);
         bind(_helixTaskResourceManager).to(PinotHelixTaskResourceManager.class);
         bind(_taskManager).to(PinotTaskManager.class);
-        bind(connectionManager).to(HttpConnectionManager.class);
         bind(_executorService).to(Executor.class);
         bind(_controllerMetrics).to(ControllerMetrics.class);
         bind(accessControlFactory).to(AccessControlFactory.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -79,7 +79,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.helix.ZNRecord;
@@ -109,9 +108,6 @@ public class PinotSegmentUploadRestletResource {
 
   @Inject
   ControllerMetrics _controllerMetrics;
-
-  @Inject
-  HttpConnectionManager _connectionManager;
 
   @Inject
   Executor _executor;
@@ -706,7 +702,7 @@ public class PinotSegmentUploadRestletResource {
    */
   private StorageQuotaChecker.QuotaCheckerResponse checkStorageQuota(@Nonnull File segmentFile,
       @Nonnull SegmentMetadata metadata, @Nonnull TableConfig offlineTableConfig) throws InvalidConfigException {
-    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
+    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager);
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());
     return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName, metadata.getName(),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import org.apache.commons.httpclient.ConnectTimeoutException;
 import org.apache.commons.httpclient.ConnectionPoolTimeoutException;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -47,11 +46,9 @@ public class ServerTableSizeReader {
       ServerTableSizeReader.class);
 
   private final Executor executor;
-  private final HttpConnectionManager connectionManager;
 
-  public ServerTableSizeReader(Executor executor, HttpConnectionManager connectionManager) {
+  public ServerTableSizeReader(Executor executor) {
     this.executor = executor;
-    this.connectionManager = connectionManager;
   }
 
   public Map<String, List<SegmentSizeInfo>> getSizeDetailsFromServers(BiMap<String, String> serverEndPoints,
@@ -64,7 +61,7 @@ public class ServerTableSizeReader {
       serverUrls.add(tableSizeUri);
     }
 
-    MultiGetRequest mget = new MultiGetRequest(executor, connectionManager);
+    MultiGetRequest mget = new MultiGetRequest(executor);
     LOGGER.info("Reading segment sizes from {} servers for table: {}, timeoutMsec: {}", serverUrls.size(), table, timeoutMsec);
     CompletionService<GetMethod> completionService = mget.execute(serverUrls, timeoutMsec);
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
@@ -33,7 +33,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +47,6 @@ public class TableSize {
   PinotHelixResourceManager _pinotHelixResourceManager;
   @Inject
   Executor _executor;
-  @Inject
-  HttpConnectionManager _connectionManager;
 
   @GET
   @Path("/tables/{tableName}/size")
@@ -66,7 +63,7 @@ public class TableSize {
           @QueryParam("detailed") boolean detailed
   ) {
     TableSizeReader
-        tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
+        tableSizeReader = new TableSizeReader(_executor, _pinotHelixResourceManager);
     TableSizeReader.TableSizeDetails tableSizeDetails = null;
     try {
       tableSizeDetails = tableSizeReader.getTableSizeDetails(tableName,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -30,8 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.httpclient.HttpConnectionManager;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
@@ -80,8 +78,7 @@ public class SegmentStatusChecker {
     _segmentStatusIntervalSeconds = config.getStatusCheckerFrequencyInSeconds();
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _metricsRegistry = metricsRegistry;
-    HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
-    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), httpConnectionManager, _pinotHelixResourceManager);
+    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), _pinotHelixResourceManager);
 
     _executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
       @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import org.apache.commons.httpclient.HttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -45,13 +44,11 @@ import javax.annotation.Nullable;
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
   private Executor _executor;
-  private HttpConnectionManager _connectionManager;
   private PinotHelixResourceManager _helixResourceManager;
 
-  public TableSizeReader(Executor executor, HttpConnectionManager connectionManager,
+  public TableSizeReader(Executor executor,
       PinotHelixResourceManager helixResourceManager) {
     _executor = executor;
-    _connectionManager = connectionManager;
     _helixResourceManager = helixResourceManager;
   }
 
@@ -143,7 +140,7 @@ public class TableSizeReader {
     // get list of servers
     Map<String, List<String>> serverSegmentsMap =
         _helixResourceManager.getInstanceToSegmentsInATableMap(table);
-    ServerTableSizeReader serverTableSizeReader = new ServerTableSizeReader(_executor, _connectionManager);
+    ServerTableSizeReader serverTableSizeReader = new ServerTableSizeReader(_executor);
     BiMap<String, String> endpoints = _helixResourceManager.getDataInstanceAdminEndpoints(serverSegmentsMap.keySet());
     Map<String, List<SegmentSizeInfo>> serverSizeInfo =
         serverTableSizeReader.getSizeDetailsFromServers(endpoints, table, timeoutMsec);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
@@ -32,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.httpclient.HttpConnectionManager;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -46,7 +44,6 @@ public class ServerTableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(3);
-  private final HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
   private final int serverPortStart = 10000;
   private final String URI_PATH = "/table/";
   private final List<HttpServer> servers = new ArrayList<>();
@@ -144,7 +141,7 @@ public class ServerTableSizeReaderTest {
 
   @Test
   public void testServerSizeReader() {
-    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor);
     BiMap<String, String> endpoints = HashBiMap.create();
     for (int i = 0; i < 2; i++) {
       endpoints.put(serverList.get(i), endpointList.get(i));
@@ -163,7 +160,7 @@ public class ServerTableSizeReaderTest {
 
   @Test
   public void testServerSizesErrors() {
-    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor);
     BiMap<String, String> endpoints = HashBiMap.create();
     for (int i = 0; i < serverCount; i++) {
       endpoints.put(serverList.get(i), endpointList.get(i));

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -36,8 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import org.apache.commons.httpclient.HttpConnectionManager;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -55,7 +53,6 @@ import static org.mockito.Mockito.*;
 public class TableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReaderTest.class);
   private final Executor executor = Executors.newFixedThreadPool(1);
-  private final HttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
 
   private PinotHelixResourceManager helix;
   private Map<String, FakeSizeServer> serverMap = new HashMap<>();
@@ -219,7 +216,7 @@ public class TableSizeReaderTest {
 
   @Test
   public void testNoSuchTable() throws InvalidConfigException {
-    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    TableSizeReader reader = new TableSizeReader(executor, helix);
     Assert.assertNull(reader.getTableSizeDetails("mytable", 5000));
   }
 
@@ -243,7 +240,7 @@ public class TableSizeReaderTest {
           }
         });
 
-    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    TableSizeReader reader = new TableSizeReader(executor, helix);
     return reader.getTableSizeDetails(table, timeoutMsec);
   }
 


### PR DESCRIPTION
It appears that MultiThreadedHttpConnectionManager is buggy - especially when it encounters a connection refused error on any connection, it fails to "release" the underlying connection and subsequent connections to other servers over the pool encounter connection-refused due to the stale connection. This causes failures in the TableSize API which is invoked during segment upload, failing the upload.

Also, in the current code, we use default size for max connections which is 20; for one of large clusters (with ~80 servers hosting segments of a table), the 20 max connection essentially means that the connections are established and torn down, essentially rendering the pool ineffective. 

If we do need to use a pool, we should consider using PoolingHttpConnectionManager - this requires a httpclient version bump to 4.x.x from the existing 3.1. That is a larger change - for this phase, we'll consider the simpler case of bypassing the pool completely.

Testing done:
Deployed updated binary in integration cluster and hit table/size api on all tables hosted on the controller - checked that the basic functionality worked, there are no resource leaks (via netstat/lsof). Also, checked that there are no connection refused errors to hosts that are up.