### PR TITLE
[PINOT-6856]: Fix controller storage check logic when it is unable to get reports from servers

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
@@ -42,7 +42,9 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   TABLE_QUOTA("TableQuotaBasedOnTableConfig", false), // Table quota based on setting in table config.
 
-  TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false); // Table storage quota utilization.
+  TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false), // Table storage quota utilization.
+  TABLE_STORAGE_ESTIMATION_FAILURE("TableStorageEstimationFailure", false), // Table storage estimation failure.
+  TABLE_STORAGE_ESTIMATION_PARTIAL("TableStorageEstimationPartial", false); // partial estimation of table storage
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
@@ -43,8 +43,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   TABLE_QUOTA("TableQuotaBasedOnTableConfig", false), // Table quota based on setting in table config.
 
   TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false), // Table storage quota utilization.
-  TABLE_STORAGE_ESTIMATION_FAILURE("TableStorageEstimationFailure", false), // Table storage estimation failure.
-  TABLE_STORAGE_EST_FAILED_SEGMENTS("TableStorageEstFailedSegments", false); // number fo segments we failed to get size for
+  TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false); // percentage of segments we failed to get size for
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerGauge.java
@@ -44,7 +44,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false), // Table storage quota utilization.
   TABLE_STORAGE_ESTIMATION_FAILURE("TableStorageEstimationFailure", false), // Table storage estimation failure.
-  TABLE_STORAGE_ESTIMATION_PARTIAL("TableStorageEstimationPartial", false); // partial estimation of table storage
+  TABLE_STORAGE_EST_FAILED_SEGMENTS("TableStorageEstFailedSegments", false); // number fo segments we failed to get size for
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -709,7 +709,8 @@ public class PinotSegmentUploadRestletResource {
     if (!_controllerConf.getEnableStorageQuotaCheck()) {
       return StorageQuotaChecker.success("Quota check is disabled");
     }
-    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
+    TableSizeReader tableSizeReader = new TableSizeReader(_executor, _connectionManager,
+        _controllerMetrics, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _pinotHelixResourceManager);
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());
     return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName, metadata.getName(),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/TableSize.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.util.TableSizeReader;
@@ -51,6 +52,8 @@ public class TableSize {
   @Inject
   HttpConnectionManager _connectionManager;
 
+  @Inject ControllerMetrics _controllerMetrics;
+
   @GET
   @Path("/tables/{tableName}/size")
   @Produces(MediaType.APPLICATION_JSON)
@@ -66,7 +69,8 @@ public class TableSize {
           @QueryParam("detailed") boolean detailed
   ) {
     TableSizeReader
-        tableSizeReader = new TableSizeReader(_executor, _connectionManager, _pinotHelixResourceManager);
+        tableSizeReader = new TableSizeReader(_executor, _connectionManager,
+        _controllerMetrics, _pinotHelixResourceManager);
     TableSizeReader.TableSizeDetails tableSizeDetails = null;
     try {
       tableSizeDetails = tableSizeReader.getTableSizeDetails(tableName,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -81,7 +81,8 @@ public class SegmentStatusChecker {
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _metricsRegistry = metricsRegistry;
     HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
-    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), httpConnectionManager, _pinotHelixResourceManager);
+    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), httpConnectionManager,
+        _metricsRegistry, _pinotHelixResourceManager);
 
     _executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
       @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.controller.util.TableSizeReader;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -62,7 +61,6 @@ public class SegmentStatusChecker {
   private final HelixAdmin _helixAdmin;
   private final long _segmentStatusIntervalSeconds;
   private final int _waitForPushTimeSeconds;
-  private final TableSizeReader _tableSizeReader;
 
   // log messages about disabled tables atmost once a day
   private static final long DISABLED_TABLE_LOG_INTERVAL_MS = TimeUnit.DAYS.toMillis(1);
@@ -81,8 +79,6 @@ public class SegmentStatusChecker {
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
     _metricsRegistry = metricsRegistry;
     HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
-    _tableSizeReader = new TableSizeReader(Executors.newCachedThreadPool(), httpConnectionManager,
-        _metricsRegistry, _pinotHelixResourceManager);
 
     _executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
       @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -220,7 +220,7 @@ public class TableSizeReader {
     if (subTypeSizeDetails.missingSegments > 0) {
       int totalSegments = subTypeSizeDetails.segments.size();
       int missingPercent = totalSegments == 0 ? 0 : subTypeSizeDetails.missingSegments * 100 / totalSegments;
-      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT,
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT,
           missingPercent);
       if (subTypeSizeDetails.missingSegments == totalSegments) {
         LOGGER.warn("Could not get size reports from any server for all segments of the table {}", table);
@@ -231,7 +231,7 @@ public class TableSizeReader {
             totalSegments, table);
       }
     } else {
-      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT,
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT,
           0);
     }
     return subTypeSizeDetails;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -218,29 +218,20 @@ public class TableSizeReader {
       }
     }
     if (subTypeSizeDetails.missingSegments > 0) {
-      if (subTypeSizeDetails.missingSegments == subTypeSizeDetails.segments.size()) {
+      int totalSegments = subTypeSizeDetails.segments.size();
+      int missingPercent = totalSegments == 0 ? 0 : subTypeSizeDetails.missingSegments * 100 / totalSegments;
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT,
+          missingPercent);
+      if (subTypeSizeDetails.missingSegments == totalSegments) {
         LOGGER.warn("Could not get size reports from any server for all segments of the table {}", table);
         subTypeSizeDetails.reportedSizeInBytes = -1;
         subTypeSizeDetails.estimatedSizeInBytes = -1;
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
-            1);
-        // reset metric tracking partial estimation
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
-            0);
-
       } else {
         LOGGER.warn("Missing size report for {} out of {} segments for table {}", subTypeSizeDetails.missingSegments,
-            subTypeSizeDetails.segments.size(), table);
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
-            subTypeSizeDetails.missingSegments);
-        // reset metric tracking failure
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
-            0);
+            totalSegments, table);
       }
     } else {
-      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
-          0);
-      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT,
           0);
     }
     return subTypeSizeDetails;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableSizeReader.java
