### PR TITLE
Changing FileUploadPathProvider to use PinotFS

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
@@ -15,42 +15,63 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import java.io.File;
-import org.apache.commons.io.FileUtils;
 import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.filesystem.PinotFS;
+import com.linkedin.pinot.filesystem.PinotFSFactory;
+import java.io.File;
+import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 // TODO This is a misc class used by many jersey apis. Need to rename it correctly
 public class FileUploadPathProvider {
   public final static String STATE = "state";
   public final static String TABLE_NAME = "tableName";
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileUploadPathProvider.class);
 
   private final ControllerConf _controllerConf;
 
-  private final File _fileUploadTmpDir;
-  private final File _baseDataDir;
-  private final File _tmpUntarredPath;
-  private final File _schemasTmpDir;
+  private final URI _fileUploadTmpDirURI;
+  private final URI _baseDataDirURI;
+  private final URI _tmpUntarredPathURI;
+  private final URI _schemasTmpDirURI;
   private final String _vip;
 
   public FileUploadPathProvider(ControllerConf controllerConf) throws InvalidControllerConfigException {
     _controllerConf = controllerConf;
+
+    // Pick the correct scheme for PinotFS. For pluggable storage, we will expect that the directory is configured
+    // with a storage prefix. For backwards compatibility, we will assume local/mounted NFS storage if nothing is configured.
+    String scheme = "file";
+    String dataDir = _controllerConf.getDataDir();
     try {
-      _baseDataDir = new File(_controllerConf.getDataDir());
-      if (!_baseDataDir.exists()) {
-        FileUtils.forceMkdir(_baseDataDir);
+      URI uri = new URI(_controllerConf.getDataDir());
+      scheme = uri.getScheme();
+    } catch (Exception e) {
+      // Assume local FS
+      LOGGER.warn("Could not create controller config data dir URI with {}", _controllerConf.getDataDir());
+      dataDir = "file://" + _controllerConf.getDataDir();
+    }
+
+    PinotFS pinotFS = PinotFSFactory.create(scheme);
+
+    try {
+      _baseDataDirURI = new URI(dataDir);
+      if (!pinotFS.exists(_baseDataDirURI)) {
+        pinotFS.mkdir(_baseDataDirURI);
       }
-      _fileUploadTmpDir = new File(_baseDataDir, "fileUploadTemp");
-      if (!_fileUploadTmpDir.exists()) {
-        FileUtils.forceMkdir(_fileUploadTmpDir);
+      _fileUploadTmpDirURI = new URI(_baseDataDirURI + "/fileUploadTemp");
+      if (!pinotFS.exists(_fileUploadTmpDirURI)) {
+        pinotFS.mkdir(_fileUploadTmpDirURI);
       }
-      _tmpUntarredPath = new File(_fileUploadTmpDir, "untarred");
-      if (!_tmpUntarredPath.exists()) {
-        _tmpUntarredPath.mkdirs();
+      _tmpUntarredPathURI = new URI(_fileUploadTmpDirURI + "/untarred");
+      if (!pinotFS.exists(_tmpUntarredPathURI)) {
+        pinotFS.mkdir(_tmpUntarredPathURI);
       }
-      _schemasTmpDir = new File(_baseDataDir, "schemasTemp");
-      if (!_schemasTmpDir.exists()) {
-        FileUtils.forceMkdir(_schemasTmpDir);
+      _schemasTmpDirURI = new URI(_baseDataDirURI + "/schemasTemp");
+      if (!pinotFS.exists(_schemasTmpDirURI)) {
+        pinotFS.mkdir(_schemasTmpDirURI);
       }
       _vip = _controllerConf.generateVipUrl();
     } catch (Exception e) {
@@ -58,23 +79,41 @@ public class FileUploadPathProvider {
     }
   }
 
-  public File getFileUploadTmpDir() {
-    return _fileUploadTmpDir;
-  }
-
-  public File getBaseDataDir() {
-    return _baseDataDir;
-  }
-
-  public File getTmpUntarredPath() {
-    return _tmpUntarredPath;
-  }
-
   public String getVip() {
     return _vip;
   }
 
+  public URI getFileUploadTmpDirURI() {
+    return _fileUploadTmpDirURI;
+  }
+
+  public URI getBaseDataDirURI() {
+    return _baseDataDirURI;
+  }
+
+  public URI getTmpUntarredPathURI() {
+    return _tmpUntarredPathURI;
+  }
+
+  public URI getSchemasTmpDirURI() {
+    return _schemasTmpDirURI;
+  }
+
+  // TODO: The following getters that return files should eventually be migrated to URIs once pluggable storage support
+  // is complete throughout the system. Leaving this here for backwards compatibility for now.
+  public File getFileUploadTmpDir() {
+    return new File(_fileUploadTmpDirURI);
+  }
+
+  public File getBaseDataDir() {
+    return new File(_baseDataDirURI);
+  }
+
+  public File getTmpUntarredPath() {
+    return new File(_tmpUntarredPathURI);
+  }
+
   public File getSchemasTmpDir() {
-    return _schemasTmpDir;
+    return new File(_schemasTmpDirURI);
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProviderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProviderTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.resources;
+
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import java.io.File;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class FileUploadPathProviderTest extends ControllerTest {
+  private static ControllerConf _controllerConf;
+  @BeforeClass
+  public void setUp() {
+    startZk();
+    _controllerConf = getDefaultControllerConfiguration();
+    startController(_controllerConf);
+  }
+
+  @Test
+  public void testFileUploadPathProvider() throws Exception {
+    FileUploadPathProvider provider = new FileUploadPathProvider(_controllerConf);
+    Assert.assertEquals(provider.getBaseDataDir().getAbsolutePath(), _controllerDataDir);
+    String fileUploadTmpDirPath = provider.getFileUploadTmpDir().getAbsolutePath();
+    Assert.assertEquals(fileUploadTmpDirPath, new File(_controllerDataDir, "fileUploadTemp").getAbsolutePath());
+    Assert.assertEquals(provider.getSchemasTmpDir().getAbsolutePath(), new File(_controllerDataDir, "schemasTemp").getAbsolutePath());
+    Assert.assertEquals(provider.getTmpUntarredPath().getAbsolutePath(), new File(fileUploadTmpDirPath, "untarred").getAbsolutePath());
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
+}


### PR DESCRIPTION
* In order to support segment move to and from remote filesystems during segment, we need to make FileUploadPathProvider storage agnostic. 