### PR TITLE
Revert "Remove using http connection pool in table-size api path

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
 import javax.annotation.Nonnull;
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,13 +73,19 @@ public class MultiGetRequest {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiGetRequest.class);
 
   Executor executor;
+  HttpConnectionManager connectionManager;
 
   /**
    * @param executor executor service to use for making parallel requests
+   * @param connectionManager http connection manager to use.
    */
-  public MultiGetRequest(@Nonnull Executor executor) {
+  public MultiGetRequest(@Nonnull Executor executor,
+      @Nonnull HttpConnectionManager connectionManager) {
     Preconditions.checkNotNull(executor);
+    Preconditions.checkNotNull(connectionManager);
+
     this.executor = executor;
+    this.connectionManager = connectionManager;
   }
 
   /**
@@ -98,7 +105,7 @@ public class MultiGetRequest {
         @Override
         public GetMethod call()
             throws Exception {
-          HttpClient client = new HttpClient();
+          HttpClient client = new HttpClient(connectionManager);
           GetMethod getMethod = new GetMethod(url);
           getMethod.getParams().setSoTimeout(timeoutMs);
           // if all connections in the connection manager are busy this will wait to retrieve a connection

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +107,8 @@ public class MultiGetRequestTest {
 
   @Test
   public void testMultiGet() {
-    MultiGetRequest mget = new MultiGetRequest(Executors.newCachedThreadPool());
+    MultiGetRequest mget = new MultiGetRequest(Executors.newCachedThreadPool(),
+        new MultiThreadedHttpConnectionManager());
     List<String> urls = Arrays.asList("http://localhost:" + String.valueOf(portStart) + URI_PATH,
         "http://localhost:" + String.valueOf(portStart + 1) + URI_PATH,
         "http://localhost:" + String.valueOf(portStart + 2) + URI_PATH,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -46,6 +46,8 @@ import java.io.OutputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.task.TaskDriver;
@@ -182,6 +184,8 @@ public class ControllerStarter {
 
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");
+    final MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+    connectionManager.getParams().setConnectionTimeout(_config.getServerAdminRequestTimeoutSeconds() * 1000);
     // register all the controller objects for injection to jersey resources
     _adminApp.registerBinder(new AbstractBinder() {
       @Override
@@ -190,6 +194,7 @@ public class ControllerStarter {
         bind(_helixResourceManager).to(PinotHelixResourceManager.class);
         bind(_helixTaskResourceManager).to(PinotHelixTaskResourceManager.class);
         bind(_taskManager).to(PinotTaskManager.class);
+        bind(connectionManager).to(HttpConnectionManager.class);
         bind(_executorService).to(Executor.class);
         bind(_controllerMetrics).to(ControllerMetrics.class);
         bind(accessControlFactory).to(AccessControlFactory.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -79,6 +79,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.helix.ZNRecord;
@@ -108,6 +109,9 @@ public class PinotSegmentUploadRestletResource {
 
   @Inject
   ControllerMetrics _controllerMetrics;
+
+  @Inject
+  HttpConnectionManager _connectionManager;
 
   @Inject
   Executor _executor;
@@ -705,7 +709,7 @@ public class PinotSegmentUploadRestletResource {
     if (!_controllerConf.getEnableStorageQuotaCheck()) {
       return StorageQuotaChecker.success("Quota check is disabled");
     }
-    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _pinotHelixResourceManager);
+    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager);
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());
     return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName, metadata.getName(),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import org.apache.commons.httpclient.ConnectTimeoutException;
 import org.apache.commons.httpclient.ConnectionPoolTimeoutException;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -46,9 +47,11 @@ public class ServerTableSizeReader {
       ServerTableSizeReader.class);
 
   private final Executor executor;
+  private final HttpConnectionManager connectionManager;
 
-  public ServerTableSizeReader(Executor executor) {
+  public ServerTableSizeReader(Executor executor, HttpConnectionManager connectionManager) {
     this.executor = executor;
+    this.connectionManager = connectionManager;
   }
 
   public Map<String, List<SegmentSizeInfo>> getSizeDetailsFromServers(BiMap<String, String> serverEndPoints,
@@ -61,7 +64,7 @@ public class ServerTableSizeReader {
       serverUrls.add(tableSizeUri);
     }
 
-    MultiGetRequest mget = new MultiGetRequest(executor);
+    MultiGetRequest mget = new MultiGetRequest(executor, connectionManager);
     LOGGER.info("Reading segment sizes from {} servers for table: {}, timeoutMsec: {}", serverUrls.size(), table, timeoutMsec);
     CompletionService<GetMethod> completionService = mget.execute(serverUrls, timeoutMsec);
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
@@ -33,6 +33,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,8 @@ public class TableSize {
   PinotHelixResourceManager _pinotHelixResourceManager;
   @Inject
   Executor _executor;
+  @Inject
+  HttpConnectionManager _connectionManager;
 
   @GET
   @Path("/tables/{tableName}/size")
@@ -63,7 +66,7 @@ public class TableSize {
           @QueryParam("detailed") boolean detailed
   ) {
     TableSizeReader
-        tableSizeReader = new TableSizeReader(_executor, _pinotHelixResourceManager);
+        tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
     TableSizeReader.TableSizeDetails tableSizeDetails = null;
     try {
       tableSizeDetails = tableSizeReader.getTableSizeDetails(tableName,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
@@ -78,7 +80,8 @@ public class SegmentStatusChecker {
     _segmentStatusIntervalSeconds = config.getStatusCheckerFrequencyInSeconds();
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _metricsRegistry = metricsRegistry;
-    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), _pinotHelixResourceManager);
+    HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
+    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), httpConnectionManager, _pinotHelixResourceManager);
 
     _executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
       @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -44,11 +45,13 @@ import javax.annotation.Nullable;
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
   private Executor _executor;
+  private HttpConnectionManager _connectionManager;
   private PinotHelixResourceManager _helixResourceManager;
 
-  public TableSizeReader(Executor executor,
+  public TableSizeReader(Executor executor, HttpConnectionManager connectionManager,
       PinotHelixResourceManager helixResourceManager) {
     _executor = executor;
+    _connectionManager = connectionManager;
     _helixResourceManager = helixResourceManager;
   }
 
@@ -140,7 +143,7 @@ public class TableSizeReader {
     // get list of servers
     Map<String, List<String>> serverSegmentsMap =
         _helixResourceManager.getInstanceToSegmentsInATableMap(table);
-    ServerTableSizeReader serverTableSizeReader = new ServerTableSizeReader(_executor);
+    ServerTableSizeReader serverTableSizeReader = new ServerTableSizeReader(_executor, _connectionManager);
     BiMap<String, String> endpoints = _helixResourceManager.getDataInstanceAdminEndpoints(serverSegmentsMap.keySet());
     Map<String, List<SegmentSizeInfo>> serverSizeInfo =
         serverTableSizeReader.getSizeDetailsFromServers(endpoints, table, timeoutMsec);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -44,6 +46,7 @@ public class ServerTableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(3);
+  private final HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
   private final int serverPortStart = 10000;
   private final String URI_PATH = "/table/";
   private final List<HttpServer> servers = new ArrayList<>();
@@ -141,7 +144,7 @@ public class ServerTableSizeReaderTest {
 
   @Test
   public void testServerSizeReader() {
-    ServerTableSizeReader reader = new ServerTableSizeReader(executor);
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
     BiMap<String, String> endpoints = HashBiMap.create();
     for (int i = 0; i < 2; i++) {
       endpoints.put(serverList.get(i), endpointList.get(i));
@@ -160,7 +163,7 @@ public class ServerTableSizeReaderTest {
 
   @Test
   public void testServerSizesErrors() {
-    ServerTableSizeReader reader = new ServerTableSizeReader(executor);
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
     BiMap<String, String> endpoints = HashBiMap.create();
     for (int i = 0; i < serverCount; i++) {
       endpoints.put(serverList.get(i), endpointList.get(i));

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -53,6 +55,7 @@ import static org.mockito.Mockito.*;
 public class TableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReaderTest.class);
   private final Executor executor = Executors.newFixedThreadPool(1);
+  private final HttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
 
   private PinotHelixResourceManager helix;
   private Map<String, FakeSizeServer> serverMap = new HashMap<>();
@@ -216,7 +219,7 @@ public class TableSizeReaderTest {
 
   @Test
   public void testNoSuchTable() throws InvalidConfigException {
-    TableSizeReader reader = new TableSizeReader(executor, helix);
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
     Assert.assertNull(reader.getTableSizeDetails("mytable", 5000));
   }
 
@@ -240,7 +243,7 @@ public class TableSizeReaderTest {
           }
         });
 
-    TableSizeReader reader = new TableSizeReader(executor, helix);
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
     return reader.getTableSizeDetails(table, timeoutMsec);
   }
 


### PR DESCRIPTION
This reverts commit d4fb2e0cb4c6c1bee69aa6452e4690e30f308829.

As silly as this sounds, this commit was based on an incorrect log line :(. Will fix the logs in another PR.

Also, turns out that we don't have any limits on the thread-pool used for making out bound connections, so removing the connection pool as well results in unbounded connections being made.