### PR TITLE
[TE] rootcause - remove wo3w and wo4w by default

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -280,16 +280,27 @@ export default Component.extend({
         const value = this._getAggregate(offset);
         const change = curr / value - 1;
 
-        anomalyInfo[offset] = {
-          value: humanizeFloat(value), // numerical value to display
-          change: humanizeChange(change), // text of % change with + or - sign
-          direction: toColorDirection(change, isInverse(metricUrn, entities))
-        };
+        if (!Number.isNaN(value)) {
+          anomalyInfo[offset] = {
+            value: humanizeFloat(value), // numerical value to display
+            change: humanizeChange(change), // text of % change with + or - sign
+            direction: toColorDirection(change, isInverse(metricUrn, entities))
+          };
+        }
       });
 
       return anomalyInfo;
     }
   ),
+
+  /**
+   * Returns any offset that has associated current and change values
+   * @type {Array}
+   */
+  availableOffsets: computed('offsets', 'anomalyInfo', function () {
+    const { offsets, anomalyInfo } = getProperties(this, 'offsets', 'anomalyInfo');
+    return offsets.filter(offset => offset in anomalyInfo);
+  }),
 
   /**
    * Returns the aggregate value for a given offset. Handles computed baseline special case.
@@ -302,7 +313,9 @@ export default Component.extend({
     const { metricUrn, aggregates, predicted } = getProperties(this, 'metricUrn', 'aggregates', 'predicted');
 
     if (offset === 'predicted') {
-      return parseFloat(predicted);
+      const value = parseFloat(predicted);
+      if (value === 0.0) { return Number.NaN; }
+      return value;
     }
 
     return aggregates[toOffsetUrn(metricUrn, offset)];

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
@@ -40,7 +40,7 @@
         </div>
 
         <div class="rootcause-anomaly__stats-wrapper">
-          {{#each offsets as |offset|}}
+          {{#each availableOffsets as |offset|}}
             <div class="rootcause-anomaly__stats">
               <span class="rootcause-anomaly__stats-label">{{offset}}</span>
               <span class="rootcause-anomaly__stats-value">

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -139,14 +139,10 @@ export default Component.extend({
             baseline: this._makeRecord(urn, 'baseline', entities, aggregates),
             wo1w: this._makeRecord(urn, 'wo1w', entities, aggregates),
             wo2w: this._makeRecord(urn, 'wo2w', entities, aggregates),
-            wo3w: this._makeRecord(urn, 'wo3w', entities, aggregates),
-            wo4w: this._makeRecord(urn, 'wo4w', entities, aggregates),
             sortable_current: this._makeChange(urn, 'current', aggregates),
             sortable_baseline: this._makeChange(urn, 'baseline', aggregates),
             sortable_wo1w: this._makeChange(urn, 'wo1w', aggregates),
-            sortable_wo2w: this._makeChange(urn, 'wo2w', aggregates),
-            sortable_wo3w: this._makeChange(urn, 'wo3w', aggregates),
-            sortable_wo4w: this._makeChange(urn, 'wo4w', aggregates)
+            sortable_wo2w: this._makeChange(urn, 'wo2w', aggregates)
           };
         });
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -317,6 +317,7 @@ export default Controller.extend({
       //
       // related metrics
       //
+      const anomalyMetricUrns = new Set();
       const relatedMetricUrns = new Set();
 
       if (activeTab === ROOTCAUSE_TAB_METRICS
@@ -326,7 +327,7 @@ export default Controller.extend({
       }
 
       if (context.anomalyUrns.size > 0) {
-        filterPrefix(context.anomalyUrns, 'thirdeye:metric:').forEach(urn => relatedMetricUrns.add(urn));
+        filterPrefix(context.anomalyUrns, 'thirdeye:metric:').forEach(urn => anomalyMetricUrns.add(urn));
       }
 
       //
@@ -371,11 +372,17 @@ export default Controller.extend({
       //
       // aggregates
       //
-      const offsets = ['current', 'baseline', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
+      const offsets = ['current', 'baseline', 'wo1w', 'wo2w'];
       const offsetUrns = [...relatedMetricUrns]
         .map(urn => [].concat(offsets.map(offset => toOffsetUrn(urn, offset))))
         .reduce((agg, l) => agg.concat(l), []);
-      aggregatesService.request(context, new Set(offsetUrns));
+
+      const anomalyOffsets = ['current', 'baseline', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
+      const anomalyOffsetUrns = [...anomalyMetricUrns]
+        .map(urn => [].concat(anomalyOffsets.map(offset => toOffsetUrn(urn, offset))))
+        .reduce((agg, l) => agg.concat(l), []);
+
+      aggregatesService.request(context, new Set([...offsetUrns, ...anomalyOffsetUrns]));
 
     }
   ),

--- a/thirdeye/thirdeye-frontend/app/shared/metricsTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/metricsTableColumns.js
@@ -42,20 +42,6 @@ export default [
     disableFiltering: true,
     className: 'metrics-table__column metrics-table__column--small'
   }, {
-    propertyName: 'wo3w',
-    template: 'custom/metrics-table-offset',
-    sortedBy: 'sortable_wo3w',
-    title: 'Wo3W',
-    disableFiltering: true,
-    className: 'metrics-table__column metrics-table__column--small'
-  }, {
-    propertyName: 'wo4w',
-    template: 'custom/metrics-table-offset',
-    sortedBy: 'sortable_wo4w',
-    title: 'Wo4W',
-    disableFiltering: true,
-    className: 'metrics-table__column metrics-table__column--small'
-  }, {
     propertyName: 'score',
     title: 'Outlier',
     disableFiltering: true,


### PR DESCRIPTION
* remove metric table wo3w and wo4w by default to reduce data source load

* hide predicted value header box if not available