### PR TITLE
Move to Ted Dunning's implementation of TDigest.

### DIFF
--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -154,6 +154,10 @@
       <artifactId>stream</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.xerial.larray</groupId>
       <artifactId>larray</artifactId>
       <exclusions>

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
@@ -16,11 +16,12 @@
 package com.linkedin.pinot.core.common.datatable;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.AvgPair;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.QuantileDigest;
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -104,7 +105,7 @@ public class ObjectCustomSerDe {
       case IntOpenHashSet:
         return (T) deserializeIntOpenHashSet(bytes);
       case TDigest:
-        return (T) TDigest.fromBytes(ByteBuffer.wrap(bytes));
+        return (T) MergingDigest.fromBytes(ByteBuffer.wrap(bytes));
       default:
         throw new IllegalArgumentException("Illegal object type for de-serialization: " + objectType);
     }
@@ -141,7 +142,7 @@ public class ObjectCustomSerDe {
       case IntOpenHashSet:
         return (T) deserializeIntOpenHashSet(byteBuffer);
       case TDigest:
-        return (T) TDigest.fromBytes(byteBuffer);
+        return (T) MergingDigest.fromBytes(byteBuffer);
       default:
         throw new IllegalArgumentException("Illegal object type for de-serialization: " + objectType);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import com.tdunning.math.stats.TDigest;
 import javax.annotation.Nonnull;
 
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDeTest.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.core.common.datatable;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.AvgPair;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
+import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.io.IOException;
@@ -172,7 +172,7 @@ public class ObjectCustomSerDeTest {
   public void testTDigest()
       throws IOException {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
-      TDigest expected = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+      TDigest expected = TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
       int size = RANDOM.nextInt(1000) + 2; // TDigest.quantile() requires at least 2 entries.
       for (int j = 0; j < size; j++) {
         expected.add(RANDOM.nextDouble());

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.segment.index.creator;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.google.common.primitives.Ints;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
@@ -37,6 +36,7 @@ import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverIm
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import com.linkedin.pinot.core.segment.store.SegmentDirectory;
 import com.linkedin.pinot.core.util.AvroUtils;
+import com.tdunning.math.stats.TDigest;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -276,7 +276,7 @@ public class SegmentGenerationWithBytesTypeTest {
       for (int i = 0; i < NUM_ROWS; i++) {
         GenericData.Record record = new GenericData.Record(avroSchema);
 
-        TDigest tDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+        TDigest tDigest = TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
         tDigest.add(_random.nextDouble());
 
         ByteBuffer buffer = ByteBuffer.allocate(tDigest.byteSize());

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestMVQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestMVQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
@@ -26,6 +25,7 @@ import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.tdunning.math.stats.TDigest;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,7 +56,7 @@ public class PercentileTDigestMVQueriesTest extends PercentileTDigestQueriesTest
 
       int numMultiValues = RANDOM.nextInt(MAX_NUM_MULTI_VALUES) + 1;
       Double[] values = new Double[numMultiValues];
-      TDigest tDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+      TDigest tDigest = TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
       for (int j = 0; j < numMultiValues; j++) {
         double value = RANDOM.nextDouble() * VALUE_RANGE;
         values[j] = value;

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
@@ -40,6 +39,7 @@ import com.linkedin.pinot.core.query.aggregation.function.PercentileTDigestAggre
 import com.linkedin.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.DoubleList;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -122,7 +122,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
       double value = RANDOM.nextDouble() * VALUE_RANGE;
       valueMap.put(DOUBLE_COLUMN, value);
 
-      TDigest tDigest = new TDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+      TDigest tDigest = TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
       tDigest.add(value);
       ByteBuffer byteBuffer = ByteBuffer.allocate(tDigest.byteSize());
       tDigest.asBytes(byteBuffer);

--- a/pom.xml
+++ b/pom.xml
@@ -614,6 +614,11 @@
         <version>2.7.0</version>
       </dependency>
       <dependency>
+        <groupId>com.tdunning</groupId>
+        <artifactId>t-digest</artifactId>
+        <version>3.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>


### PR DESCRIPTION
Moved from streamlib's implementation of TDigest to Ted Dunning's, as the former does not handle empty TDigest objects, and has poor performance as compared to the latter. to Move to Ted Dunning's implementation of TDigest.