### PR TITLE
[TE] datasource - change data source properties type to Map<String, Object>

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourceConfig.java
@@ -27,14 +27,14 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class DataSourceConfig {
 
   private String className;
-  private Map<String, String> properties;
+  private Map<String, Object> properties;
   private String autoLoadClassName = null;
 
 
   public DataSourceConfig() {
 
   }
-  public DataSourceConfig(String className, Map<String, String> properties, String autoLoadClassName) {
+  public DataSourceConfig(String className, Map<String, Object> properties, String autoLoadClassName) {
     this.className = className;
     this.properties = properties;
     this.autoLoadClassName = autoLoadClassName;
@@ -46,10 +46,10 @@ public class DataSourceConfig {
   public void setClassName(String className) {
     this.className = className;
   }
-  public Map<String, String> getProperties() {
+  public Map<String, Object> getProperties() {
     return properties;
   }
-  public void setProperties(Map<String, String> properties) {
+  public void setProperties(Map<String, Object> properties) {
     this.properties = properties;
   }
   public String getAutoLoadClassName() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourcesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourcesLoader.java
@@ -60,7 +60,7 @@ public class DataSourcesLoader {
    Map<String, ThirdEyeDataSource> dataSourceMap = new HashMap<>();
    for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
      String className = dataSourceConfig.getClassName();
-     Map<String, String> properties = dataSourceConfig.getProperties();
+     Map<String, Object> properties = dataSourceConfig.getProperties();
      try {
        LOG.info("Creating thirdeye datasource {} with properties '{}'", className, properties);
        Constructor<?> constructor = Class.forName(className).getConstructor(Map.class);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSource.java
@@ -115,10 +115,10 @@ public class CSVThirdEyeDataSource implements ThirdEyeDataSource {
    * @param properties the property to initialize this data source
    * @throws Exception the exception
    */
-  public CSVThirdEyeDataSource(Map<String, String> properties) throws Exception {
+  public CSVThirdEyeDataSource(Map<String, Object> properties) throws Exception {
     Map<String, DataFrame> dataframes = new HashMap<>();
-    for (Map.Entry<String, String> property : properties.entrySet()) {
-      try (InputStreamReader reader = new InputStreamReader(makeUrlFromPath(property.getValue()).openStream())) {
+    for (Map.Entry<String, Object> property : properties.entrySet()) {
+      try (InputStreamReader reader = new InputStreamReader(makeUrlFromPath(property.getValue().toString()).openStream())) {
         dataframes.put(property.getKey(), DataFrame.fromCsv(reader));
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
@@ -83,7 +83,7 @@ public class PinotControllerResponseCacheLoader extends PinotResponseCacheLoader
    *
    * @throws Exception when an error occurs connecting to the Pinot controller.
    */
-  public void init(Map<String, String> properties) throws Exception {
+  public void init(Map<String, Object> properties) throws Exception {
     PinotThirdEyeDataSourceConfig dataSourceConfig = PinotThirdEyeDataSourceConfig.createFromProperties(properties);
     this.init(dataSourceConfig);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
@@ -28,5 +28,5 @@ public abstract class PinotResponseCacheLoader extends CacheLoader<PinotQuery, T
    *
    * @throws Exception when an error occurs connecting to the Pinot controller.
    */
-  public abstract void init(Map<String, String> properties) throws Exception;
+  public abstract void init(Map<String, Object> properties) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -104,7 +104,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
    *
    * @param properties the property to initialize this data source.
    */
-  public PinotThirdEyeDataSource(Map<String, String> properties) throws Exception {
+  public PinotThirdEyeDataSource(Map<String, Object> properties) throws Exception {
     Preconditions.checkNotNull(properties, "Data source property cannot be empty.");
 
     PinotResponseCacheLoader pinotResponseCacheLoader = getCacheLoaderInstance(properties);
@@ -124,11 +124,11 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
    *
    * @throws Exception when an error occurs connecting to the Pinot controller.
    */
-  static PinotResponseCacheLoader getCacheLoaderInstance(Map<String, String> properties)
+  static PinotResponseCacheLoader getCacheLoaderInstance(Map<String, Object> properties)
       throws Exception {
     final String cacheLoaderClassName;
     if (properties.containsKey(CACHE_LOADER_CLASS_NAME_STRING)) {
-      cacheLoaderClassName = properties.get(CACHE_LOADER_CLASS_NAME_STRING);
+      cacheLoaderClassName = properties.get(CACHE_LOADER_CLASS_NAME_STRING).toString();
     } else {
       cacheLoaderClassName = PinotControllerResponseCacheLoader.class.getName();
     }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfigTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfigTest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
-
 public class PinotThirdEyeDataSourceConfigTest {
   private static final String CONTROLLER_HOST = "host";
   private static final String CONTROLLER_PORT = "1234";
@@ -33,11 +31,11 @@ public class PinotThirdEyeDataSourceConfigTest {
   private static final String TAG = "tag";
   private static final String SPACE_STRING = "      ";
 
-  ImmutableMap<String, String> processedProperties;
+  ImmutableMap<String, Object> processedProperties;
 
   @Test
   public void testCreateProcessedPropertyMap() throws Exception {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), SPACE_STRING + CONTROLLER_HOST);
     properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT + SPACE_STRING);
     properties.put(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue(), ZOOKEEPER_URL + SPACE_STRING);
@@ -45,14 +43,14 @@ public class PinotThirdEyeDataSourceConfigTest {
     properties.put(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue(), SPACE_STRING + BROKER_URL);
     properties.put(PinotThirdeyeDataSourceProperties.TAG.getValue(), TAG + SPACE_STRING);
 
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
     builder.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), CONTROLLER_HOST);
     builder.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT);
     builder.put(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue(), ZOOKEEPER_URL);
     builder.put(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue(), CLUSTER_NAME);
     builder.put(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue(), BROKER_URL);
     builder.put(PinotThirdeyeDataSourceProperties.TAG.getValue(), TAG);
-    ImmutableMap<String, String> expectedProperties = builder.build();
+    ImmutableMap<String, Object> expectedProperties = builder.build();
 
     processedProperties = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
 
@@ -61,29 +59,29 @@ public class PinotThirdEyeDataSourceConfigTest {
 
   @Test
   public void testCreateProcessedPropertyMapWithEmptyMap() throws Exception {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
 
-    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
+    ImmutableMap<String, Object> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
 
     Assert.assertNull(processPropertyMap);
   }
 
   @Test
   public void testCreateProcessedPropertyMapWithNullMap() throws Exception {
-    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(null);
+    ImmutableMap<String, Object> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(null);
 
     Assert.assertNull(processPropertyMap);
   }
 
   @Test
   public void testProcessPropertyMapWithMissingProperties() throws Exception {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), SPACE_STRING + CONTROLLER_HOST);
     properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT + SPACE_STRING);
     // Missing ZOOKEEPER_URL
     properties.put(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue(), SPACE_STRING + CLUSTER_NAME);
     // Returned a null property map
-    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
+    ImmutableMap<String, Object> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
 
     Assert.assertNull(processPropertyMap);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
@@ -27,7 +27,7 @@ public class PinotThirdEyeDataSourceTest {
 
   @Test
   public void testInitializeCacheLoaderFromGivenClass() throws Exception {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put(PinotThirdEyeDataSource.CACHE_LOADER_CLASS_NAME_STRING,
         PinotControllerResponseCacheLoader.class.getName());
 
@@ -37,7 +37,7 @@ public class PinotThirdEyeDataSourceTest {
 
   @Test
   public void testInitializeCacheLoaderFromEmptyClass() throws Exception {
-    Map<String, String> properties = Collections.emptyMap();
+    Map<String, Object> properties = Collections.emptyMap();
 
     PinotResponseCacheLoader cacheLoaderInstance = PinotThirdEyeDataSource.getCacheLoaderInstance(properties);
     Assert.assertTrue(PinotControllerResponseCacheLoader.class.equals(cacheLoaderInstance.getClass()));


### PR DESCRIPTION
Data source configs in ThirdEye currently artificially limit the YAML interface to String/String tuples. This PR allows data source properties to be nested as arbitrary String/Object tuples and enables more realistic configuration scenarios.