### PR TITLE
Fix error logs in ServerTableSizeReader

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -69,7 +69,6 @@ public class ServerTableSizeReader {
 
     for (int i = 0; i < serverUrls.size(); i++) {
       GetMethod getMethod = null;
-      String url = serverUrls.get(i);
       try {
         getMethod = completionService.take().get();
         URI uri = getMethod.getURI();
@@ -81,19 +80,19 @@ public class ServerTableSizeReader {
         TableSizeInfo tableSizeInfo = new ObjectMapper().readValue(getMethod.getResponseBodyAsString(), TableSizeInfo.class);
         serverSegmentSizes.put(instance, tableSizeInfo.segments);
       } catch (InterruptedException e) {
-        LOGGER.warn("Interrupted exception while reading segment size for table: {}. Server: {}", table, url, e);
+        LOGGER.warn("Interrupted exception while reading segment size for table: {}", table, e);
       } catch (ExecutionException e) {
         if (Throwables.getRootCause(e) instanceof SocketTimeoutException) {
-          LOGGER.warn("Server request to read table size was timed out for table: {}. Server: {}", table, url, e);
+          LOGGER.warn("Server request to read table size was timed out for table: {}.", table, e);
         } else if (Throwables.getRootCause(e) instanceof ConnectTimeoutException) {
-          LOGGER.warn("Server request to read table size timed out waiting for connection. table: {}. Server: {}", table, url, e);
+          LOGGER.warn("Server request to read table size timed out waiting for connection. table: {}.", table, e);
         } else if (Throwables.getRootCause(e) instanceof ConnectionPoolTimeoutException) {
-          LOGGER.warn("Server request to read table size timed out on getting a connection from pool, table: {}. Server: {}", table, url, e);
+          LOGGER.warn("Server request to read table size timed out on getting a connection from pool, table: {}.", table, e);
         } else {
-          LOGGER.warn("Execution exception while reading segment sizes for table: {}. Server: {}", table, url, e);
+          LOGGER.warn("Execution exception while reading segment sizes for table: {}.", table, e);
         }
       } catch(Exception e) {
-        LOGGER.warn("Error while reading segment sizes for table: {}. Server: {}", table, url);
+        LOGGER.warn("Error while reading segment sizes for table: {}", table);
       } finally {
         if (getMethod != null) {
           getMethod.releaseConnection();


### PR DESCRIPTION
When we encounter exception while retrieving the result of a http call via completion service, we don't have a good way of determining the server uri of the original request. The earlier code used the loop counter to figure out the server, which has nothing to do with the task that the completion service can return.

This change removes the server ids from the logs as the current logs are incorrect.