### PR TITLE
Reduce heap usage during segment builds

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -41,7 +41,6 @@ import org.apache.commons.codec.binary.Hex;
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLifecycleAware {
-
   private static final Integer DEFAULT_DIMENSION_NULL_VALUE_OF_INT = Integer.MIN_VALUE;
   private static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_LONG = Long.MIN_VALUE;
   private static final Float DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT = Float.NEGATIVE_INFINITY;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -21,10 +21,8 @@ import com.google.gson.JsonPrimitive;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.config.ConfigNodeLifecycleAware;
-import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
-import java.nio.charset.Charset;
 import javax.annotation.Nonnull;
 import org.apache.avro.Schema.Type;
 import org.apache.commons.codec.DecoderException;
@@ -43,7 +41,6 @@ import org.apache.commons.codec.binary.Hex;
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLifecycleAware {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private static final Integer DEFAULT_DIMENSION_NULL_VALUE_OF_INT = Integer.MIN_VALUE;
   private static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_LONG = Long.MIN_VALUE;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSchema.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
 
@@ -30,7 +29,6 @@ import javax.annotation.Nonnull;
  * The <code>DataSchema</code> class describes the schema of {@link DataTable}.
  */
 public class DataSchema {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private String[] _columnNames;
   private ColumnDataType[] _columnDataTypes;
@@ -121,7 +119,7 @@ public class DataSchema {
 
     // Write the column names.
     for (String columnName : _columnNames) {
-      byte[] bytes = columnName.getBytes(UTF_8);
+      byte[] bytes = StringUtil.encodeUtf8(columnName);
       dataOutputStream.writeInt(bytes.length);
       dataOutputStream.write(bytes);
     }
@@ -130,7 +128,7 @@ public class DataSchema {
     for (ColumnDataType columnDataType : _columnDataTypes) {
       // We don't want to use ordinal of the enum since adding a new data type will break things if server and broker
       // use different versions of DataType class.
-      byte[] bytes = columnDataType.name().getBytes(UTF_8);
+      byte[] bytes = StringUtil.encodeUtf8(columnDataType.name());
       dataOutputStream.writeInt(bytes.length);
       dataOutputStream.write(bytes);
     }
@@ -154,7 +152,7 @@ public class DataSchema {
       byte[] bytes = new byte[length];
       readLength = dataInputStream.read(bytes);
       assert readLength == length;
-      columnNames[i] = new String(bytes, UTF_8);
+      columnNames[i] = StringUtil.decodeUtf8(bytes);
     }
 
     // Read the column types.
@@ -163,7 +161,7 @@ public class DataSchema {
       byte[] bytes = new byte[length];
       readLength = dataInputStream.read(bytes);
       assert readLength == length;
-      columnDataTypes[i] = ColumnDataType.valueOf(new String(bytes, UTF_8));
+      columnDataTypes[i] = ColumnDataType.valueOf(StringUtil.decodeUtf8(bytes));
     }
 
     return new DataSchema(columnNames, columnDataTypes);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSchema.java
@@ -29,7 +29,6 @@ import javax.annotation.Nonnull;
  * The <code>DataSchema</code> class describes the schema of {@link DataTable}.
  */
 public class DataSchema {
-
   private String[] _columnNames;
   private ColumnDataType[] _columnDataTypes;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
@@ -15,12 +15,14 @@
  */
 package com.linkedin.pinot.common.utils;
 
+import java.io.UnsupportedEncodingException;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 
 
 public class StringUtil {
   private static final char NULL_CHARACTER = '\0';
+  private static String charSet = "UTF-8";
 
   /**
    * Joins the given keys with the separator.
@@ -53,5 +55,25 @@ public class StringUtil {
       }
     }
     return new String(chars, 0, index);
+  }
+
+  public static byte[] encodeUtf8(String s) {
+    try {
+      return s.getBytes(charSet);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String decodeUtf8(byte[] bytes) {
+    return decodeUtf8(bytes, 0, bytes.length);
+  }
+
+  public static String decodeUtf8(byte[] bytes, int startIndex, int endIndex) {
+    try {
+      return new String(bytes, startIndex, endIndex, charSet);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 
 public class StringUtil {
   private static final char NULL_CHARACTER = '\0';
-  private static String charSet = "UTF-8";
+  private static final String charSet = "UTF-8";
 
   /**
    * Joins the given keys with the separator.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
@@ -18,13 +18,13 @@ package com.linkedin.pinot.core.common.datatable;
 import com.linkedin.pinot.common.response.ProcessingException;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.common.utils.StringUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.StringUtils;
 
 public class DataTableImplV2 implements DataTable {
   private static final int VERSION = 2;
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   // VERSION
   // NUM_ROWS
@@ -212,7 +211,7 @@ public class DataTableImplV2 implements DataTable {
       byte[] buffer = new byte[length];
       int numBytesRead = dataInputStream.read(buffer);
       assert numBytesRead == length;
-      return new String(buffer, UTF_8);
+      return StringUtil.decodeUtf8(buffer);
     }
   }
 
@@ -302,14 +301,14 @@ public class DataTableImplV2 implements DataTable {
     for (Entry<String, Map<Integer, String>> dictionaryMapEntry : _dictionaryMap.entrySet()) {
       String columnName = dictionaryMapEntry.getKey();
       Map<Integer, String> dictionary = dictionaryMapEntry.getValue();
-      byte[] bytes = columnName.getBytes(UTF_8);
+      byte[] bytes = StringUtil.encodeUtf8(columnName);
       dataOutputStream.writeInt(bytes.length);
       dataOutputStream.write(bytes);
       dataOutputStream.writeInt(dictionary.size());
 
       for (Entry<Integer, String> dictionaryEntry : dictionary.entrySet()) {
         dataOutputStream.writeInt(dictionaryEntry.getKey());
-        byte[] valueBytes = dictionaryEntry.getValue().getBytes(UTF_8);
+        byte[] valueBytes = StringUtil.encodeUtf8(dictionaryEntry.getValue());
         dataOutputStream.writeInt(valueBytes.length);
         dataOutputStream.write(valueBytes);
       }
@@ -324,11 +323,11 @@ public class DataTableImplV2 implements DataTable {
 
     dataOutputStream.writeInt(_metadata.size());
     for (Entry<String, String> entry : _metadata.entrySet()) {
-      byte[] keyBytes = entry.getKey().getBytes(UTF_8);
+      byte[] keyBytes = StringUtil.encodeUtf8(entry.getKey());
       dataOutputStream.writeInt(keyBytes.length);
       dataOutputStream.write(keyBytes);
 
-      byte[] valueBytes = entry.getValue().getBytes(UTF_8);
+      byte[] valueBytes = StringUtil.encodeUtf8(entry.getValue());
       dataOutputStream.writeInt(valueBytes.length);
       dataOutputStream.write(valueBytes);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.common.datatable;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.clearspring.analytics.stream.quantile.TDigest;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.AvgPair;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.QuantileDigest;
@@ -29,7 +30,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -42,7 +42,6 @@ public class ObjectCustomSerDe {
   private ObjectCustomSerDe() {
   }
 
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   /**
    * Given an object, serialize it into a byte array.
@@ -51,7 +50,7 @@ public class ObjectCustomSerDe {
   @Nonnull
   public static byte[] serialize(@Nonnull Object object) throws IOException {
     if (object instanceof String) {
-      return ((String) object).getBytes("UTF-8");
+      return StringUtil.encodeUtf8((String) object);
     } else if (object instanceof Long) {
       return serializeLong((Long) object);
     } else if (object instanceof Double) {
@@ -85,7 +84,7 @@ public class ObjectCustomSerDe {
   public static <T> T deserialize(@Nonnull byte[] bytes, @Nonnull ObjectType objectType) throws IOException {
     switch (objectType) {
       case String:
-        return (T) new String(bytes, UTF_8);
+        return (T) StringUtil.decodeUtf8(bytes);
       case Long:
         return (T) new Long(ByteBuffer.wrap(bytes).getLong());
       case Double:
@@ -120,7 +119,7 @@ public class ObjectCustomSerDe {
     switch (objectType) {
       case String:
         byte[] bytes = getBytesFromByteBuffer(byteBuffer);
-        return (T) new String(bytes, UTF_8);
+        return (T) StringUtil.decodeUtf8(bytes);
       case Long:
         return (T) new Long(byteBuffer.getLong());
       case Double:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
@@ -16,16 +16,15 @@
 package com.linkedin.pinot.core.data;
 
 import com.linkedin.pinot.common.data.RowEvent;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
+import com.linkedin.pinot.common.utils.StringUtil;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 
 
 /**
@@ -111,7 +110,7 @@ public class GenericRow implements RowEvent {
   public byte[] toBytes() throws IOException {
     StringWriter writer = new StringWriter();
     OBJECT_MAPPER.writeValue(writer, _fieldMap);
-    return writer.toString().getBytes(Charset.forName("UTF-8"));
+    return StringUtil.encodeUtf8(writer.toString());
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/MurmurPartitionFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/MurmurPartitionFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.data.partition;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.StringUtil;
 import org.apache.kafka.common.utils.Utils;
-import java.nio.charset.Charset;
 
 
 /**
@@ -32,7 +32,6 @@ import java.nio.charset.Charset;
  */
 public class MurmurPartitionFunction implements PartitionFunction {
   private static final String NAME = "Murmur";
-  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
   private final int _numPartitions;
 
   /**
@@ -47,7 +46,7 @@ public class MurmurPartitionFunction implements PartitionFunction {
   @Override
   public int getPartition(Object valueIn) {
     String value = (valueIn instanceof String) ? (String) valueIn : valueIn.toString();
-    return (Utils.murmur2((value).getBytes(UTF8_CHARSET)) & 0x7fffffff) % _numPartitions;
+    return (Utils.murmur2(StringUtil.encodeUtf8(value)) & 0x7fffffff) % _numPartitions;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.core.io.reader.impl;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +158,7 @@ public class FixedByteSingleValueMultiColReader implements Closeable {
    * @return
    */
   public String getString(int row, int col) {
-    return new String(getBytes(row, col), Charset.forName("UTF-8"));
+    return StringUtil.decodeUtf8(getBytes(row, col));
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
@@ -15,11 +15,11 @@
  */
 package com.linkedin.pinot.core.io.reader.impl.v1;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.io.reader.impl.ChunkReaderContext;
 import com.linkedin.pinot.core.io.writer.impl.v1.VarByteChunkSingleValueWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 
 
 /**
@@ -27,7 +27,6 @@ import java.nio.charset.Charset;
  * For data layout, please refer to the documentation for {@link VarByteChunkSingleValueWriter}
  */
 public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
   private final int _maxChunkSize;
 
   // Thread local (reusable) byte[] to read bytes from data file.
@@ -64,7 +63,7 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
     chunkBuffer.position(rowOffset);
     chunkBuffer.get(bytes, 0, length);
 
-    return new String(bytes, 0, length, UTF_8);
+    return StringUtil.decodeUtf8(bytes, 0, length);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 
 public final class FixedByteValueReaderWriter implements Closeable {
-
   private final PinotDataBuffer _dataBuffer;
 
   public FixedByteValueReaderWriter(PinotDataBuffer dataBuffer) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
@@ -15,14 +15,13 @@
  */
 package com.linkedin.pinot.core.io.util;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.charset.Charset;
 
 
 public final class FixedByteValueReaderWriter implements Closeable {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final PinotDataBuffer _dataBuffer;
 
@@ -51,11 +50,11 @@ public final class FixedByteValueReaderWriter implements Closeable {
     for (int i = 0; i < numBytesPerValue; i++) {
       byte currentByte = _dataBuffer.getByte(startOffset + i);
       if (currentByte == paddingByte) {
-        return new String(buffer, 0, i, UTF_8);
+        return StringUtil.decodeUtf8(buffer, 0, i);
       }
       buffer[i] = currentByte;
     }
-    return new String(buffer, UTF_8);
+    return StringUtil.decodeUtf8(buffer);
   }
 
   public String getPaddedString(int index, int numBytesPerValue, byte[] buffer) {
@@ -63,7 +62,7 @@ public final class FixedByteValueReaderWriter implements Closeable {
     for (int i = 0; i < numBytesPerValue; i++) {
       buffer[i] = _dataBuffer.getByte(startOffset + i);
     }
-    return new String(buffer, UTF_8);
+    return StringUtil.decodeUtf8(buffer);
   }
 
   public byte[] getBytes(int index, int numBytesPerValue, byte[] output) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
@@ -15,13 +15,11 @@
  */
 package com.linkedin.pinot.core.io.writer.impl;
 
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
-import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
 
 public class FixedByteSingleValueMultiColWriter {
@@ -95,7 +93,7 @@ public class FixedByteSingleValueMultiColWriter {
   }
 
   public void setString(int row, int col, String string) {
-    setBytes(row, col, string.getBytes(Charset.forName("UTF-8")));
+    setBytes(row, col, StringUtil.encodeUtf8(string));
   }
 
   public void setBytes(int row, int col, byte[] bytes) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.core.io.writer.impl.v1;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import javax.annotation.concurrent.NotThreadSafe;
 
 
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
   private static final int CURRENT_VERSION = 2;
 
   private final int _chunkHeaderSize;
@@ -76,7 +75,7 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
 
   @Override
   public void setString(int row, String string) {
-    byte[] bytes = string.getBytes(UTF_8);
+    byte[] bytes = StringUtil.encodeUtf8(string);
     setBytes(row, bytes);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
@@ -20,7 +20,6 @@ import javax.annotation.Nonnull;
 
 
 public abstract class MutableDictionary extends BaseDictionary {
-
   @Override
   public String getStringValue(int dictId) {
     return get(dictId).toString();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
@@ -16,12 +16,10 @@
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import com.linkedin.pinot.core.segment.index.readers.BaseDictionary;
-import java.nio.charset.Charset;
 import javax.annotation.Nonnull;
 
 
 public abstract class MutableDictionary extends BaseDictionary {
-  protected static final Charset UTF_8 = Charset.forName("UTF-8");
 
   @Override
   public String getStringValue(int dictId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -15,17 +15,16 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
 
 
 public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
   private final MutableOffHeapByteArrayStore _byteStore;
   private String _min = null;
   private String _max = null;
@@ -48,21 +47,21 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public Object get(int dictionaryId) {
-    return new String(_byteStore.get(dictionaryId), UTF_8);
+    return StringUtil.decodeUtf8(_byteStore.get(dictionaryId));
   }
 
   @Override
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof String) {
       // Single value
-      byte[] serializedValue =  ((String) rawValue).getBytes(UTF_8);
+      byte[] serializedValue =  StringUtil.encodeUtf8((String) rawValue);
       indexValue(rawValue, serializedValue);
       updateMinMax((String) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        byte[] serializedValue =  ((String) value).getBytes(UTF_8);
+        byte[] serializedValue =  StringUtil.encodeUtf8((String) value);
         indexValue(value, serializedValue);
         updateMinMax((String) value);
       }
@@ -70,7 +69,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   private String getInternal(int dictId) {
-    return new String(_byteStore.get(dictId), UTF_8);
+    return StringUtil.decodeUtf8(_byteStore.get(dictId));
   }
 
   @Override
@@ -82,7 +81,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public int indexOf(Object rawValue) {
-    byte[] serializedValue = ((String) rawValue).getBytes(UTF_8);
+    byte[] serializedValue = StringUtil.encodeUtf8((String) rawValue);
     return getDictId(rawValue, serializedValue);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -24,7 +24,6 @@ import javax.annotation.Nonnull;
 
 
 public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
-
   private final MutableOffHeapByteArrayStore _byteStore;
   private String _min = null;
   private String _max = null;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.segment.creator.impl;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
@@ -29,7 +30,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 public class SegmentDictionaryCreator implements Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDictionaryCreator.class);
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final Object _sortedValues;
   private final FieldSpec _fieldSpec;
@@ -148,7 +147,7 @@ public class SegmentDictionaryCreator implements Closeable {
         for (int i = 0; i < numValues; i++) {
           String value = sortedStrings[i];
           _stringValueToIndexMap.put(value, i);
-          byte[] valueBytes = value.getBytes(UTF_8);
+          byte[] valueBytes = StringUtil.encodeUtf8(value);
           sortedStringBytes[i] = valueBytes;
           _numBytesPerEntry = Math.max(_numBytesPerEntry, valueBytes.length);
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -15,17 +15,15 @@
  */
 package com.linkedin.pinot.core.segment.creator.impl.stats;
 
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.segment.creator.StatsCollectorConfig;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
-import java.nio.charset.Charset;
 import java.util.Arrays;
-
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 
 
 public class StringColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private String min = V1Constants.Str.NULL_STRING;
   private String max = V1Constants.Str.NULL_STRING;
@@ -59,7 +57,7 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
         String value = e.toString();
         set.add(value);
 
-        int valueLength = value.getBytes(UTF_8).length;
+        int valueLength = StringUtil.encodeUtf8(value).length;
         smallestStringLength = Math.min(smallestStringLength, valueLength);
         longestStringLength = Math.max(longestStringLength, valueLength);
       }
@@ -79,7 +77,7 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
       updatePartition(value);
       set.add(value);
 
-      int valueLength = value.getBytes(UTF_8).length;
+      int valueLength = StringUtil.encodeUtf8(value).length;
       smallestStringLength = Math.min(smallestStringLength, valueLength);
       longestStringLength = Math.max(longestStringLength, valueLength);
       totalNumberOfEntries++;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 
 
 public class StringColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-
   private String min = V1Constants.Str.NULL_STRING;
   private String max = V1Constants.Str.NULL_STRING;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.segment.index.loader.defaultcolumn;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.segment.creator.ColumnIndexCreationInfo;
 import com.linkedin.pinot.core.segment.creator.ForwardIndexType;
 import com.linkedin.pinot.core.segment.creator.InvertedIndexType;
@@ -300,7 +301,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
         Preconditions.checkState(defaultValue instanceof String);
         String stringDefaultValue = (String) defaultValue;
         // Length of the UTF-8 encoded byte array.
-        dictionaryElementSize = stringDefaultValue.getBytes("UTF8").length;
+        dictionaryElementSize = StringUtil.encodeUtf8(stringDefaultValue).length;
         sortedArray = new String[]{stringDefaultValue};
         break;
       default:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -16,17 +16,16 @@
 package com.linkedin.pinot.core.segment.index.readers;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 
 
 @SuppressWarnings("Duplicates")
 public abstract class ImmutableDictionaryReader extends BaseDictionary {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private final FixedByteValueReaderWriter _valueReader;
   private final int _length;
@@ -191,7 +190,7 @@ public abstract class ImmutableDictionaryReader extends BaseDictionary {
   }
 
   protected String padString(String value) {
-    byte[] valueBytes = value.getBytes(UTF_8);
+    byte[] valueBytes = StringUtil.encodeUtf8(value);
     int length = valueBytes.length;
     String paddedValue;
     if (length >= _numBytesPerValue) {
@@ -200,7 +199,7 @@ public abstract class ImmutableDictionaryReader extends BaseDictionary {
       byte[] paddedValueBytes = new byte[_numBytesPerValue];
       System.arraycopy(valueBytes, 0, paddedValueBytes, 0, length);
       Arrays.fill(paddedValueBytes, length, _numBytesPerValue, _paddingByte);
-      paddedValue = new String(paddedValueBytes, UTF_8);
+      paddedValue = StringUtil.decodeUtf8(paddedValueBytes);
     }
     return paddedValue;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 
 @SuppressWarnings("Duplicates")
 public abstract class ImmutableDictionaryReader extends BaseDictionary {
-
   private final FixedByteValueReaderWriter _valueReader;
   private final int _length;
   private final int _numBytesPerValue;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTree.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTree.java
@@ -18,12 +18,12 @@ package com.linkedin.pinot.core.startree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -37,7 +37,6 @@ public class OffHeapStarTree implements StarTree {
   public static final long MAGIC_MARKER = 0xBADDA55B00DAD00DL;
   public static final int VERSION = 1;
 
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
   private static final int DIMENSION_NAME_MAX_LENGTH = 4096;
 
   private final PinotDataBuffer _dataBuffer;
@@ -86,7 +85,7 @@ public class OffHeapStarTree implements StarTree {
       _dataBuffer.copyTo(offset, dimensionNameBytes, 0, dimensionLength);
       offset += dimensionLength;
 
-      String dimensionName = new String(dimensionNameBytes, 0, dimensionLength, UTF_8);
+      String dimensionName = StringUtil.decodeUtf8(dimensionNameBytes, 0, dimensionLength);
       dimensionNames[dimensionId] = dimensionName;
     }
     _dimensionNames = Arrays.asList(dimensionNames);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.Pairs.IntPair;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.segment.creator.ColumnIndexCreationInfo;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -35,7 +36,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -95,7 +95,6 @@ import org.slf4j.LoggerFactory;
  */
 public class OffHeapStarTreeBuilder implements StarTreeBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapStarTreeBuilder.class);
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   // If the temporary buffer needed is larger than 500M, use MMAP, otherwise use DIRECT
   private static final long MMAP_SIZE_THRESHOLD = 500_000_000;
@@ -845,7 +844,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     for (String dimension : _dimensionNames) {
       headerSizeInBytes += Integer.BYTES; // For dimension index
       headerSizeInBytes += Integer.BYTES; // For length of dimension name
-      headerSizeInBytes += dimension.getBytes(UTF_8).length; // For dimension name
+      headerSizeInBytes += StringUtil.encodeUtf8(dimension).length; // For dimension name
     }
 
     headerSizeInBytes += Integer.BYTES; // For number of nodes.
@@ -876,7 +875,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       dataBuffer.putInt(offset, i);
       offset += Integer.BYTES;
 
-      byte[] dimensionBytes = dimensionName.getBytes(UTF_8);
+      byte[] dimensionBytes = StringUtil.encodeUtf8(dimensionName);
       int dimensionLength = dimensionBytes.length;
       dataBuffer.putInt(offset, dimensionLength);
       offset += Integer.BYTES;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
@@ -17,12 +17,9 @@ package com.linkedin.pinot.core.startree.hll;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import com.google.common.collect.ImmutableBiMap;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.core.data.GenericRow;
-import com.linkedin.pinot.startree.hll.HllSizeUtils;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,10 +28,6 @@ import java.util.List;
  * Utility functions for manipulation of hll field.
  */
 public class HllUtil {
-
-  private static final ImmutableBiMap<Integer, Integer> LOG2M_TO_SIZE_IN_BYTES = HllSizeUtils.getLog2mToSizeInBytes();
-
-  private static final Charset charset = Charset.forName("UTF-8");
 
   /**
    * To display a row with hll fields properly,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
@@ -28,7 +28,6 @@ import java.util.List;
  * Utility functions for manipulation of hll field.
  */
 public class HllUtil {
-
   /**
    * To display a row with hll fields properly,
    * instead of directly invoking {@link GenericRow#toString()},

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.tools.segment.converter;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
 import com.linkedin.pinot.core.common.DataSource;
@@ -31,7 +32,6 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.charset.Charset;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
 public class DictionaryToRawIndexConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryToRawIndexConverter.class);
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   @Option(name = "-dataDir", required = true, usage = "Directory containing uncompressed segments")
   private String _dataDir = null;
@@ -353,7 +352,7 @@ public class DictionaryToRawIndexConverter {
     while (bvIter.hasNext()) {
       int dictId = bvIter.nextIntVal();
       String value = (String) dictionary.get(dictId);
-      lengthOfLongestEntry = Math.max(lengthOfLongestEntry, value.getBytes(UTF_8).length);
+      lengthOfLongestEntry = Math.max(lengthOfLongestEntry, StringUtil.encodeUtf8(value).length);
     }
 
     return lengthOfLongestEntry;


### PR DESCRIPTION
While measuring heap allocations during segment builds, jmap showed
sun.nio.cs.UTF_8$Decoder and sun.nio.cs.UTF_8$Encoder among the top
40 objects in both size and number of instances. In 4 use internal use cases
the jmap output had these numbers, allocated during segment creation
(in most cases, there were in the top 5 in terms of memory)

Use case 1:
 num     #instances         #bytes  class name
----------------------------------------------
   3:      26459379     1058375160  sun.nio.cs.UTF_8$Decoder
   7:       5592818      313197808  sun.nio.cs.UTF_8$Encoder

Use case 2:
   2:        950923       38036920  sun.nio.cs.UTF_8$Decoder
   30:          2349         131544  sun.nio.cs.UTF_8$Encoder

Use case 3:
   3:       5385769      215430760  sun.nio.cs.UTF_8$Decoder

Use case 4:
   5:       5407753      216310120  sun.nio.cs.UTF_8$Decoder
   7:       2016142      112903952  sun.nio.cs.UTF_8$Encoder

Upon closer look, it appears that the call String.getBytes("UTF-8") caches the
decoder in a ThreaLocal variable in StringCoding class, whereas the call to String.getBytes(Charset)
ends up creating a new decoder everytime.

Same with encoder calls.

It should help to cache the encoder/decoder in query path as well.

This change replaces calls to encode/decode Strings to utf8 with a method in
StringUtil class.

After the change, the decoder/encoder do not appear in the top objects.