### PR TITLE
[TE] RCA Dimension algorithm table: manual order

### DIFF
--- a/thirdeye/thirdeye-frontend/app/adapters/base.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/base.js
@@ -68,7 +68,7 @@ export default DS.RESTAdapter.extend({
         return `${this.get('namespace')}/${query.appName}`;
       }
       case 'dimensions': {
-        return `${this.get('namespace')}`;
+        return `${this.get('namespace')}/${query.orderType}DimensionOrder`;
       }
       case 'shareDashboard': {
         return `${this.get('namespace')}/${query.key}`;

--- a/thirdeye/thirdeye-frontend/app/adapters/dimensions.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/dimensions.js
@@ -2,5 +2,5 @@ import BaseAdapter from './base';
 
 export default BaseAdapter.extend({
   //for api call - /dashboard/summary/autoDimensionOrder?dataset=search_v3_additive&metric=sat_click&currentStart=1524643200000&currentEnd=1525248000000&baselineStart=1524038400000&baselineEnd=1524643200000&summarySize=20&oneSideError=false&depth=3&dimensions=country_code#
-  namespace: '/dashboard/summary/autoDimensionOrder'
+  namespace: '/dashboard/summary'
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-algorithm/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-algorithm/component.js
@@ -114,6 +114,7 @@ export default Component.extend({
     depth: '3',
     dimensions: [],
     summarySize: 20,
+    orderType: 'auto',
     oneSideError: 'false',
     excludedDimensions: []
   },
@@ -284,6 +285,7 @@ export default Component.extend({
       'customTableSettings',
       'isUserCustomizingRequest'
     );
+
     // Labels to omit from URN when isolating filter keys
     const baseUrnArr = ['thirdeye', 'metric'];
     // Stringifying any custom settings so that we can append to our caching key
@@ -294,7 +296,8 @@ export default Component.extend({
       return isNaN(urnFragment) && !baseUrnArr.includes(urnFragment);
     }).join(';');
     // Grab metric Id from URN
-    const metricId = metricArr[metricArr.length - 1];
+    //const metricId = metricArr[metricArr.length - 1];
+    const metricId = metricUrn.match(/^thirdeye:metric\:(\d+)/)[1];
     // Construct API-ready filter string
     const finalFilterStr = makeFilterString(decodeURIComponent(rawFilterStr));
     // Baseline start/end is dependent on 'compareMode' (WoW, Wo2W, etc)
@@ -318,6 +321,7 @@ export default Component.extend({
         summarySize: customTableSettings.summarySize,
         oneSideError: customTableSettings.oneSideError,
         depth: customTableSettings.depth,
+        orderType: customTableSettings.orderType,
         filters: rawFilterStr.length ? finalFilterStr : ''
       };
       // Add dimensions/exclusions into query if not empty

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-settings/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-settings/component.js
@@ -21,8 +21,17 @@
  */
 
 import Component from '@ember/component';
-import { reads } from '@ember/object/computed';
-import { computed, get, set, getProperties, setProperties } from '@ember/object';
+import {
+  get,
+  set,
+  computed,
+  getProperties,
+  setProperties
+} from '@ember/object';
+import {
+  reads,
+  equal
+} from '@ember/object/computed';
 
 export default Component.extend({
   tagName: 'main',
@@ -40,6 +49,7 @@ export default Component.extend({
   selectedErrorOption: reads('customTableSettings.oneSideError'),
   selectedIncludeDimensions: reads('customTableSettings.dimensions'),
   selectedExcludeDimensions: reads('customTableSettings.excludedDimensions'),
+  isDimensionOrderActive: equal('customTableSettings.orderType', 'manual'),
 
   // Mapping field keys to actual API queryparam keys
   fieldKeyMap: {
@@ -84,13 +94,24 @@ export default Component.extend({
      * @param {String} inputName - field name
      * @param {String} inputValue - field value
      */
-    onInput(inputName, inputValue,) {
+    onInput(inputName, inputValue) {
       const customTableSettings = get(this, 'customTableSettings');
       const apiKey = get(this, 'fieldKeyMap')[inputName];
       // Set shared custom settings object props
       set(this, `customTableSettings.${apiKey}`, inputValue);
       // Set triggered field value
       set(this, inputName, inputValue);
+    },
+
+    /**
+     * Switch request order type when 'preserve order' checkbox is changed
+     * @method onChangeMaintainOrder
+     */
+    onChangeMaintainOrder() {
+      // toggle the checkbox value (box checked)
+      set(this, 'isDimensionOrderActive', !get(this, 'isDimensionOrderActive'));
+      // set property value in settings object passed from parent
+      set(this, 'customTableSettings.orderType', get(this, 'isDimensionOrderActive') ? 'manual' : 'auto');
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-settings/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-settings/template.hbs
@@ -18,11 +18,12 @@
     {{/power-select-multiple}}
 
     <div class="te-form__sub-label te-form__sub-label--micro">Show only these dimensions</div>
-    {{!-- {{input
+    {{input
       type="checkbox"
       id="dimension-order"
-      checked=true}}
-    <label for="dimension-order" class="control-label te-label te-label--small">Maintain this order</label> --}}
+      change=(action "onChangeMaintainOrder")
+      checked=isDimensionOrderActive}}
+    <label for="dimension-order" class="control-label te-label te-label--small">Maintain this order</label>
   </div>
 </fieldset>
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -177,7 +177,7 @@ export default Route.extend({
         const { id, duration, startDate, endDate } = tuneModel;
         this.transitionTo('manage.alert.explore', id, { queryParams: { duration, startDate, endDate }});
       } else {
-        this.transitionTo('manage.alert', alertId);
+        this.transitionTo('manage.alert.explore', alertId);
       }
     },
 

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/dimensions/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/dimensions/service.js
@@ -35,7 +35,8 @@ export default Service.extend({
       'baselineStart',  // number: baseline start ISO
       'baselineEnd',    // number: baseline end ISO
       'summarySize',    // number: number of results requested
-      'depth'           // number: nesting levels 1 - 3
+      'depth',          // number: nesting levels 1 - 3
+      'orderType'       // string: manual or auto
     ];
 
     requiredKeys.forEach((key) => {


### PR DESCRIPTION
Enabling call to 'manualDimensionOrder' API from dimension analysis algorithm table when user checks the "Maintain this order" checkbox in the settings modal.

<img width="700" alt="screen shot 2018-08-30 at 1 34 03 pm" src="https://user-images.githubusercontent.com/11814420/44871782-674d8300-ac59-11e8-9c79-d4c9f490ab94.png">

Also, a tiny fix to a transition in the `manage.alerts.index` route.