### PR TITLE
Bump helix version to 0.8.2

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.helix.ControllerChangeListener;
@@ -92,7 +93,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
     String zkUrl = _pinotHelixResourceManager.getHelixZkURL();
     _zkClient = new ZkClient(zkUrl, ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
     _zkClient.setZkSerializer(new ZNRecordSerializer());
-    _zkClient.waitUntilConnected();
+    _zkClient.waitUntilConnected(20, TimeUnit.SECONDS);
 
     // Subscribe to any data/child changes to property
     _zkClient.subscribeChildChanges(_tableConfigPath, this);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
@@ -94,7 +95,7 @@ public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements 
     ZkClient zkClient = new ZkClient(_zkAddress);
     zkClient.setZkSerializer(new ZNRecordStreamingSerializer());
     LOGGER.info("Connecting to Zookeeper at: {}", _zkAddress);
-    zkClient.waitUntilConnected();
+    zkClient.waitUntilConnected(20, TimeUnit.SECONDS);
     ZkBaseDataAccessor<ZNRecord> baseDataAccessor = new ZkBaseDataAccessor<>(zkClient);
     ZKHelixDataAccessor zkHelixDataAccessor = new ZKHelixDataAccessor(_clusterName, baseDataAccessor);
     PropertyKey property = zkHelixDataAccessor.keyBuilder().liveInstances();

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
-    <helix.version>0.8.1</helix.version>
+    <helix.version>0.8.2</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
This PR bumps helix version to 0.8.2.
The method `waitUntilConnected()` has been removed. Use `waitUntilConnected(long time, TimeUnit timeUnit)` instead.