### PR TITLE
Resolve UI showing MTTD is 0

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -285,7 +285,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         anomalyFunctionSpec.setWindowSize(6);
         anomalyFunctionSpec.setWindowUnit(TimeUnit.HOURS);
         anomalyFunctionSpec.setFrequency(new TimeGranularity(15, TimeUnit.MINUTES));
-        anomalyFunctionSpec.setProperties("");
+        anomalyFunctionSpec.setProperties("signTestWindowSize=24");
         anomalyFunctionSpec.setRequiresCompletenessCheck(false);
         break;
       case HOURS:


### PR DESCRIPTION
Expose default sign test window size to fix cases when mttd is shown as 0.