### PR TITLE
[TE] report-missing-anomaly from dashboard base functionality

### DIFF
--- a/thirdeye/thirdeye-frontend/app/models/anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/models/anomalies.js
@@ -8,6 +8,7 @@ export default DS.Model.extend({
   current: DS.attr(),
   baseline: DS.attr(),
   feedback: DS.attr(),
+  source: DS.attr(),
   comment: DS.attr(),
   metricName: DS.attr(),
   metricId: DS.attr(),

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/current-wow/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/current-wow/template.hbs
@@ -1,4 +1,4 @@
 <p>{{record.current}}/{{record.baseline}}</p>
-<p class="te-anomaly-table__value-label te-anomaly-table__value-label--{{calculate-direction record.change}}">
+<p class="te-anomaly-table__value-label te-anomaly-table__value-label--dash te-anomaly-table__value-label--{{calculate-direction record.change}}">
   ({{record.humanizedChangeDisplay}})
 </p>

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions/template.hbs
@@ -3,6 +3,15 @@
     {{#link-to "manage.alert.explore" record.anomaly.functionId (query-params duration=record.queryDuration startDate=record.queryStart endDate=record.queryEnd) class="te-anomaly-table__link"}}
       {{record.anomaly.functionName}}
     {{/link-to}}
+
+    {{!--  TODO: move this into a link above each metric table - Report missing anomaly link
+    {{#link-to "manage.alert.explore" record.anomaly.functionId (query-params duration=record.queryDuration startDate=record.queryStart endDate=record.queryEnd openReport=true) class="te-anomaly-table__link te-anomaly-table__link--glyph" target="_blank"}}
+      <i class="glyphicon glyphicon-edit"></i>
+      {{#tooltip-on-element class="te-anomaly-table__tooltip"}}
+        Report missing anomaly for this alert.
+      {{/tooltip-on-element}}
+    {{/link-to}} --}}
+
   </li>
   {{#each-in record.anomaly.dimensions as |dimName dimList|}}
      <li class="te-anomaly-table__list-item" title="{{dimension.dimensionVal}}">

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -13,9 +13,9 @@
  *   },
  */
 import Component from "@ember/component";
-import { getWithDefault } from '@ember/object';
+import { getWithDefault, computed, get, set } from '@ember/object';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
-import { set, setProperties } from '@ember/object';
+import { setProperties } from '@ember/object';
 import { getAnomalyDataUrl } from 'thirdeye-frontend/utils/api/anomaly';
 import { inject as service } from '@ember/service';
 
@@ -24,6 +24,19 @@ export default Component.extend({
   anomalyResponseNames: anomalyUtil.anomalyResponseObj.mapBy('name'),
   anomalyDataUrl: getAnomalyDataUrl(),
   showResponseSaved: false,
+  isUserReported: false,
+  hasComment: false,
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+    const anomalyComment = get(this.record.anomaly, 'comment');
+    const hasComment = (anomalyComment && anomalyComment.replace(/ /g, '') !== 'null');
+    const isUserReported = get(this.record.anomaly, 'source') === 'USER_LABELED_ANOMALY';
+    setProperties(this, {
+      hasComment,
+      isUserReported
+    });
+  },
 
   actions: {
     /**
@@ -50,12 +63,12 @@ export default Component.extend({
         const filterMap = getWithDefault(res, 'searchFilters.statusFilterMap', null);
         if (filterMap && filterMap.hasOwnProperty(responseObj.status)) {
           humanizedAnomaly.set('anomalyFeedback', selectedResponse);
-          this.set('showResponseSaved', true);
+          set(this, 'showResponseSaved', true);
         } else {
           return Promise.reject(new Error('Response not saved'));
         }
       } catch (err) {
-        this.setProperties({
+        setProperties(this, {
           showResponseFailed: true,
           showResponseSaved: false
         });

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -13,11 +13,16 @@
  *   },
  */
 import Component from "@ember/component";
-import { getWithDefault, computed, get, set } from '@ember/object';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
-import { setProperties } from '@ember/object';
 import { getAnomalyDataUrl } from 'thirdeye-frontend/utils/api/anomaly';
 import { inject as service } from '@ember/service';
+import {
+  set,
+  get,
+  computed,
+  setProperties,
+  getWithDefault
+} from '@ember/object';
 
 export default Component.extend({
   tagName: '',//using tagless so i can add my own in hbs

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
@@ -1,13 +1,12 @@
 <div class="anomalies-table__column-cell">
-  {{#if showResponseSaved}}
-    <i class="{{if showResponseSaved "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-ok-circle" ></i>
+  {{#if isUserReported}}
+    <div class="te-anomaly-table__text">User Reported</div>
   {{else}}
-    <i class="{{if showResponseFailed "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-remove-circle" ></i>
-  {{/if}}
-
-  {{#if record.isUserReported}}
-    <span class="te-anomaly-table__text">User Reported</span>
-  {{else}}
+    {{#if showResponseSaved}}
+      <i class="{{if showResponseSaved "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-ok-circle" ></i>
+    {{else}}
+      <i class="{{if showResponseFailed "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-remove-circle" ></i>
+    {{/if}}
     {{#power-select
       triggerId=record.anomalyId
       triggerClass="te-anomaly-table__select te-anomaly-table__select--margin-left"
@@ -20,9 +19,12 @@
       {{response}}
     {{/power-select}}
   {{/if}}
+  {{#if hasComment}}
+    <div class="te-anomaly-table__comment">
+      <i class="glyphicon glyphicon-th-list"></i>
+      {{#tooltip-on-element class="te-anomaly-table__tooltip"}}
+        {{record.anomaly.comment}}
+      {{/tooltip-on-element}}
+    </div>
+  {{/if}}
 </div>
-{{#if record.anomaly.comment}}
-  <div class="te-anomaly-table__comment">
-    comment: {{markdown-to-html record.anomaly.comment}}
-  </div>
-{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/start-duration/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/start-duration/template.hbs
@@ -1,14 +1,12 @@
-<p>
+<p class="anomalies-table__text anomalies-table__text--stronger">
   <label class="te-label te-label--small">
-    <span>
-      {{moment-format record.anomaly.start 'MMM D, hh:mm A'}}
-      {{#tooltip-on-element class="te-tooltip"}}
-        Start: {{moment-format record.anomaly.start 'MMM D, hh:mm A'}}<br />
-        End: {{moment-format record.anomaly.end 'MMM D, hh:mm A'}}
-      {{/tooltip-on-element}}
-    </span>
+    {{moment-format record.anomaly.start 'MMM D, hh:mm A'}}
+    {{#tooltip-on-element}}
+      Start: {{moment-format record.anomaly.start 'MMM D, hh:mm A'}}<br />
+      End: {{moment-format record.anomaly.end 'MMM D, hh:mm A'}}
+    {{/tooltip-on-element}}
   </label>
 </p>
-<p class="anomalies-table__duration">
+<p class="anomalies-table__text">
   {{record.duration}}
 </p>

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import { computed, set, get } from '@ember/object';
-import { later } from "@ember/runloop";
 import { isBlank } from '@ember/utils';
 import moment from 'moment';
 import { setUpTimeRangeOptions } from 'thirdeye-frontend/utils/manage-alert-utils';

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import { computed, set, get } from '@ember/object';
+import { later } from "@ember/runloop";
 import { isBlank } from '@ember/utils';
 import moment from 'moment';
 import { setUpTimeRangeOptions } from 'thirdeye-frontend/utils/manage-alert-utils';

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -245,7 +245,13 @@
                     {{/if}}
 
                     {{#if anomaly.isUserReported}}
-                      <span class="te-anomaly-table__text">User Reported</span>
+                      <div class="te-anomaly-table__text te-anomaly-table__text--explore">User Reported</div>
+                      <div class="te-anomaly-table__comment">
+                        <i class="glyphicon glyphicon-th-list"></i>
+                        {{#tooltip-on-element class="te-anomaly-table__tooltip"}}
+                          {{anomaly.anomalyFeedbackComments}}
+                        {{/tooltip-on-element}}
+                      </div>
                     {{else}}
                       {{#power-select
                         triggerId=anomaly.anomalyId

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -85,7 +85,7 @@ const fillAppBuckets = (allApps, validGroups) => {
   let appBucket = [];
 
   allApps.forEach((app) => {
-    let associatedGroups = validGroups.filter(group => group.application.toLowerCase().includes(app.application));
+    let associatedGroups = validGroups.filter(group => group.application.includes(app.application));
     if (associatedGroups.length) {
       let uniqueIds = Array.from(new Set([].concat(...associatedGroups.map(group => group.emailConfig.functionIds))));
       if (isDemoMode) {
@@ -217,6 +217,10 @@ export default Route.extend({
     const groupsWithAppName = activeGroups.filter(group => isPresent(group.application));
     const groupsWithAlertId = groupsWithAppName.filter(group => group.emailConfig.functionIds.length > 0);
     const filteredGroups = isDemoMode ? groupsWithAlertId.slice(0, 3) : groupsWithAlertId;
+
+    // NOTE: use this in order to find non-existent alert in the event of an error
+    // filteredGroups.filter(group => group.emailConfig.functionIds.includes(45639479)));
+
     const idsByApplication = fillAppBuckets(model.applications, filteredGroups);
     Object.assign(model, { idsByApplication });
   },

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
@@ -34,6 +34,9 @@ const HumanizedAnomaly = EmberObject.extend({// ex: record.humanizedChangeDispla
   severity: computed('anomaly.severity', function() {
     return humanizeFloat(get(this, 'anomaly.severity'));
   }),
+  source: computed('anomaly.source', function() {
+    return humanizeFloat(get(this, 'anomaly.source'));
+  }),
   anomalyFeedback: computed('anomaly.feedback', function() {
     return get(this, 'anomaly.feedback') ? anomalyResponseObj.find(res => res.value === get(this, 'anomaly.feedback')).name : '';
   }),

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -4,8 +4,8 @@
   border: 1px solid app-shade(black, 1);
 
   &__comment {
-    word-wrap: break-word;
-    width: 220px;
+    margin-top: 10px;
+    float: left;
   }
 
   &__wrapper {
@@ -14,7 +14,12 @@
   }
 
   &__text {
-    margin-right: 30px;
+    margin: 10px 10px 0 30px;
+
+    &--explore {
+      float: left;
+      margin-left: 0;
+    }
   }
 
   &__head {
@@ -72,21 +77,20 @@
   }
 
   &__list-item {
+    font-size: 13px;
+
     &--smaller {
-      font-size: 12px;
       margin-left: -2px;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
     &--lighter {
-      font-size: 12px;
       color: app-shade(black, 6);
     }
 
     &--warning {
       color: $te-red;
-      font-size: 13px;
     }
 
     &--shadow {
@@ -97,7 +101,7 @@
   }
 
   &__list-value {
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
     margin-left: 5px;
   }
@@ -111,6 +115,10 @@
 
     &--down {
       color: $te-red;
+    }
+
+    &--dash {
+      line-height: 5px;
     }
   }
 
@@ -140,6 +148,21 @@
     font-weight: 600;
     letter-spacing: .03em;
     font-size: 15px;
+
+    &--glyph {
+      margin-left: 10px;
+      color: rgba(0, 0, 0, .3);
+      font-size: 17px;
+      display: inline-block;
+
+      &:hover {
+        color: #78b12f;
+      }
+    }
+  }
+
+  &__tooltip {
+    font-weight: normal;
   }
 
   &__icon {

--- a/thirdeye/thirdeye-frontend/app/styles/pods/home/index/dashboard.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/home/index/dashboard.scss
@@ -84,6 +84,14 @@
           width: 280px;
         }
     }
+
+    &__text {
+      margin-bottom: 0px;
+
+      &--stronger {
+        font-weight: bold;
+      }
+    }
   }
 
   .te-anomaly-table {


### PR DESCRIPTION
In this pass:
- adding "source" attribute to anomaly model (in order to display user-reported anomalies in dashboard)
- putting in a fix for /manage/alerts/performance (bug was omitting the full set of applications in the report table)
- adding comment field to display of user-reported anomalies in both dashboard and alert page

Dashboard view:
![screen shot 2018-08-23 at 6 27 52 pm](https://user-images.githubusercontent.com/11814420/44560061-95cfd900-a702-11e8-9b0a-359ce588005d.png)

Alert page view:
![screen shot 2018-08-23 at 6 32 00 pm](https://user-images.githubusercontent.com/11814420/44560119-e47d7300-a702-11e8-9572-0c6cb79f07f7.png)

>> all tests passing !!!