@@ -225,18 +225,23 @@ public class TableSizeReader {
         _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
             1);
         // reset metric tracking partial estimation
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL,
+        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
             0);
 
       } else {
         LOGGER.warn("Missing size report for {} out of {} segments for table {}", subTypeSizeDetails.missingSegments,
             subTypeSizeDetails.segments.size(), table);
-        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL,
-            1);
+        _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
+            subTypeSizeDetails.missingSegments);
         // reset metric tracking failure
         _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
             0);
       }
+    } else {
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE,
+          0);
+      _controllerMetrics.setValueOfTableGauge(table, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS,
+          0);
     }
     return subTypeSizeDetails;
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -329,7 +329,7 @@ public class TableSizeReaderTest {
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, offlineSizes.estimatedSizeInBytes);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
     Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType,
-        ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 0);
+        ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT), 0);
   }
 
   @Test
@@ -344,7 +344,8 @@ public class TableSizeReaderTest {
     Assert.assertEquals(offlineSizes.reportedSizeInBytes, -1);
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, -1);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 100);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType,
+        ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT), 100);
   }
 
   @Test
@@ -359,7 +360,8 @@ public class TableSizeReaderTest {
     validateTableSubTypeSize(servers, offlineSizes);
     Assert.assertNull(tableSizeDetails.realtimeSegments);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 20);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType,
+        ControllerGauge.TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT), 20);
   }
 
   @Test

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -317,7 +317,8 @@ public class TableSizeReaderTest {
   @Test
   public void testGetTableSubTypeSizeAllSuccess() throws InvalidConfigException {
     final String[] servers = { "server0", "server1"};
-    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "offline");
+    String table = "offline";
+    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, table);
     TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
     Assert.assertNotNull(offlineSizes);
     Assert.assertEquals(offlineSizes.segments.size(), 4);
@@ -326,6 +327,9 @@ public class TableSizeReaderTest {
     Assert.assertNull(tableSizeDetails.realtimeSegments);
     Assert.assertEquals(tableSizeDetails.reportedSizeInBytes, offlineSizes.reportedSizeInBytes);
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, offlineSizes.estimatedSizeInBytes);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 0);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 0);
   }
 
   @Test
@@ -341,7 +345,7 @@ public class TableSizeReaderTest {
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, -1);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
     Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 1);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL), 0);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 0);
   }
 
   @Test
@@ -355,7 +359,7 @@ public class TableSizeReaderTest {
     validateTableSubTypeSize(servers, offlineSizes);
     Assert.assertNull(tableSizeDetails.realtimeSegments);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL), 1);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 1);
     Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 0);
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -18,7 +18,10 @@ package com.linkedin.pinot.controller.api.resources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.exception.InvalidConfigException;
+import com.linkedin.pinot.common.metrics.ControllerGauge;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
 import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -26,6 +29,7 @@ import com.linkedin.pinot.controller.util.TableSizeReader;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -56,7 +60,7 @@ public class TableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReaderTest.class);
   private final Executor executor = Executors.newFixedThreadPool(1);
   private final HttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
-
+  private final ControllerMetrics _controllerMetrics = new ControllerMetrics(new MetricsRegistry());
   private PinotHelixResourceManager helix;
   private Map<String, FakeSizeServer> serverMap = new HashMap<>();
   private final String URI_PATH = "/table/";
@@ -86,7 +90,7 @@ public class TableSizeReaderTest {
 
     int counter = 0;
     // server0
-    FakeSizeServer s = new FakeSizeServer(Arrays.asList("s1","s2", "s3"));
+    FakeSizeServer s = new FakeSizeServer(Arrays.asList("s2", "s3", "s6"));
     s.start(URI_PATH, createHandler(200, s.sizes, 0));
     serverMap.put(serverName(counter), s);
     ++counter;
@@ -116,7 +120,7 @@ public class TableSizeReaderTest {
     ++counter;
 
     // server5 ... timing out server
-    s = new FakeSizeServer(Arrays.asList("s3","s5"));
+    s = new FakeSizeServer(Arrays.asList("s1", "s3"));
     s.start(URI_PATH, createHandler(200, s.sizes, timeoutMsec * 100));
     serverMap.put(serverName(counter), s);
     ++counter;
@@ -219,7 +223,8 @@ public class TableSizeReaderTest {
 
   @Test
   public void testNoSuchTable() throws InvalidConfigException {
-    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager,
+        _controllerMetrics, helix);
     Assert.assertNull(reader.getTableSizeDetails("mytable", 5000));
   }
 
@@ -243,7 +248,8 @@ public class TableSizeReaderTest {
           }
         });
 
