### PR TITLE
[TE] frontend - calculate precision/recall stats from anomaly feedback classification

### DIFF
--- a/thirdeye/thirdeye-frontend/app/models/anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/models/anomalies.js
@@ -13,6 +13,7 @@ export default DS.Model.extend({
   metricId: DS.attr(),
   functionName: DS.attr(),
   functionId: DS.attr(),
-  dataset: DS.attr()
+  dataset: DS.attr(),
+  classification: DS.attr()
 });
 //DEMO: avoidTheSharedObject: attr('object', { defaultValue: () => {} })

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/route.js
@@ -82,10 +82,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
     return new RSVP.Promise(async (resolve, reject) => {
       try {
         const anomalyMapping = appName ? await this.get('_getAnomalyMapping').perform(model) : [];//DEMO:
-        const anomalyPerformance = appName ? await this.get('anomaliesApiService').queryPerformanceByAppNameUrl(appName, moment(this.get('startDate')).startOf('day').utc().format(), moment(this.get('endDate')).startOf('day').utc().format()) : [];
         const defaultParams = {
           anomalyMapping,
-          anomalyPerformance,
           appName,
           startDate,
           endDate,

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
@@ -45,6 +45,9 @@ const HumanizedAnomaly = EmberObject.extend({// ex: record.humanizedChangeDispla
   }),
   queryEnd: computed('humanizedObject.queryEnd', function() {
     return get(this, 'humanizedObject.queryEnd');
+  }),
+  classification: computed('anomaly.classification', function () {
+    return get(this, 'anomaly.classification');
   })
 });
 
@@ -138,30 +141,5 @@ export default Service.extend({
     const anomalies = await queryCache.query(modelName, query, { reload: false, cacheKey: queryCache.urlForQueryKey(modelName, query) });
     return anomalies;
   },
-
-  /**
-   * @summary Fetch the application performance details
-   * @method queryPerformanceByAppNameUrl
-   * @param {String} appName - the application name
-   * @param {Number} startStamp - the anomaly iso start time
-   * @param {Number} endStamp - the anomaly iso end time
-   * @return {Ember.RSVP.Promise}
-   * @example: /detection-job/eval/application/{someAppName}?start={2017-09-01T00:00:00Z}&end={2018-04-01T00:00:00Z}
-     usage: `this.get('anomaliesApiService').queryPerformanceByAppNameUrl(appName, moment(this.get('startDate')).startOf('day').utc().format(), moment(this.get('endDate')).startOf('day').utc().format());`
-   */
-  async queryPerformanceByAppNameUrl(appName, start, end) {
-    assert('you must pass appName param as an required argument.', appName);
-    assert('you must pass start param as an required argument.', start);
-    assert('you must pass end param as an required argument.', end);
-
-    const queryCache = this.get('queryCache');
-    const modelName = 'performance';
-    const query = { appName, start, end };
-    const cacheKey = queryCache.urlForQueryKey(modelName, query);
-    const performanceInfo = await queryCache.query(modelName, query, { reload: false, cacheKey });
-    return EmberObject.create(performanceInfo.meta);//Wrap it in an ember object for easier usage later (get/set etc).
-    // const url = anomalyApiUrls.getPerformanceByAppNameUrl(appName, startTime, endTime) ;//TODO: remove from the utils/api/anomaly.js
-    // return fetch(url).then(checkStatus).catch(() => {});//TODO: leave to document in RFC. Will remove. - lohuynh
-  }
 
 });


### PR DESCRIPTION
This PR changes the way of calculating precision/recall stats in the dashboard. Instead of calling an endpoint, it calculates it in the frontend based on the anomaly feedback classification.