### PR TITLE
Testing pinotFS instantiation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -328,8 +328,6 @@ public class ControllerStarter {
     conf.setStatusCheckerWaitForPushTimeInSeconds(10 * 60);
     conf.setTenantIsolationEnabled(true);
 
-    // set to null because the local file pinot fs factory class is included by default
-    conf.setPinotFSFactoryClasses(null);
     final ControllerStarter starter = new ControllerStarter(conf);
 
     starter.start();

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -101,8 +101,6 @@ public abstract class ControllerTest {
     config.setDataDir(DEFAULT_DATA_DIR);
     config.setZkStr(ZkStarter.DEFAULT_ZK_STR);
 
-    // Includes default local PinotFS class
-    config.setPinotFSFactoryClasses(null);
     return config;
   }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartControllerCommand.java
@@ -148,7 +148,6 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
 
         conf.setRetentionControllerFrequencyInSeconds(3600 * 6);
         conf.setValidationControllerFrequencyInSeconds(3600);
-        conf.setPinotFSFactoryClasses(null);
       }
 
       LOGGER.info("Executing command: " + toString());

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -195,7 +195,6 @@ public class PerfBenchmarkDriver {
     conf.setTenantIsolationEnabled(false);
     conf.setControllerVipHost("localhost");
     conf.setControllerVipProtocol("http");
-    conf.setPinotFSFactoryClasses(null);
     return conf;
   }
 


### PR DESCRIPTION
Ensuring default controller starter behavior works as expected without having to add a config for the PinotFSFactory classes by removing the config setting in all our test paths and throughout our code. Verified that local implem is returned by default