### PR TITLE
Fix NPE when getting rebalance strategy

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Basic rebalance segments strategy, which rebalances offline segments using autorebalance strategy,
+ * Basic rebalance segments strategy, which rebalances offline segments using auto-rebalance strategy,
  * and consuming segments using the partition assignment strategy for the table
  */
 public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.controller.helix.core.rebalance;
 
 import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategy;
 import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategyEnum;
 import org.apache.helix.HelixManager;
 
@@ -51,6 +50,9 @@ public class RebalanceSegmentStrategyFactory {
   public RebalanceSegmentStrategy getRebalanceSegmentsStrategy(TableConfig tableConfig) {
     // If we use replica group segment assignment strategy, we pick the replica group rebalancer
     String segmentAssignmentStrategy = tableConfig.getValidationConfig().getSegmentAssignmentStrategy();
+    if (segmentAssignmentStrategy == null) {
+      return new DefaultRebalanceSegmentStrategy(_helixManager);
+    }
     switch (SegmentAssignmentStrategyEnum.valueOf(segmentAssignmentStrategy)) {
       case ReplicaGroupSegmentAssignmentStrategy:
         return new ReplicaGroupRebalanceSegmentStrategy(_helixManager);


### PR DESCRIPTION
This RB fixes NullPointerException when fetching rebalance strategy from table config.

Sample exception message:
```
java.lang.Enum.valueOf - Line 236 (Enum.java) 
com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategyEnum.valueOf - Line 23 (SegmentAssignmentStrategyEnum.java)
...
```