### PR TITLE
[TE] detection - legacy emulation properties injection chain and preview fixes

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/preview/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/preview/controller.js
@@ -169,12 +169,16 @@ export default Controller.extend({
     'timeseries',
     'baseline',
     'diagnosticsSeries',
+    'analysisRange',
+    'displayRange',
     function () {
       const metricUrn = get(this, 'metricUrn');
       const anomalies = get(this, 'anomalies');
       const timeseries = get(this, 'timeseries');
       const baseline = get(this, 'baseline');
       const diagnosticsSeries = get(this, 'diagnosticsSeries');
+      const analysisRange = get(this, 'analysisRange');
+      const displayRange = get(this, 'displayRange');
 
       const series = {};
 
@@ -213,6 +217,16 @@ export default Controller.extend({
           values: baseline.value,
           type: 'line',
           color: 'light-' + toColor(metricUrn)
+        };
+      }
+
+      // detection range
+      if (timeseries && !_.isEmpty(timeseries.value)) {
+        series['pre-detection-region'] = {
+          timestamps: [displayRange[0], analysisRange[0]],
+          values: [1, 1],
+          type: 'region',
+          color: 'grey'
         };
       }
 

--- a/thirdeye/thirdeye-frontend/app/styles/components/anomaly-graph.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/anomaly-graph.scss
@@ -136,6 +136,7 @@ $colors:
   "red" $te-red,
   "green" $te-green,
   "pink" $te-pink,
+  "grey" $te-grey,
   "dark-orange" #B74700;
 
 // creates .c3-region-"color" classes


### PR DESCRIPTION
Several smaller fixes and enhancements for legacy emulation:
* shade non-detection period in preview
* inject anomaly function and spec down the full legacy emulation chain
* add support for tolerating legacy detection failures by default