### PR TITLE
Support null values in BYTES data type.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -22,7 +22,6 @@ import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.config.ConfigNodeLifecycleAware;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import javax.annotation.Nonnull;
 import org.apache.avro.Schema.Type;
 import org.apache.commons.codec.DecoderException;
@@ -41,11 +40,13 @@ import org.apache.commons.codec.binary.Hex;
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLifecycleAware {
+  private static final byte[] NULL_BYTE_ARRAY_VALUE = new byte[0];
+
   private static final Integer DEFAULT_DIMENSION_NULL_VALUE_OF_INT = Integer.MIN_VALUE;
   private static final Long DEFAULT_DIMENSION_NULL_VALUE_OF_LONG = Long.MIN_VALUE;
   private static final Float DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT = Float.NEGATIVE_INFINITY;
   private static final Double DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE = Double.NEGATIVE_INFINITY;
-  private static final ByteArray DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = new ByteArray(new byte[0]);
+  private static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = NULL_BYTE_ARRAY_VALUE;
 
   private static final String DEFAULT_DIMENSION_NULL_VALUE_OF_STRING = "null";
   private static final Integer DEFAULT_METRIC_NULL_VALUE_OF_INT = 0;
@@ -53,7 +54,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
   private static final Float DEFAULT_METRIC_NULL_VALUE_OF_FLOAT = 0.0F;
   private static final Double DEFAULT_METRIC_NULL_VALUE_OF_DOUBLE = 0.0D;
   private static final String DEFAULT_METRIC_NULL_VALUE_OF_STRING = "null";
-  private static final ByteArray DEFAULT_METRIC_NULL_VALUE_OF_BYTES = new ByteArray(new byte[0]);
+  private static final byte[] DEFAULT_METRIC_NULL_VALUE_OF_BYTES = NULL_BYTE_ARRAY_VALUE;
 
   @ConfigKey("name")
   protected String _name;
@@ -154,7 +155,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
           return stringDefaultNullValue;
         case BYTES:
           try {
-            return new ByteArray(Hex.decodeHex(stringDefaultNullValue.toCharArray()));
+            return Hex.decodeHex(stringDefaultNullValue.toCharArray());
           } catch (DecoderException e) {
             Utils.rethrowException(e); // Re-throw to avoid handling exceptions in all callers.
           }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -22,12 +22,11 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
 import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.common.utils.time.TimeConverter;
 import com.linkedin.pinot.common.utils.time.TimeConverterProvider;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.function.FunctionExpressionEvaluator;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -210,15 +209,6 @@ public class PlainFieldExtractor implements FieldExtractor {
             hasError = true;
             _errorCount.put(column, _errorCount.get(column) + 1);
           }
-        } else if (value instanceof ByteBuffer) { // TODO: Need better handle for ByteBuffers.
-          // ByteBuffer implementations are package private and cannot be put into TYPE_MAP.
-          ByteBuffer byteBuffer = (ByteBuffer) value;
-
-          // Assumes byte-buffer is ready to read. Also, avoid getting underlying array, as it may be over-sized.
-          byte[] bytes = new byte[byteBuffer.limit()];
-          byteBuffer.get(bytes);
-          value = bytes;
-          source = PinotDataType.BYTES;
         } else {
           // Single-value.
           source = SINGLE_VALUE_TYPE_MAP.get(value.getClass());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/AvroUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/AvroUtils.java
@@ -21,10 +21,12 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
+import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.data.GenericRow;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -291,6 +293,14 @@ public class AvroUtils {
     }
     if (fieldSpec.getDataType() == FieldSpec.DataType.STRING) {
       return avroValue.toString();
+    } else if (fieldSpec.getDataType() == FieldSpec.DataType.BYTES && avroValue instanceof ByteBuffer) {
+      // Avro ByteBuffer maps to byte[].
+      ByteBuffer byteBuffer = (ByteBuffer) avroValue;
+
+      // Assumes byte-buffer is ready to read. Also, avoid getting underlying array, as it may be over-sized.
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
+      return bytes;
     }
     return avroValue;
   }


### PR DESCRIPTION
1. Use default null value of byte[0] for BYTES data type.
2. Convert ByteBuffer type (from avro) into byte[] transform step,
instead of field extractor step.