### PR TITLE
When deleting task queue, enable force delete

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -138,7 +138,8 @@ public class PinotHelixTaskResourceManager {
   public synchronized void deleteTaskQueue(@Nonnull String taskType) {
     String helixJobQueueName = getHelixJobQueueName(taskType);
     LOGGER.info("Deleting task queue: {} for task type: {}", helixJobQueueName, taskType);
-    _taskDriver.delete(helixJobQueueName);
+    // NOTE: set force delete to true to remove the task queue from ZooKeeper immediately
+    _taskDriver.delete(helixJobQueueName, true);
   }
 
   /**


### PR DESCRIPTION
1. We don't care about the result of the task, so always delete all related ZNodes immediately
2. With force delete, will get exception when task queue does not exist (expected behavior)