### PR TITLE
Changing pinotFS to use temp file instead of uri for copyToLocal

### DIFF
--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -110,13 +110,13 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
-    copy(srcUri, tempFile.toURI());
-    LOGGER.info("Copy file from {} to {}; Length of file: {}", srcUri, tempFile, tempFile.length());
+  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
+    copy(srcUri, dstFile.toURI());
+    LOGGER.info("Copy file from {} to {}; Length of file: {}", srcUri, dstFile, dstFile.length());
   }
 
   @Override
-  public void copyFromLocalFile(URI srcUri, URI dstUri) throws IOException {
-    copy(srcUri, dstUri);
+  public void copyFromLocalFile(File srcFile, URI dstUri) throws IOException {
+    copy(srcFile.toURI(), dstUri);
   }
 }

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -22,6 +22,8 @@ import java.nio.file.Files;
 import java.util.Collection;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,7 @@ import org.apache.commons.io.FileUtils;
  * if access to the file is denied.
  */
 public class LocalPinotFS extends PinotFS {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LocalPinotFS.class);
 
   public LocalPinotFS() {
   }
@@ -107,8 +110,9 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, URI dstUri) throws IOException {
-    copy(srcUri, dstUri);
+  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
+    copy(srcUri, tempFile.toURI());
+    LOGGER.info("Copy file from {} to {}; Length of file: {}", srcUri, tempFile, tempFile.length());
   }
 
   @Override

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.filesystem;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import org.apache.commons.configuration.Configuration;
@@ -89,10 +90,10 @@ public abstract class PinotFS {
   /**
    * Copies a file from a remote filesystem to the local one. Keeps the original file.
    * @param srcUri location of current file on remote filesystem
-   * @param dstUri location of destination on local filesystem
-   * @throws IOException IO Failures
+   * @param tempFile location of destination on local filesystem
+   * @throws Exception 
    */
-  public abstract void copyToLocalFile(URI srcUri, URI dstUri) throws IOException;
+  public abstract void copyToLocalFile(URI srcUri, File tempFile) throws Exception;
 
   /**
    * The src file is on the local disk. Add it to filesystem at the given dst name and the source is kept intact

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -90,17 +90,17 @@ public abstract class PinotFS {
   /**
    * Copies a file from a remote filesystem to the local one. Keeps the original file.
    * @param srcUri location of current file on remote filesystem
-   * @param tempFile location of destination on local filesystem
-   * @throws Exception 
+   * @param dstFile location of destination on local filesystem
+   * @throws Exception
    */
-  public abstract void copyToLocalFile(URI srcUri, File tempFile) throws Exception;
+  public abstract void copyToLocalFile(URI srcUri, File dstFile) throws Exception;
 
   /**
    * The src file is on the local disk. Add it to filesystem at the given dst name and the source is kept intact
    * afterwards.
-   * @param srcUri location of src file on local disk
+   * @param srcFile location of src file on local disk
    * @param dstUri location of dst on remote filesystem
    * @throws IOException for IO Error
    */
-  public abstract void copyFromLocalFile(URI srcUri, URI dstUri) throws IOException;
+  public abstract void copyFromLocalFile(File srcFile, URI dstUri) throws IOException;
 }

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -125,9 +125,9 @@ public class LocalPinotFSTest {
 
     Assert.assertTrue(testFile.exists());
 
-    localPinotFS.copyFromLocalFile(testFile.toURI(), secondTestFileUri);
+    localPinotFS.copyFromLocalFile(testFile, secondTestFileUri);
     Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
-    localPinotFS.copyToLocalFile(testFile.toURI(), secondTestFileUri);
+    localPinotFS.copyToLocalFile(testFile.toURI(), new File(secondTestFileUri));
     Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
 
     // List files on a file - exception if file already exists

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
@@ -20,6 +20,7 @@ import com.microsoft.azure.datalake.store.ADLStoreClient;
 import com.microsoft.azure.datalake.store.DirectoryEntry;
 import com.microsoft.azure.datalake.store.oauth2.AccessTokenProvider;
 import com.microsoft.azure.datalake.store.oauth2.ClientCredsTokenProvider;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -115,9 +116,9 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, URI dstUri) throws IOException {
+  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
     try (InputStream adlStream = _adlStoreClient.getReadStream(srcUri.getPath())) {
-      Path dstFilePath = Paths.get(dstUri);
+      Path dstFilePath = Paths.get(tempFile.toURI());
 
       /* Copy the source file to the destination directory as a file with the same name as the source,
        * replace an existing file with the same name in the destination directory, if any.
@@ -125,7 +126,7 @@ public class AzurePinotFS extends PinotFS {
        */
       Files.copy(adlStream, dstFilePath);
 
-      LOGGER.info("Copied file {} from ADL to {}", srcUri, dstUri);
+      LOGGER.info("Copied file {} from ADL to {}", srcUri, tempFile);
     } catch (Exception ex) {
       throw ex;
     }

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
@@ -116,9 +116,9 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
+  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
     try (InputStream adlStream = _adlStoreClient.getReadStream(srcUri.getPath())) {
-      Path dstFilePath = Paths.get(tempFile.toURI());
+      Path dstFilePath = Paths.get(dstFile.toURI());
 
       /* Copy the source file to the destination directory as a file with the same name as the source,
        * replace an existing file with the same name in the destination directory, if any.
@@ -126,14 +126,14 @@ public class AzurePinotFS extends PinotFS {
        */
       Files.copy(adlStream, dstFilePath);
 
-      LOGGER.info("Copied file {} from ADL to {}", srcUri, tempFile);
+      LOGGER.info("Copied file {} from ADL to {}", srcUri, dstFile);
     } catch (Exception ex) {
       throw ex;
     }
   }
 
   @Override
