### PR TITLE
Invalidate controller leader cached value if exceptions occur during segment completion calls

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.server.realtime;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.core.query.utils.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
@@ -23,7 +24,6 @@ import org.apache.helix.ZNRecord;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 // Helix keeps the old controller around for 30s before electing a new one, so we will keep getting
 // the old controller as leader, and it will keep returning NOT_LEADER.
@@ -39,8 +39,12 @@ public class ControllerLeaderLocator {
   // Co-ordinates of the last known controller leader.
   private Pair<String, Integer> _controllerLeaderHostPort = null;
 
-  // Should we refresh the controller leader co-ordinates?
-  private volatile boolean _refresh = true;
+  // Indicates whether cached controller leader value is invalid
+  private volatile boolean _cachedControllerLeaderInvalid = true;
+  // Time in millis when cache invalidate was last set
+  private volatile long _lastCacheInvalidateMillis = 0;
+  // Minimum millis which must elapse between consecutive invalidation of cache
+  private static final long MILLIS_BETWEEN_INVALIDATE = 30_000;
 
   ControllerLeaderLocator(HelixManager helixManager) {
     _helixManager = helixManager;
@@ -70,33 +74,67 @@ public class ControllerLeaderLocator {
 
   /**
    * Locate the controller leader so that we can send LLC segment completion requests to it.
+   * Checks the {@link ControllerLeaderLocator::_cachedControllerLeaderInvalid} flag and fetches the leader from helix if cached value is invalid
    *
    * @return The host:port string of the current controller leader.
    */
   public synchronized Pair<String, Integer> getControllerLeader() {
-    if (!_refresh) {
+    if (!_cachedControllerLeaderInvalid) {
       return _controllerLeaderHostPort;
     }
 
     BaseDataAccessor<ZNRecord> dataAccessor = _helixManager.getHelixDataAccessor().getBaseDataAccessor();
     Stat stat = new Stat();
     try {
-      ZNRecord znRecord = dataAccessor.get("/" + _clusterName + "/CONTROLLER/LEADER", stat, AccessOption.THROW_EXCEPTION_IFNOTEXIST);
+      ZNRecord znRecord =
+          dataAccessor.get("/" + _clusterName + "/CONTROLLER/LEADER", stat, AccessOption.THROW_EXCEPTION_IFNOTEXIST);
       String leader = znRecord.getId();
       int index = leader.lastIndexOf('_');
       String leaderHost = leader.substring(0, index);
-      int leadePort = Integer.valueOf(leader.substring(index + 1));
-      _controllerLeaderHostPort = new Pair<>(leaderHost, leadePort);
-      _refresh = false;
+      int leaderPort = Integer.valueOf(leader.substring(index + 1));
+      _controllerLeaderHostPort = new Pair<>(leaderHost, leaderPort);
+      _cachedControllerLeaderInvalid = false;
       return _controllerLeaderHostPort;
     } catch (Exception e) {
       LOGGER.warn("Could not locate controller leader, exception", e);
-      _refresh = true;
+      _cachedControllerLeaderInvalid = true;
       return null;
     }
   }
 
-  public synchronized void refreshControllerLeader() {
-    _refresh = true;
+  /**
+   * Invalidates the cached controller leader value by setting the {@link ControllerLeaderLocator::_cacheControllerLeadeInvalid} flag.
+   * This flag is always checked first by {@link ControllerLeaderLocator::getControllerLeader()} method before returning the leader. If set, leader is fetched from helix, else cached leader value is returned.
+   *
+   * Invalidates are not allowed more frequently than {@link ControllerLeaderLocator::MILLIS_BETWEEN_INVALIDATE} millis.
+   * The cache is invalidated whenever server gets NOT_LEADER or NOT_SENT response. A NOT_LEADER response definitely needs a cache refresh. However, a NOT_SENT response could also happen for reasons other than controller not being leader.
+   * Thus the frequency limiting is done to guard against frequent cache refreshes, in cases where we might be getting too many NOT_SENT responses due to some other errors.
+   */
+  public synchronized void invalidateCachedControllerLeader() {
+    long millisSinceLastInvalidate = System.currentTimeMillis() - _lastCacheInvalidateMillis;
+    if (millisSinceLastInvalidate < MILLIS_BETWEEN_INVALIDATE) {
+      LOGGER.info(
+          "Millis since last controller cache value invalidate {} is less than allowed frequency {}. Skipping invalidate.",
+          millisSinceLastInvalidate, MILLIS_BETWEEN_INVALIDATE);
+    } else {
+      LOGGER.info("Invalidating cached controller leader value");
+      _cachedControllerLeaderInvalid = true;
+      _lastCacheInvalidateMillis = System.currentTimeMillis();
+    }
+  }
+
+  @VisibleForTesting
+  protected boolean isCachedControllerLeaderInvalid() {
+    return _cachedControllerLeaderInvalid;
+  }
+
+  @VisibleForTesting
+  protected long getLastCacheInvalidateMillis() {
+    return _lastCacheInvalidateMillis;
+  }
+
+  @VisibleForTesting
+  protected  long getMillisBetweenInvalidate() {
+    return MILLIS_BETWEEN_INVALIDATE;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
@@ -111,7 +111,8 @@ public class ControllerLeaderLocator {
    * Thus the frequency limiting is done to guard against frequent cache refreshes, in cases where we might be getting too many NOT_SENT responses due to some other errors.
    */
   public synchronized void invalidateCachedControllerLeader() {
-    long millisSinceLastInvalidate = System.currentTimeMillis() - _lastCacheInvalidateMillis;
+    long now = System.currentTimeMillis();
+    long millisSinceLastInvalidate = now - _lastCacheInvalidateMillis;
     if (millisSinceLastInvalidate < MILLIS_BETWEEN_INVALIDATE) {
       LOGGER.info(
           "Millis since last controller cache value invalidate {} is less than allowed frequency {}. Skipping invalidate.",
@@ -119,7 +120,7 @@ public class ControllerLeaderLocator {
     } else {
       LOGGER.info("Invalidating cached controller leader value");
       _cachedControllerLeaderInvalid = true;
-      _lastCacheInvalidateMillis = System.currentTimeMillis();
+      _lastCacheInvalidateMillis = now;
     }
   }
 
@@ -134,7 +135,12 @@ public class ControllerLeaderLocator {
   }
 
   @VisibleForTesting
-  protected  long getMillisBetweenInvalidate() {
+  protected long getMillisBetweenInvalidate() {
     return MILLIS_BETWEEN_INVALIDATE;
+  }
+
+  @VisibleForTesting
+  protected void setLastCacheInvalidateMillis(long lastCacheInvalidateMillis) {
+    _lastCacheInvalidateMillis = lastCacheInvalidateMillis;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -165,12 +165,15 @@ public class ServerSegmentCompletionProtocolHandler {
       response = new SegmentCompletionProtocol.Response(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {
-        ControllerLeaderLocator.getInstance().refreshControllerLeader();
+        ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();
       }
     } catch (Exception e) {
       // Catch all exceptions, we want the protocol to handle the case assuming the request was never sent.
       response = SegmentCompletionProtocol.RESP_NOT_SENT;
       LOGGER.error("Could not send request {}", url, e);
+      // Invalidate controller leader cache, as exception could be because of leader being down (deployment/failure) and hence unable to send {@link SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER}
+      // If cache is not invalidated, we will not recover from exceptions until the controller comes back up
+      ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();
     }
     raiseSegmentCompletionProtocolResponseMetric(response);
     return response;
@@ -186,12 +189,15 @@ public class ServerSegmentCompletionProtocolHandler {
       response = new SegmentCompletionProtocol.Response(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {
-        ControllerLeaderLocator.getInstance().refreshControllerLeader();
+        ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();
       }
     } catch (Exception e) {
       // Catch all exceptions, we want the protocol to handle the case assuming the request was never sent.
       response = SegmentCompletionProtocol.RESP_NOT_SENT;
       LOGGER.error("Could not send request {}", url, e);
+      // Invalidate controller leader cache, as exception could be because of leader being down (deployment/failure) and hence unable to send {@link SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER}
+      // If cache is not invalidated, we will not recover from exceptions until the controller comes back up
+      ControllerLeaderLocator.getInstance().invalidateCachedControllerLeader();
     }
     raiseSegmentCompletionProtocolResponseMetric(response);
     return response;

--- a/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -34,10 +34,10 @@ public class ControllerLeaderLocatorTest {
 
   /**
    * Tests the invalidate logic for cached controller leader
-   * @throws InterruptedException
+   * We set the value for lastCacheInvalidateMillis as we do not want to rely on operations being executed within or after the time thresholds in the tests
    */
   @Test
-  public void testInvalidateCachedControllerLeader() throws InterruptedException {
+  public void testInvalidateCachedControllerLeader()  {
     HelixManager helixManager = mock(HelixManager.class);
     HelixDataAccessor helixDataAccessor = mock(HelixDataAccessor.class);
     BaseDataAccessor<ZNRecord> baseDataAccessor = mock(BaseDataAccessor.class);
@@ -67,10 +67,11 @@ public class ControllerLeaderLocatorTest {
 
     // invalidate within {@link ControllerLeaderLocator::getMillisBetweenInvalidate()} millis
     // values should remain unchanged
+    lastCacheInvalidateMillis = System.currentTimeMillis();
+    controllerLeaderLocator.setLastCacheInvalidateMillis(lastCacheInvalidateMillis);
     controllerLeaderLocator.invalidateCachedControllerLeader();
     Assert.assertTrue(controllerLeaderLocator.isCachedControllerLeaderInvalid());
     Assert.assertEquals(controllerLeaderLocator.getLastCacheInvalidateMillis(), lastCacheInvalidateMillis);
-    lastCacheInvalidateMillis = controllerLeaderLocator.getLastCacheInvalidateMillis();
 
     // getControllerLeader, which validates the cache
     controllerLeaderLocator.getControllerLeader();
@@ -79,14 +80,16 @@ public class ControllerLeaderLocatorTest {
 
     // invalidate within {@link ControllerLeaderLocator::getMillisBetweenInvalidate()} millis
     // values should remain unchanged
+    lastCacheInvalidateMillis = System.currentTimeMillis();
+    controllerLeaderLocator.setLastCacheInvalidateMillis(lastCacheInvalidateMillis);
     controllerLeaderLocator.invalidateCachedControllerLeader();
     Assert.assertFalse(controllerLeaderLocator.isCachedControllerLeaderInvalid());
     Assert.assertEquals(controllerLeaderLocator.getLastCacheInvalidateMillis(), lastCacheInvalidateMillis);
-    lastCacheInvalidateMillis = controllerLeaderLocator.getLastCacheInvalidateMillis();
 
-    // invalidate after {@link ControllerLeaderLocator::getMillisBetweenInvalidate()} millis have elapsed
+    // invalidate after {@link ControllerLeaderLocator::getMillisBetweenInvalidate()} millis have elapsed, by setting lastCacheInvalidateMillis to well before the millisBetweenInvalidate
     // cache should be invalidated and last cache invalidation time should get updated
-    Thread.sleep(controllerLeaderLocator.getMillisBetweenInvalidate());
+    lastCacheInvalidateMillis = System.currentTimeMillis() - 2 * controllerLeaderLocator.getMillisBetweenInvalidate();
+    controllerLeaderLocator.setLastCacheInvalidateMillis(lastCacheInvalidateMillis);
     controllerLeaderLocator.invalidateCachedControllerLeader();
     Assert.assertTrue(controllerLeaderLocator.isCachedControllerLeaderInvalid());
     Assert.assertTrue(controllerLeaderLocator.getLastCacheInvalidateMillis() > lastCacheInvalidateMillis);


### PR DESCRIPTION
We recently faced an error scenario on perf controller. The leader controller was taken down. The servers cache the leader controller value, until a NOT_LEADER response is received, after which the cached value gets refreshed. 
But in this scenario, since the controller was down, it could not send NOT_LEADER. We threw an exception, but never refreshed the controller leader cached value.
The servers kept trying to send requests to the controller who they thought was the leader, and we never recovered from this. The only way out was a server restart.

Adding logic to invalidate and refresh caches in exception scenarios