### PR TITLE
Fix TDigest for cases where only one value in TDigest

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -200,7 +200,20 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   @Nonnull
   @Override
   public Double extractFinalResult(@Nonnull TDigest intermediateResult) {
-    return intermediateResult.quantile(_percentile / 100.0);
+    return calculatePercentile(intermediateResult, _percentile);
+  }
+
+  /**
+   * Calculates percentile from {@link TDigest}.
+   * <p>Handles cases where only one value in TDigest object.
+   */
+  public static double calculatePercentile(@Nonnull TDigest tDigest, int percentile) {
+    if (tDigest.size() == 1) {
+      // Specialize cases where only one value in TDigest (cannot use quantile method)
+      return tDigest.centroids().iterator().next().mean();
+    } else {
+      return tDigest.quantile(percentile / 100.0);
+    }
   }
 
   /**

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -81,7 +81,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   protected static final String DOUBLE_COLUMN = "doubleColumn";
   protected static final String TDIGEST_COLUMN = "tDigestColumn";
   protected static final String GROUP_BY_COLUMN = "groupByColumn";
-  protected static final String[] GROUPS = new String[]{"G1", "G2", "G3", "G4", "G5"};
+  protected static final String[] GROUPS = new String[]{"G1", "G2", "G3"};
   protected static final long RANDOM_SEED = System.nanoTime();
   protected static final Random RANDOM = new Random(RANDOM_SEED);
   protected static final String ERROR_MESSAGE = "Random seed: " + RANDOM_SEED;
@@ -171,9 +171,11 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
         expected = doubleList.getDouble(doubleList.size() * percentile / 100);
       }
       TDigest tDigestForDoubleColumn = (TDigest) aggregationResult.get(1);
-      Assert.assertEquals(tDigestForDoubleColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+      Assert.assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigestForDoubleColumn, percentile),
+          expected, DELTA, ERROR_MESSAGE);
       TDigest tDigestForTDigestColumn = (TDigest) aggregationResult.get(2);
-      Assert.assertEquals(tDigestForTDigestColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+      Assert.assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigestForTDigestColumn, percentile),
+          expected, DELTA, ERROR_MESSAGE);
     }
   }
 
@@ -211,9 +213,13 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
           expected = doubleList.getDouble(doubleList.size() * percentile / 100);
         }
         TDigest tDigestForDoubleColumn = (TDigest) groupByResult.getResultForKey(groupKey, 1);
-        Assert.assertEquals(tDigestForDoubleColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+        Assert.assertEquals(
+            PercentileTDigestAggregationFunction.calculatePercentile(tDigestForDoubleColumn, percentile), expected,
+            DELTA, ERROR_MESSAGE);
         TDigest tDigestForTDigestColumn = (TDigest) groupByResult.getResultForKey(groupKey, 2);
-        Assert.assertEquals(tDigestForTDigestColumn.quantile(percentile / 100.0), expected, DELTA, ERROR_MESSAGE);
+        Assert.assertEquals(
+            PercentileTDigestAggregationFunction.calculatePercentile(tDigestForTDigestColumn, percentile), expected,
+            DELTA, ERROR_MESSAGE);
       }
     }
   }


### PR DESCRIPTION
TDigest.quantile() does not support one value case, directly return value when there is only one value