-  public void copyFromLocalFile(URI srcUri, URI dstUri) throws IOException {
+  public void copyFromLocalFile(File srcFile, URI dstUri) throws IOException {
     // TODO: Add this method. Not needed for now because of metadata upload
     throw new UnsupportedOperationException("Cannot copy from local to Azure");
   }

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.filesystem;
 
 import com.google.common.base.Strings;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -119,8 +120,8 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, URI dstUri) throws IOException {
-    hadoopFS.copyToLocalFile(new Path(srcUri), new Path(dstUri));
+  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
+    hadoopFS.copyToLocalFile(new Path(srcUri), new Path(tempFile.toURI()));
   }
 
   @Override

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
@@ -120,13 +120,13 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public void copyToLocalFile(URI srcUri, File tempFile) throws Exception {
-    hadoopFS.copyToLocalFile(new Path(srcUri), new Path(tempFile.toURI()));
+  public void copyToLocalFile(URI srcUri, File dstFile) throws Exception {
+    hadoopFS.copyToLocalFile(new Path(srcUri), new Path(dstFile.toURI()));
   }
 
   @Override
-  public void copyFromLocalFile(URI srcUri, URI dstUri) throws IOException {
-    hadoopFS.copyFromLocalFile(new Path(srcUri), new Path(dstUri));
+  public void copyFromLocalFile(File srcFile, URI dstUri) throws IOException {
+    hadoopFS.copyFromLocalFile(new Path(srcFile.toURI()), new Path(dstUri));
   }
 
   private void authenticate(org.apache.hadoop.conf.Configuration hadoopConf, org.apache.commons.configuration.Configuration configs) {

--- a/pinot-hadoop-filesystem/src/test/java/com/linkedin/pinot/filesystem/test/AzurePinotFSTest.java
+++ b/pinot-hadoop-filesystem/src/test/java/com/linkedin/pinot/filesystem/test/AzurePinotFSTest.java
@@ -72,7 +72,7 @@ public class AzurePinotFSTest {
     MockADLFileInputStream adlFileInputStream = new MockADLFileInputStream(
         new ByteArrayInputStream(Files.readAllBytes(Paths.get(testFileURI))));
     when(adlStoreClient.getReadStream(anyString())).thenReturn(adlFileInputStream);
-    azurePinotFS.copyToLocalFile(testFileURI, file.toURI());
+    azurePinotFS.copyToLocalFile(testFileURI, file);
     Assert.assertTrue(file.exists());
   }
 


### PR DESCRIPTION
* Currently, we use URI. This doesn't make sense because it will always be copied to the local filesystem, so we should use a File object.