### PR TITLE
[TE] detection - uniform legacy property injection

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/ConfigUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/ConfigUtils.java
@@ -52,7 +52,7 @@ public class ConfigUtils {
    */
   public static <T> List<T> getList(Object value, List<T> defaultValue) {
     if (value == null) {
-      return defaultValue;
+      return new ArrayList<>(defaultValue);
     }
 
     if (!(value instanceof Collection)) {
@@ -91,7 +91,7 @@ public class ConfigUtils {
    */
   public static <K, V> Map<K, V> getMap(Object value, Map<K, V> defaultValue) {
     if (value == null) {
-      return defaultValue;
+      return new HashMap<>(defaultValue);
     }
 
     if (!(value instanceof Map)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/DimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/DimensionWrapper.java
@@ -45,18 +45,18 @@ public class DimensionWrapper extends DetectionPipeline {
   private static final String PROP_CLASS_NAME = "className";
 
   private final String metricUrn;
-  protected final List<String> dimensions;
   private final int k;
   private final double minContribution;
   private final double minValue;
   private final double minValueHourly;
   private final double minValueDaily;
   private final Period lookback;
-  private DateTimeZone timezone;
+  private final DateTimeZone timezone;
 
-  private final Collection<String> nestedMetricUrns;
   protected final String nestedMetricUrnKey;
-  private final List<Map<String, Object>> nestedProperties;
+  protected final List<String> dimensions;
+  protected final Collection<String> nestedMetricUrns;
+  protected final List<Map<String, Object>> nestedProperties;
 
   public DimensionWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) {
     super(provider, config, startTime, endTime);
@@ -73,9 +73,7 @@ public class DimensionWrapper extends DetectionPipeline {
     this.timezone = DateTimeZone.forID(MapUtils.getString(config.getProperties(), "timezone", "America/Los_Angeles"));
 
     // prototyping
-    Preconditions.checkArgument(config.getProperties().containsKey(PROP_NESTED), "Missing " + PROP_NESTED);
-
-    this.nestedMetricUrns = (Collection<String>) MapUtils.getObject(config.getProperties(), PROP_NESTED_METRIC_URNS, Collections.singleton(this.metricUrn));
+    this.nestedMetricUrns = ConfigUtils.getList(config.getProperties().get(PROP_NESTED_METRIC_URNS), Collections.singletonList(this.metricUrn));
     this.nestedMetricUrnKey = MapUtils.getString(config.getProperties(), PROP_NESTED_METRIC_URN_KEY, PROP_NESTED_METRIC_URN_KEY_DEFAULT);
     this.nestedProperties = ConfigUtils.getList(config.getProperties().get(PROP_NESTED));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyDimensionWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyDimensionWrapper.java
@@ -1,13 +1,17 @@
 package com.linkedin.thirdeye.detection.algorithm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
+import com.linkedin.thirdeye.detection.ConfigUtils;
 import com.linkedin.thirdeye.detection.DataProvider;
 import com.linkedin.thirdeye.detection.DetectionPipeline;
 import com.linkedin.thirdeye.detection.DetectionPipelineResult;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
@@ -17,6 +21,8 @@ import org.apache.commons.collections.MapUtils;
  * The Legacy dimension wrapper. Do dimension exploration for existing anomaly functions.
  */
 public class LegacyDimensionWrapper extends DimensionWrapper {
+  private static final String PROP_METRIC_URN = "metricUrn";
+  private static final String PROP_CLASS_NAME = "className";
   private static final String PROP_SPEC = "specs";
   private static final String PROP_ANOMALY_FUNCTION_CLASS = "anomalyFunctionClassName";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -34,9 +40,8 @@ public class LegacyDimensionWrapper extends DimensionWrapper {
    * @param endTime the end time
    * @throws Exception the exception
    */
-  public LegacyDimensionWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
-      throws Exception {
-    super(provider, config, startTime, endTime);
+  public LegacyDimensionWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) throws Exception {
+    super(provider, augmentConfig(config), startTime, endTime);
 
     this.anomalyFunctionClassName = MapUtils.getString(config.getProperties(), PROP_ANOMALY_FUNCTION_CLASS);
     this.anomalyFunctionSpecs = MapUtils.getMap(config.getProperties(), PROP_SPEC);
@@ -46,6 +51,10 @@ public class LegacyDimensionWrapper extends DimensionWrapper {
     this.anomalyFunction.init(OBJECT_MAPPER.readValue(specs, AnomalyFunctionDTO.class));
     if (this.anomalyFunction.getSpec().getExploreDimensions() != null) {
       this.dimensions.add(this.anomalyFunction.getSpec().getExploreDimensions());
+    }
+
+    if (this.nestedProperties.isEmpty()) {
+      this.nestedProperties.add(Collections.singletonMap(PROP_CLASS_NAME, (Object) LegacyAnomalyFunctionAlgorithm.class.getName()));
     }
   }
 
@@ -68,5 +77,29 @@ public class LegacyDimensionWrapper extends DimensionWrapper {
     DetectionPipeline pipeline = this.provider.loadPipeline(nestedConfig, this.startTime, this.endTime);
 
     return pipeline.run();
+  }
+
+  private static DetectionConfigDTO augmentConfig(DetectionConfigDTO config) {
+    config.setProperties(augmentProperties(config.getProperties()));
+    return config;
+  }
+
+  private static Map<String, Object> augmentProperties(Map<String, Object> properties) {
+    Map<String, Object> spec = ConfigUtils.getMap(properties.get(PROP_SPEC));
+
+    if (!properties.containsKey(PROP_METRIC_URN)) {
+      long metricId = MapUtils.getLongValue(spec, "metricId");
+      String filterString = MapUtils.getString(spec, "filters");
+
+      Multimap<String, String> filters = HashMultimap.create();
+      for (String item : filterString.split(";")) {
+        String[] parts = item.split("=", 2);
+        filters.put(parts[0], parts[1]);
+      }
+
+      properties.put(PROP_METRIC_URN,MetricEntity.fromMetric(1.0, metricId, filters).getUrn());
+    }
+    
+    return properties;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/ConfigUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/ConfigUtilsTest.java
@@ -1,7 +1,11 @@
 package com.linkedin.thirdeye.detection;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
@@ -48,6 +52,22 @@ public class ConfigUtilsTest {
   @Test
   public void testGetMultimapPartialNull() {
     Assert.assertEquals(ConfigUtils.getMultimap(Collections.singletonMap("a", Arrays.asList("A", null))).size(), 2);
+  }
+
+  @Test
+  public void testGetListModification() {
+    List<String> defaultList = new ArrayList<>();
+    List<String> list = ConfigUtils.getList(null, defaultList);
+    list.add("value");
+    Assert.assertNotEquals(list, defaultList);
+  }
+
+  @Test
+  public void testGetMapModification() {
+    Map<String, String> defaultMap = new HashMap<>();
+    Map<String, String> map = ConfigUtils.getMap(null, defaultMap);
+    map.put("key", "value");
+    Assert.assertNotEquals(map, defaultMap);
   }
 
   @Test


### PR DESCRIPTION
This PR unifies legacy detection emulation property injection. It is no longer necessary to specify the default chain for "alert filter - merger - dimensions - detection". Specifying the top-level component with spec, class name, and anomaly function class name is sufficient.

As a side effect, all of the following configs work by default (i.e. only **className** changes):
* { "className": "com.linkedin.thirdeye.detection.algorithm.LegacyAlertFilterWrapper", "spec": {...}, "anomalyFunctionClassName": "..."}
* { "className": "com.linkedin.thirdeye.detection.algorithm.LegacyMergeWrapper", "spec": {...}, "anomalyFunctionClassName": "..."}
* { "className": "com.linkedin.thirdeye.detection.algorithm.LegacyDimensionWrapper", "spec": {...}, "anomalyFunctionClassName": "..."}
* { "className": "com.linkedin.thirdeye.detection.algorithm.LegacyAnomalyFunctionAlgorithm", "spec": {...}, "anomalyFunctionClassName": "..."}
