### PR TITLE
Enhance broker log for queries

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.broker.requesthandler;
 
 import com.linkedin.pinot.broker.api.RequesterIdentity;
 import com.linkedin.pinot.common.response.BrokerResponse;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.json.JSONObject;
@@ -30,7 +29,5 @@ public interface BrokerRequestHandler {
 
   void shutDown();
 
-  @Nonnull
-  BrokerResponse handleRequest(@Nonnull JSONObject request, @Nullable RequesterIdentity requesterIdentity)
-      throws Exception;
+  BrokerResponse handleRequest(JSONObject request, @Nullable RequesterIdentity requesterIdentity) throws Exception;
 }


### PR DESCRIPTION
1. Log only one line per request
2. Change 'Request' to 'RequestId' for easier grep
3. Keep only @Nullable annotation for readability

E.g. RequestId:7, table:myTable_OFFLINE, timeMs:8, docs:10/44673408, entries:0/80, servers:1/1, exceptions:0, serverStats:<hostName>_O=0,0,0,7, query:select * from myTable limit 10