### PR TITLE
[PINOT-6845] Provide a controller override for storage quota checks

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -80,6 +80,9 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
   private static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
 
+  private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
+  private static final boolean DEFAULT_STORAGE_QUOTA_CHECK = true;
+
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
   public ControllerConf(File file) throws ConfigurationException {
@@ -392,5 +395,9 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public void setRealtimeSegmentMetadataCommitNumLocks(int realtimeSegmentMetadataCommitNumLocks) {
     setProperty(REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS, realtimeSegmentMetadataCommitNumLocks);
+  }
+
+  public boolean getEnableStorageQuotaCheck() {
+    return getBoolean(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_STORAGE_QUOTA_CHECK);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -702,6 +702,9 @@ public class PinotSegmentUploadRestletResource {
    */
   private StorageQuotaChecker.QuotaCheckerResponse checkStorageQuota(@Nonnull File segmentFile,
       @Nonnull SegmentMetadata metadata, @Nonnull TableConfig offlineTableConfig) throws InvalidConfigException {
+    if (!_controllerConf.getEnableStorageQuotaCheck()) {
+      return StorageQuotaChecker.success("Quota check is disabled");
+    }
     TableSizeReader tableSizeReader = new TableSizeReader(_executor, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager);
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());


### PR DESCRIPTION
Changes include:
- add a controller level config to disable storage quota checks. Enabled by default. Will flip this around when we are ready to reenable the storage checks.
- Use the conf to determine if quota needs to be checked during upload.

Testing done:
Pushed changes to integration test controller and confirmed that quota tests are not done.

Currently there is no test coverage for the APIs. Will look into adding them in subsequent PRs.