### PR TITLE
Fix Swagger urls to use https if enabled

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -39,6 +39,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   private static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   private static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
+  private static final String CONSOLE_WEBAPP_USE_HTTPS = "controller.query.console.useHttps";
   private static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   private static final String RETENTION_MANAGER_FREQUENCY_IN_SECONDS = "controller.retention.frequencyInSeconds";
   private static final String VALIDATION_MANAGER_FREQUENCY_IN_SECONDS = "controller.validation.frequencyInSeconds";
@@ -118,11 +119,23 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(CONSOLE_WEBAPP_ROOT_PATH, path);
   }
 
-  public String getQueryConsole() {
+  public String getQueryConsoleWebappPath() {
     if (containsKey(CONSOLE_WEBAPP_ROOT_PATH)) {
       return (String) getProperty(CONSOLE_WEBAPP_ROOT_PATH);
     }
     return ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm();
+  }
+
+  public void setQueryConsoleUseHttps(boolean useHttps){
+    setProperty(CONSOLE_WEBAPP_USE_HTTPS, useHttps);
+  }
+
+  public boolean getQueryConsoleUseHttps() {
+    if (containsKey(CONSOLE_WEBAPP_USE_HTTPS)) {
+      return (boolean) getProperty(CONSOLE_WEBAPP_USE_HTTPS);
+    } else {
+      return false;
+    }
   }
 
   public void setJerseyAdminPrimary(String jerseyAdminPrimary) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -84,7 +84,7 @@ public class ControllerStarter {
 
   public ControllerStarter(ControllerConf conf) {
     _config = conf;
-    _adminApp = new ControllerAdminApiApplication(_config.getQueryConsole());
+    _adminApp = new ControllerAdminApiApplication(_config.getQueryConsoleWebappPath(), _config.getQueryConsoleUseHttps());
     _helixResourceManager = new PinotHelixResourceManager(_config);
     _retentionManager = new RetentionManager(_helixResourceManager, _config.getRetentionControllerFrequencyInSeconds(),
         _config.getDeletedSegmentsRetentionInDays());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
@@ -43,10 +43,12 @@ public class ControllerAdminApiApplication extends ResourceConfig {
   private boolean started = false;
   private static final String RESOURCE_PACKAGE = "com.linkedin.pinot.controller.api.resources";
   private static String CONSOLE_WEB_PATH;
+  private final boolean _useHttps;
 
-  public ControllerAdminApiApplication(String consoleWebPath) {
+  public ControllerAdminApiApplication(String consoleWebPath, boolean useHttps) {
     super();
     CONSOLE_WEB_PATH = consoleWebPath;
+    _useHttps = useHttps;
     if (!CONSOLE_WEB_PATH.endsWith("/")) {
       CONSOLE_WEB_PATH += "/";
     }
@@ -114,7 +116,11 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Controller information");
     beanConfig.setContact("https://github.com/linkedin/pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{"http"});
+    if (_useHttps) {
+      beanConfig.setSchemes(new String[]{"https"});
+    } else {
+      beanConfig.setSchemes(new String[]{"http"});
+    }
     beanConfig.setBasePath(baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);


### PR DESCRIPTION
Add a configuration parameter (controller.query.console.useHttps) that
configures the Swagger documentation to use https instead of http.