### PR TITLE
[TE] detection - legacy emulation compensate lossy merger

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyAnomalyFunctionAlgorithm.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyAnomalyFunctionAlgorithm.java
@@ -134,9 +134,8 @@ public class LegacyAnomalyFunctionAlgorithm extends DetectionPipeline {
         public MergedAnomalyResultDTO apply(AnomalyResult result) {
           MergedAnomalyResultDTO anomaly = new MergedAnomalyResultDTO();
           anomaly.populateFrom(result);
-          anomaly.setDetectionConfigId(LegacyAnomalyFunctionAlgorithm.this.config.getId());
           anomaly.setFunctionId(null);
-          anomaly.setFunction(anomalyFunction.getSpec());
+          anomaly.setDetectionConfigId(LegacyAnomalyFunctionAlgorithm.this.config.getId());
           anomaly.setMetricUrn(metricEntity.getUrn());
           anomaly.setMetric(metricConfig.getName());
           anomaly.setCollection(metricConfig.getDataset());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/LegacyMergeWrapper.java
@@ -217,8 +217,10 @@ public class LegacyMergeWrapper extends DetectionPipeline {
       AnomalyFunctionDTO anomalyFunctionSpec = this.anomalyFunction.getSpec();
       for (MergedAnomalyResultDTO mergedAnomalyResult : mergedAnomalyResults) {
         try {
-          // anomaly meta data
-          mergedAnomalyResult.setFunction(anomalyFunctionSpec);
+          // re-populate anomaly meta data after partial erase from AnomalyTimeBasedSummarizer
+          mergedAnomalyResult.setFunctionId(null);
+          mergedAnomalyResult.setDetectionConfigId(this.config.getId());
+
           mergedAnomalyResult.setCollection(anomalyFunctionSpec.getCollection());
           mergedAnomalyResult.setMetric(anomalyFunctionSpec.getTopicMetric());
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/LegacyAnomalyFunctionAlgorithmTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/LegacyAnomalyFunctionAlgorithmTest.java
@@ -76,5 +76,7 @@ public class LegacyAnomalyFunctionAlgorithmTest {
     Assert.assertEquals(anomalies.get(0).getEndTime(), 2);
     Assert.assertEquals(anomalies.get(1).getStartTime(), 8);
     Assert.assertEquals(anomalies.get(1).getEndTime(), 9);
+    Assert.assertEquals(result.getAnomalies().get(0).getDetectionConfigId(), (Long) 125L);
+    Assert.assertNull(result.getAnomalies().get(0).getFunctionId());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/LegacyMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/LegacyMergeWrapperTest.java
@@ -114,5 +114,7 @@ public class LegacyMergeWrapperTest {
     Assert.assertEquals(result.getAnomalies().size(), 1);
     Assert.assertEquals(result.getAnomalies().get(0).getStartTime(), 0);
     Assert.assertEquals(result.getAnomalies().get(0).getEndTime(), 2300);
+    Assert.assertEquals(result.getAnomalies().get(0).getDetectionConfigId(), PROP_ID_VALUE);
+    Assert.assertNull(result.getAnomalies().get(0).getFunctionId());
   }
 }


### PR DESCRIPTION
The legacy anomaly merger performs a conversion from MergedAnomalyResultDTO to an intermediary **AnomalyResult** that loses critical data. This PR re-injects the missing meta-data in the emulation layer