-    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager,
+        _controllerMetrics, helix);
     return reader.getTableSizeDetails(table, timeoutMsec);
   }
 
@@ -297,13 +303,14 @@ public class TableSizeReaderTest {
             expectedServers.size() * expectedSegmentSize);
       } else {
         Assert.assertEquals(segmentDetails.reportedSizeInBytes, -1);
-        Assert.assertTrue(segmentDetails.estimatedSizeInBytes > 0);
+        Assert.assertEquals(segmentDetails.estimatedSizeInBytes, -1);
       }
     }
     Assert.assertEquals(tableSize.reportedSizeInBytes, reportedSize);
     Assert.assertEquals(tableSize.estimatedSizeInBytes, estimatedSize);
     if (hasErrors) {
       Assert.assertTrue(tableSize.reportedSizeInBytes != tableSize.estimatedSizeInBytes);
+      Assert.assertTrue(tableSize.missingSegments > 0);
     }
   }
 
@@ -322,14 +329,34 @@ public class TableSizeReaderTest {
   }
 
   @Test
+  public void testGetTableSubTypeSizeAllErrors() throws InvalidConfigException {
+    final String[] servers = { "server2", "server5"};
+    String table = "offline";
+    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, table);
+    TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
+    Assert.assertNotNull(offlineSizes);
+    Assert.assertEquals(offlineSizes.missingSegments, 3);
+    Assert.assertEquals(offlineSizes.segments.size(), 3);
+    Assert.assertEquals(offlineSizes.reportedSizeInBytes, -1);
+    Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, -1);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 1);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL), 0);
+  }
+
+  @Test
   public void testGetTableSubTypeSizesWithErrors() throws InvalidConfigException {
     final String[] servers = { "server0", "server1", "server2", "server5"};
+    String table = "offline";
     TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "offline");
     TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
     Assert.assertEquals(offlineSizes.segments.size(), 5);
     Assert.assertTrue(offlineSizes.reportedSizeInBytes != offlineSizes.estimatedSizeInBytes);
     validateTableSubTypeSize(servers, offlineSizes);
     Assert.assertNull(tableSizeDetails.realtimeSegments);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_PARTIAL), 1);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 0);
   }
 
   @Test

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -328,8 +328,8 @@ public class TableSizeReaderTest {
     Assert.assertEquals(tableSizeDetails.reportedSizeInBytes, offlineSizes.reportedSizeInBytes);
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, offlineSizes.estimatedSizeInBytes);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 0);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 0);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType,
+        ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 0);
   }
 
   @Test
@@ -344,8 +344,7 @@ public class TableSizeReaderTest {
     Assert.assertEquals(offlineSizes.reportedSizeInBytes, -1);
     Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, -1);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 1);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 0);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 100);
   }
 
   @Test
@@ -355,12 +354,12 @@ public class TableSizeReaderTest {
     TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "offline");
     TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
     Assert.assertEquals(offlineSizes.segments.size(), 5);
+    Assert.assertEquals(offlineSizes.missingSegments, 1);
     Assert.assertTrue(offlineSizes.reportedSizeInBytes != offlineSizes.estimatedSizeInBytes);
     validateTableSubTypeSize(servers, offlineSizes);
     Assert.assertNull(tableSizeDetails.realtimeSegments);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(table);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_EST_FAILED_SEGMENTS), 1);
-    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_ESTIMATION_FAILURE), 0);
+    Assert.assertEquals(_controllerMetrics.getValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_STORAGE_MISSING_SEGMENT_PERCENT), 20);
   }
 
   @Test


### PR DESCRIPTION
Currently, when the controller fails to get a segment size report from any replica for a given segment, it falls back to using the table-level max. The problem with that is that for highly skewed tables, we can overestimate by a lot and cause segment uploads to fail.

It appears that it might be safer to let the upload go through in such cases, than try to extrapolate sizes based on existing sizes. Depending on which segments we actually get reports back from using, mix/max/average/median etc can always be vulnerable to overestimation.

With this change, we skip segments where we have no report from any replica. For segments that have report from some, but not all, we fill in for the other replicas using the segment-level-max (it should be extremely rare that replicas report different sizes for segments!)

Changes include:
- Firing off a metric when we skip quota enforcement when we don't hear back from any server at all.
- Firing off a metric when we go through with quota enforcement with partial reports. We still go through with the check as it can help catch cases where the table is already over quota even with the existing reports.
- Added a missingSegments count to track how many segments we don't have reports for at all.
- Fixed test to add coverage for missing segments.