### PR TITLE
[TE] Add support for cc and bcc recipients in the legacy pipeline

### DIFF
--- a/thirdeye/thirdeye-frontend/app/mocks/alertConfig.js
+++ b/thirdeye/thirdeye-frontend/app/mocks/alertConfig.js
@@ -27,7 +27,11 @@ export default [
       "contactEmail": "simba@disney.com"
     },
     "alertGroupConfig": null,
-    "recipients": "simba@disney.com",
+    "receiverAddresses": {
+        "to": ["kopa@disney.com", "kiara@disney.com", "kion@disney.com"],
+        "cc": ["simba@disney.com, nala@disney.com"],
+        "bcc": ["scar@disney.com"]
+    },
     "fromAddress": "mufasa@disney.com"
   }, {
     "id": 2,
@@ -58,6 +62,8 @@ export default [
       "contactEmail": "gaston@disney.com"
     },
     "alertGroupConfig": null,
-    "recipients": "gaston@disney.com",
+    "receiverAddresses": {
+      "to": ["gaston@disney.com"]
+    },
     "fromAddress": "belle@disney.com"
   }];

--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/component.js
@@ -202,10 +202,22 @@ export default Component.extend({
   groupNameMessage: null,
 
   /**
-   * Temp storage for group recipients from text input
+   * Temp storage for recipients(to) from text input
    * @type {String}
    */
-  groupRecipients: null,
+  toAddresses: null,
+
+  /**
+   * Temp storage for recipients(cc) from text input
+   * @type {String}
+   */
+  ccAddresses: null,
+
+  /**
+   * Temp storage for recipients(bcc) from text input
+   * @type {String}
+   */
+  BccAddresses: null,
 
   /**
    * Group options available in database
@@ -474,9 +486,17 @@ export default Component.extend({
     /**
      * Handles recipient updates
      */
-    onRecipients () {
-      const recipients = get(this, 'groupRecipients');
-      set(this, 'group.recipients', recipients.replace(/[^!-~]+/g, '').replace(/,+/g, ','));
+    onToAddresses () {
+      const toAddresses = get(this, 'toAddresses');
+      set(this, 'group.receiverAddresses.to', toAddresses.replace(/[^!-~]+/g, '').replace(/,+/g, ',').split(','));
+    },
+    onCcAddresses () {
+      const ccAddresses = get(this, 'ccAddresses');
+      set(this, 'group.receiverAddresses.cc', ccAddresses.replace(/[^!-~]+/g, '').replace(/,+/g, ',').split(','));
+    },
+    onBccAddresses () {
+      const bccAddresses = get(this, 'bccAddresses');
+      set(this, 'group.receiverAddresses.bcc', bccAddresses.replace(/[^!-~]+/g, '').replace(/,+/g, ',').split(','));
     },
 
     /**
@@ -524,7 +544,9 @@ export default Component.extend({
       setProperties(this, {
         application: null,
         group: null,
-        groupRecipients: null,
+        toAddresses: null,
+        ccAddresses: null,
+        bccAddresses: null,
         showManageGroupsModal: false,
         changeCache: new Set(),
         groupNameMessage: null
@@ -551,7 +573,9 @@ export default Component.extend({
         .then(res => setProperties(this, {
           application: null,
           group: null,
-          groupRecipients: null,
+          toAddresses: null,
+          ccAddresses: null,
+          bccAddresses: null,
           showManageGroupsModal: false,
           changeCache: new Set(),
           groupNameMessage: null
@@ -574,7 +598,9 @@ export default Component.extend({
         application: group.application, // in case not set
         group,
         groupFunctionIds: (group.emailConfig.functionIds || []).join(', '),
-        groupRecipients: (group.recipients || '').split(',').join(', ')
+        toAddresses: (group.receiverAddresses.to || []).join(', '),
+        ccAddresses: (group.receiverAddresses.cc || []).join(', '),
+        bccAddresses: (group.receiverAddresses.bcc || []).join(', '),
       });
 
       this._validateGroupName(group);
@@ -623,7 +649,13 @@ export default Component.extend({
      */
     onApplication (applicationOption) {
       this._updateChangeCache();
-      setProperties(this, { application: applicationOption.application, group: null, groupRecipients: null, groupNameMessage: null });
+      setProperties(this, {
+        application: applicationOption.application,
+        group: null,
+        toAddresses: null,
+        ccAddresses: null,
+        bccAddresses: null,
+        groupNameMessage: null });
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/template.hbs
@@ -179,18 +179,57 @@
 
   <div class="row te-modal__settings">
     <div class="col-md-2">
-      <span class="te-label te-label--bold te-label--dark">Recipients</span>
+      <span class="te-label te-label--bold te-label--dark">To</span>
     </div>
     <div class="col-md-10">
       {{textarea-autosize
         cols=80
         rows=3
+        placeholder="Enter recipients (comma separated). E.g., user1@linkedin.com, user2@linkedin.com"
         type="text"
-        id="recipients"
-        value=groupRecipients
+        id="to-addresses"
+        value=toAddresses
         class="te-modal__input te-modal__input--fullwidth"
         disabled=cannotEdit
-        change=(action "onRecipients")
+        change=(action "onToAddresses")
+      }}
+    </div>
+  </div>
+
+  <div class="row te-modal__settings">
+    <div class="col-md-2">
+      <span class="te-label te-label--bold te-label--dark">Cc</span>
+    </div>
+    <div class="col-md-10">
+      {{textarea-autosize
+        cols=80
+        rows=1
+        placeholder="Enter recipients (comma separated). E.g., user1@linkedin.com, user2@linkedin.com"
+        type="text"
+        id="cc-addresses"
+        value=ccAddresses
+        class="te-modal__input te-modal__input--fullwidth"
+        disabled=cannotEdit
+        change=(action "onCcAddresses")
+      }}
+    </div>
+  </div>
+
+  <div class="row te-modal__settings">
+    <div class="col-md-2">
+      <span class="te-label te-label--bold te-label--dark">Bcc</span>
+    </div>
+    <div class="col-md-10">
+      {{textarea-autosize
+        cols=80
+        rows=1
+        placeholder="Enter recipients (comma separated). E.g., user1@linkedin.com, user2@linkedin.com"
+        type="text"
+        id="bcc-addresses"
+        value=bccAddresses
+        class="te-modal__input te-modal__input--fullwidth"
+        disabled=cannotEdit
+        change=(action "onBccAddresses")
       }}
     </div>
   </div>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -905,9 +905,9 @@ export default Controller.extend({
      * @return {undefined}
      */
     onSelectConfigGroup(selectedObj) {
-      const toAddr = (selectedObj.receiverAddresses || []).to.join(", ");
-      const ccAddr = (selectedObj.receiverAddresses || []).cc.join(", ");
-      const bccAddr = (selectedObj.receiverAddresses || []).bcc.join(", ");
+      const toAddr = ((selectedObj.receiverAddresses || []).to || []).join(", ");
+      const ccAddr = ((selectedObj.receiverAddresses || []).cc || []).join(", ");
+      const bccAddr = ((selectedObj.receiverAddresses || []).bcc || []).join(", ");
       this.setProperties({
         selectedConfigGroup: selectedObj,
         newConfigGroupName: null,
@@ -1005,7 +1005,7 @@ export default Controller.extend({
         }
         this.setProperties({
           isDuplicateEmail,
-          duplicateEmails: badEmailArr.join()
+          duplicateEmails: badEmailArr.join(", ")
         });
       }
     },

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -500,7 +500,7 @@ export default Controller.extend({
     let isEmailPresent = true;
 
     if (this.get('selectedConfigGroup') || this.get('newConfigGroupName')) {
-      isEmailPresent = isPresent(this.get('selectedGroupRecipients')) || isPresent(emailArr);
+      isEmailPresent = isPresent(this.get('selectedGroupToRecipients')) || isPresent(emailArr);
     }
 
     return isEmailPresent;
@@ -736,7 +736,9 @@ export default Controller.extend({
       selectedConfigGroup: null,
       newConfigGroupName: null,
       alertGroupNewRecipient: null,
-      selectedGroupRecipients: null,
+      selectedGroupToRecipients: null,
+      selectedGroupBccRecipients: null,
+      selectedGroupCcRecipients: null,
       isProcessingForm: false,
       isCreateGroupSuccess: false,
       isGroupNameDuplicate: false,
@@ -903,12 +905,16 @@ export default Controller.extend({
      * @return {undefined}
      */
     onSelectConfigGroup(selectedObj) {
-      const emails = selectedObj.recipients || '';
+      const toAddr = (selectedObj.receiverAddresses || []).to.join(", ");
+      const ccAddr = (selectedObj.receiverAddresses || []).cc.join(", ");
+      const bccAddr = (selectedObj.receiverAddresses || []).bcc.join(", ");
       this.setProperties({
         selectedConfigGroup: selectedObj,
         newConfigGroupName: null,
-        isEmptyEmail: isEmpty(emails),
-        selectedGroupRecipients: emails.split(',').filter(e => String(e).trim()).join(', ')
+        isEmptyEmail: isEmpty(toAddr),
+        selectedGroupToRecipients: toAddr,
+        selectedGroupCcRecipients: ccAddr,
+        selectedGroupBccRecipients: bccAddr
       });
       this.prepareFunctions(selectedObj).then(functionData => {
         this.set('selectedGroupFunctions', functionData);
@@ -958,7 +964,9 @@ export default Controller.extend({
       this.setProperties({
         newConfigGroupName: name,
         selectedConfigGroup: null,
-        selectedGroupRecipients: null,
+        selectedGroupToRecipients: null,
+        selectedGroupCcRecipients: null,
+        selectedGroupBccRecipients: null,
         isEmptyEmail: isEmpty(this.get('alertGroupNewRecipient'))
       });
     },
@@ -971,7 +979,7 @@ export default Controller.extend({
      */
     validateAlertEmail(emailInput) {
       const newEmailArr = emailInput.replace(/\s+/g, '').split(',');
-      let existingEmailArr = this.get('selectedGroupRecipients');
+      let existingEmailArr = this.get('selectedGroupToRecipients');
       let cleanEmailArr = [];
       let badEmailArr = [];
       let isDuplicateEmail = false;

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -347,9 +347,6 @@
         {{#if selectedGroupCcRecipients}}
           <div class="te-form__sub-label"><span class="te-form__sub-label--strong">Cc: {{selectedGroupCcRecipients}}</span></div>
         {{/if}}
-        {{#if selectedGroupBccRecipients}}
-        <div class="te-form__sub-label"><span class="te-form__sub-label--strong">Bcc: {{selectedGroupBccRecipients}}</span></div>
-        {{/if}}
       </label>
       {{#if isDuplicateEmail}}
         <div class="te-form__alert--warning alert-warning">Warning: <strong>{{duplicateEmails}}</strong> is already included in this group.</div>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -343,7 +343,13 @@
     <div class="col-xs-12 te-form__section-config">
       <label for="config-group" class="control-label te-label te-label--taller">
         Recipients in subscription group <span class="stronger">{{selectedConfigGroup.name}}</span>:
-        <div class="te-form__sub-label"><span class="te-form__sub-label--strong">{{if selectedGroupRecipients selectedGroupRecipients "No recipients yet"}}</span></div>
+        <div class="te-form__sub-label"><span class="te-form__sub-label--strong">To: {{if selectedGroupToRecipients selectedGroupToRecipients "No recipients yet"}}</span></div>
+        {{#if selectedGroupCcRecipients}}
+          <div class="te-form__sub-label"><span class="te-form__sub-label--strong">Cc: {{selectedGroupCcRecipients}}</span></div>
+        {{/if}}
+        {{#if selectedGroupBccRecipients}}
+        <div class="te-form__sub-label"><span class="te-form__sub-label--strong">Bcc: {{selectedGroupBccRecipients}}</span></div>
+        {{/if}}
       </label>
       {{#if isDuplicateEmail}}
         <div class="te-form__alert--warning alert-warning">Warning: <strong>{{duplicateEmails}}</strong> is already included in this group.</div>
@@ -360,7 +366,7 @@
         class="form-control te-input"
         focus-out="validateAlertEmail"
         key-up="validateAlertEmail"
-        placeholder="Add recipients. Type email addresses, separated by commas"
+        placeholder="Add the email addresses separated by commas. You can edit this or add cc and bcc fields later from the edit notification settings."
         autocomplete=false
         value=alertGroupNewRecipient
         disabled=(not generalFieldsEnabled)

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -13,7 +13,9 @@ module('Acceptance | create alert', function(hooks) {
   const id = '1';
   const selectedConfigGroup = `test_alert_${id}`;
   const selectedMetric = `test_collection_${id}::test_metric_${id}`;
-  const groupRecipient = 'simba@disney.com';
+  const toRecipients = 'kopa@disney.com, kiara@disney.com, kion@disney.com';
+  const ccRecipients = 'simba@disney.com, nala@disney.com';
+  const bccRecipients = 'scar@disney.com';
   const newRecipient = 'duane@therock.com';
   const selectedApp = 'the-lion-king';
   const alertNameGeneric = `test_function_${id}`;
@@ -124,15 +126,15 @@ module('Acceptance | create alert', function(hooks) {
     );
     assert.equal(
       $(selfServeConst.CONFIG_BLOCK).find('.control-label').get(0).innerText.replace(/\r?\n?/g, ''),
-      `Recipients in subscription group ${selectedConfigGroup}:${groupRecipient}`,
+      `Recipients in subscription group ${selectedConfigGroup}:To: ${toRecipients}Cc: ${ccRecipients}Bcc: ${bccRecipients}`,
       'Label and email for recipients is correctly rendered'
     );
 
-    await fillIn(selfServeConst.CONFIG_RECIPIENTS_INPUT, groupRecipient);
+    await fillIn(selfServeConst.CONFIG_RECIPIENTS_INPUT, toRecipients);
     await triggerKeyEvent(selfServeConst.CONFIG_RECIPIENTS_INPUT, 'keyup', '8');
     assert.equal(
       $(selfServeConst.EMAIL_WARNING).get(0).innerText,
-      `Warning: ${groupRecipient} is already included in this group.`,
+      `Warning: ${toRecipients} is already included in this group.`,
       'Duplicate email warning appears correctly.'
     );
 

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -126,7 +126,7 @@ module('Acceptance | create alert', function(hooks) {
     );
     assert.equal(
       $(selfServeConst.CONFIG_BLOCK).find('.control-label').get(0).innerText.replace(/\r?\n?/g, ''),
-      `Recipients in subscription group ${selectedConfigGroup}:To: ${toRecipients}Cc: ${ccRecipients}Bcc: ${bccRecipients}`,
+      `Recipients in subscription group ${selectedConfigGroup}:To: ${toRecipients}Cc: ${ccRecipients}`,
       'Label and email for recipients is correctly rendered'
     );
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/EmailEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/EmailEntity.java
@@ -16,12 +16,13 @@
 
 package com.linkedin.thirdeye.alert.commons;
 
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import org.apache.commons.mail.HtmlEmail;
 
 
 public class EmailEntity {
   private String from;
-  private String to;
+  private DetectionAlertFilterRecipients to;
   private String subject;
   private HtmlEmail content;
 
@@ -29,7 +30,7 @@ public class EmailEntity {
 
   }
 
-  public EmailEntity(String from, String to, String subject, HtmlEmail content) {
+  public EmailEntity(String from, DetectionAlertFilterRecipients to, String subject, HtmlEmail content) {
     this.from = from;
     this.to = to;
     this.subject = subject;
@@ -44,11 +45,11 @@ public class EmailEntity {
     this.from = from;
   }
 
-  public String getTo() {
+  public DetectionAlertFilterRecipients getTo() {
     return to;
   }
 
-  public void setTo(String to) {
+  public void setTo(DetectionAlertFilterRecipients to) {
     this.to = to;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
@@ -46,6 +46,7 @@ import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean.COMPARE_MODE;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.linkedin.thirdeye.detector.email.filter.DummyAlertFilter;
 import com.linkedin.thirdeye.detector.email.filter.PrecisionRecallEvaluator;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
@@ -144,7 +145,7 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
   }
 
   @Override
-  public EmailEntity getEmailEntity(AlertConfigDTO alertConfigDTO, String recipients, String subject,
+  public EmailEntity getEmailEntity(AlertConfigDTO alertConfigDTO, DetectionAlertFilterRecipients recipients, String subject,
       Long groupId, String groupName, Collection<AnomalyResult> anomalies, EmailContentFormatterContext context) {
     Map<String, Object> templateData = getTemplateData(alertConfigDTO, groupId, groupName, anomalies);
 
@@ -278,13 +279,13 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
    * Apply the parameter map to given email template, and format it as EmailEntity
    * @param paramMap
    * @param subject
-   * @param emailRecipients
+   * @param recipients
    * @param fromEmail
    * @param emailTemplate
    * @return
    */
-  public EmailEntity buildEmailEntity(Map<String, Object> paramMap, String subject, String emailRecipients,
-      String fromEmail, String emailTemplate) {
+  public EmailEntity buildEmailEntity(Map<String, Object> paramMap, String subject,
+      DetectionAlertFilterRecipients recipients, String fromEmail, String emailTemplate) {
     if (Strings.isNullOrEmpty(fromEmail)) {
       throw new IllegalArgumentException("Invalid sender's email");
     }
@@ -314,7 +315,7 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
       String alertEmailHtml = new String(baos.toByteArray(), AlertTaskRunnerV2.CHARSET);
 
       emailEntity.setFrom(fromEmail);
-      emailEntity.setTo(EmailUtils.getValidEmailAddresses(emailRecipients));
+      emailEntity.setTo(recipients);
       emailEntity.setSubject(subject);
       email.setHtmlMsg(alertEmailHtml);
       emailEntity.setContent(email);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/EmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/EmailContentFormatter.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.alert.commons.EmailEntity;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DetectionAlertConfigDTO;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -48,7 +49,7 @@ public interface EmailContentFormatter {
    * @param anomalies
    * @return
    */
-  EmailEntity getEmailEntity(AlertConfigDTO alertConfigDTO, String recipients, String subject,
+  EmailEntity getEmailEntity(AlertConfigDTO alertConfigDTO, DetectionAlertFilterRecipients recipients, String subject,
       Long groupId, String groupName, Collection<AnomalyResult> anomalies, EmailContentFormatterContext context);
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/OnboardingNotificationEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/OnboardingNotificationEmailContentFormatter.java
@@ -92,7 +92,9 @@ public class OnboardingNotificationEmailContentFormatter extends BaseEmailConten
       alertConfig = new AlertConfigDTO();
     }
     templateData.put("application", returnValueOrDefault(alertConfig.getApplication(), DEFAULT_NULL_STRING_VALUE));
-    templateData.put("recipients", returnValueOrDefault(alertConfig.getRecipients(), DEFAULT_NULL_STRING_VALUE));
+    templateData.put("recipients", returnValueOrDefault(StringUtils.join(alertConfig.getReceiverAddresses().getTo(), ','), DEFAULT_NULL_STRING_VALUE));
+    templateData.put("ccRecipients", returnValueOrDefault(StringUtils.join(alertConfig.getReceiverAddresses().getCc(), ','), DEFAULT_NULL_STRING_VALUE));
+    templateData.put("bccRecipients", returnValueOrDefault(StringUtils.join(alertConfig.getReceiverAddresses().getBcc(), ','), DEFAULT_NULL_STRING_VALUE));
   }
 
   private String returnValueOrDefault(String value, String defaultValue) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -37,6 +37,7 @@ import com.linkedin.thirdeye.datalayer.dto.EventDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.linkedin.thirdeye.detector.email.filter.PrecisionRecallEvaluator;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 import freemarker.template.Configuration;
@@ -140,7 +141,8 @@ public class AnomalyReportGenerator {
    * @param emailSubjectName the name of this alert configuration.
    */
   public void buildReport(Long groupId, String groupName, List<MergedAnomalyResultDTO> anomalies,
-      ThirdEyeAnomalyConfiguration configuration, String recipients, String emailSubjectName, AlertConfigDTO alertConfig) {
+      ThirdEyeAnomalyConfiguration configuration, DetectionAlertFilterRecipients recipients, String emailSubjectName,
+      AlertConfigDTO alertConfig) {
     String subject = "Thirdeye Alert : " + emailSubjectName;
     long startTime = System.currentTimeMillis();
     long endTime = 0;
@@ -162,8 +164,8 @@ public class AnomalyReportGenerator {
   //
   public void buildReport(long startTime, long endTime, Long groupId, String groupName,
       List<MergedAnomalyResultDTO> anomalies, String subject, ThirdEyeAnomalyConfiguration configuration,
-      boolean includeSentAnomaliesOnly, String emailRecipients, String emailSubjectName, AlertConfigDTO alertConfig,
-      boolean includeSummary) {
+      boolean includeSentAnomaliesOnly, DetectionAlertFilterRecipients recipients, String emailSubjectName,
+      AlertConfigDTO alertConfig, boolean includeSummary) {
     if (anomalies == null || anomalies.size() == 0) {
       LOG.info("No anomalies found to send email, please check the parameters.. exiting");
     } else {
@@ -318,7 +320,7 @@ public class AnomalyReportGenerator {
 
       // TODO remove this code. It is dead (minus certain endpoints).
       buildEmailTemplateAndSendAlert(templateData, configuration.getSmtpConfiguration(), subject,
-          emailRecipients, alertConfig.getFromAddress(), email);
+          recipients, alertConfig.getFromAddress(), email);
 
       if (StringUtils.isNotBlank(imgPath)) {
         try {
@@ -331,8 +333,8 @@ public class AnomalyReportGenerator {
   }
 
   void buildEmailTemplateAndSendAlert(Map<String, Object> paramMap,
-      SmtpConfiguration smtpConfiguration, String subject, String emailRecipients,
-      String fromEmail, HtmlEmail email) {
+      SmtpConfiguration smtpConfiguration, String subject, DetectionAlertFilterRecipients recipients, String fromEmail,
+      HtmlEmail email) {
     if (Strings.isNullOrEmpty(fromEmail)) {
       throw new IllegalArgumentException("Invalid sender's email");
     }
@@ -348,8 +350,7 @@ public class AnomalyReportGenerator {
       template.process(paramMap, out);
 
       String alertEmailHtml = new String(baos.toByteArray(), AlertTaskRunnerV2.CHARSET);
-      EmailHelper.sendEmailWithHtml(email, smtpConfiguration, subject, alertEmailHtml, fromEmail,
-          emailRecipients);
+      EmailHelper.sendEmailWithHtml(email, smtpConfiguration, subject, alertEmailHtml, fromEmail, recipients);
     } catch (Exception e) {
       Throwables.propagate(e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
@@ -21,10 +21,10 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.alert.commons.EmailEntity;
-import com.linkedin.thirdeye.alert.content.EmailContentFormatterConfiguration;
 import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertTaskRunnerV2;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 import com.linkedin.thirdeye.dashboard.Utils;
@@ -33,9 +33,12 @@ import com.linkedin.thirdeye.dashboard.views.contributor.ContributorViewRequest;
 import com.linkedin.thirdeye.dashboard.views.contributor.ContributorViewResponse;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 
+import com.linkedin.thirdeye.detection.alert.AlertUtils;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
@@ -67,8 +70,6 @@ public abstract class EmailHelper {
   private static final long DAY_MILLIS = TimeUnit.DAYS.toMillis(1);
   private static final long WEEK_MILLIS = TimeUnit.DAYS.toMillis(7);
 
-  public static final String EMAIL_ADDRESS_SEPARATOR = ",";
-
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
@@ -82,15 +83,15 @@ public abstract class EmailHelper {
   }
 
   public static void sendEmailWithTextBody(HtmlEmail email, SmtpConfiguration smtpConfigutation, String subject,
-      String textBody, String fromAddress, String toAddress) throws EmailException {
+      String textBody, String fromAddress, DetectionAlertFilterRecipients recipients) throws EmailException {
     email.setTextMsg(textBody);
-    sendEmail(smtpConfigutation, email, subject, fromAddress, toAddress);
+    sendEmail(smtpConfigutation, email, subject, fromAddress, recipients);
   }
 
   public static void sendEmailWithHtml(HtmlEmail email, SmtpConfiguration smtpConfiguration, String subject,
-      String htmlBody, String fromAddress, String toAddress) throws EmailException {
+      String htmlBody, String fromAddress, DetectionAlertFilterRecipients recipients) throws EmailException {
     email.setHtmlMsg(htmlBody);
-    sendEmail(smtpConfiguration, email, subject, fromAddress, toAddress);
+    sendEmail(smtpConfiguration, email, subject, fromAddress, recipients);
   }
 
   public static void sendEmailWithEmailEntity(EmailEntity emailEntity, SmtpConfiguration smtpConfiguration)
@@ -100,10 +101,10 @@ public abstract class EmailHelper {
 
   /** Sends email according to the provided config. */
   private static void sendEmail(SmtpConfiguration config, HtmlEmail email, String subject,
-      String fromAddress, String toAddress) throws EmailException {
+      String fromAddress, DetectionAlertFilterRecipients recipients) throws EmailException {
     if (config != null) {
       email.setSubject(subject);
-      LOG.info("Sending email to {}", toAddress);
+      LOG.info("Sending email to {}", recipients.toString());
       email.setHostName(config.getSmtpHost());
       email.setSmtpPort(config.getSmtpPort());
       if (config.getSmtpUser() != null && config.getSmtpPassword() != null) {
@@ -112,11 +113,15 @@ public abstract class EmailHelper {
         email.setSSLOnConnect(true);
       }
       email.setFrom(fromAddress);
-      for (String address : toAddress.split(EMAIL_ADDRESS_SEPARATOR)) {
-        email.addTo(address);
+      email.setTo(AlertUtils.toAddress(recipients.getTo()));
+      if (CollectionUtils.isNotEmpty(recipients.getCc())) {
+        email.setCc(AlertUtils.toAddress(recipients.getCc()));
+      }
+      if (CollectionUtils.isNotEmpty(recipients.getBcc())) {
+        email.setBcc(AlertUtils.toAddress(recipients.getBcc()));
       }
       email.send();
-      LOG.info("Email sent with subject [{}] to address [{}]!", subject, toAddress);
+      LOG.info("Email sent with subject [{}] to address [{}]!", subject, recipients.toString());
     } else {
       LOG.error("No email config provided for email with subject [{}]!", subject);
     }
@@ -224,12 +229,13 @@ public abstract class EmailHelper {
 
   public static void sendFailureEmailForScreenshot(String anomalyId, Throwable t, ThirdEyeConfiguration thirdeyeConfig)
       throws JobExecutionException {
-    sendFailureEmailForScreenshot(anomalyId, t, thirdeyeConfig.getSmtpConfiguration(), thirdeyeConfig.getFailureFromAddress(),
-        thirdeyeConfig.getFailureToAddress());
+    sendFailureEmailForScreenshot(anomalyId, t, thirdeyeConfig.getSmtpConfiguration(),
+        thirdeyeConfig.getFailureFromAddress(),
+        new DetectionAlertFilterRecipients(EmailUtils.getValidEmailAddresses(thirdeyeConfig.getFailureToAddress())));
   }
 
   public static void sendFailureEmailForScreenshot(String anomalyId, Throwable t, SmtpConfiguration smtpConfiguration,
-    String failureFromAddress, String failureToAddress) throws JobExecutionException {
+    String failureFromAddress, DetectionAlertFilterRecipients failureToAddress) throws JobExecutionException {
     HtmlEmail email = new HtmlEmail();
     String subject = String
         .format("[ThirdEye Anomaly Detector] FAILED SCREENSHOT FOR ANOMALY ID=%s", anomalyId);
@@ -261,7 +267,8 @@ public abstract class EmailHelper {
 
     try {
       EmailHelper.sendEmailWithTextBody(email, thirdeyeConfig.getSmtpConfiguration(), subject, textBody.toString(),
-              thirdeyeConfig.getFailureFromAddress(), thirdeyeConfig.getFailureToAddress());
+          thirdeyeConfig.getFailureFromAddress(),
+          new DetectionAlertFilterRecipients(EmailUtils.getValidEmailAddresses(thirdeyeConfig.getFailureToAddress())));
     } catch (EmailException e) {
       LOG.error("Exception in sending email notification for incomplete datasets", e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailScreenshotHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailScreenshotHelper.java
@@ -18,7 +18,9 @@ package com.linkedin.thirdeye.anomaly.alert.util;
 
 import com.linkedin.thirdeye.alert.content.EmailContentFormatterConfiguration;
 import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -67,7 +69,8 @@ public class EmailScreenshotHelper {
       LOG.info("Finished with result: {}", result);
     } catch (Exception e) {
       LOG.error("Exception in fetching screenshot for anomaly id {}", anomalyId, e);
-      EmailHelper.sendFailureEmailForScreenshot(anomalyId, e.fillInStackTrace(), smtpConfiguration, failureFromAddress, failureToAddress);
+      EmailHelper.sendFailureEmailForScreenshot(anomalyId, e.fillInStackTrace(), smtpConfiguration, failureFromAddress,
+          new DetectionAlertFilterRecipients(EmailUtils.getValidEmailAddresses(failureToAddress)));
     }
     return result;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/framework/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/framework/DetectionOnBoardJobRunner.java
@@ -22,8 +22,11 @@ import com.linkedin.thirdeye.anomaly.alert.util.EmailHelper;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -52,7 +55,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
   private final TimeUnit taskTimeOutUnit;
   private final SmtpConfiguration smtpConfiguration;
   private final String failureNotificationSender;
-  private final String failureNotificationReceiver;
+  private final DetectionAlertFilterRecipients failureNotificationReceiver;
   private final boolean notifyIfFails;
 
   public DetectionOnBoardJobRunner(DetectionOnboardJobContext jobContext, List<DetectionOnboardTask> tasks,
@@ -81,7 +84,8 @@ public class DetectionOnBoardJobRunner implements Runnable {
       smtpConfiguration = null;
     }
     failureNotificationSender = configuration.getString(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER_ADDRESS);
-    failureNotificationReceiver = configuration.getString(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS);
+    Set<String> toAddresses = EmailUtils.getValidEmailAddresses(configuration.getString(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS));
+    failureNotificationReceiver = new DetectionAlertFilterRecipients(toAddresses);
     notifyIfFails = configuration.getBoolean(DefaultDetectionOnboardJob.NOTIFY_IF_FAILS,
         DefaultDetectionOnboardJob.DEFAULT_NOTIFY_IF_FAILS);
   }
@@ -132,7 +136,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
       // Notify upon exception
       if (notifyIfFails && !TaskConstants.TaskStatus.COMPLETED.equals(taskStatus.getTaskStatus())) {
         if (smtpConfiguration == null || StringUtils.isBlank(failureNotificationSender)
-            || StringUtils.isBlank(failureNotificationReceiver)) {
+            || failureNotificationReceiver.getTo().isEmpty()) {
           LOG.warn("SmtpConfiguration, and email sender/recipients cannot be null or empty");
         } else {
           try {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -69,6 +69,8 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String ALERT_CRON = "alertCron";
   public static final String ALERT_FROM = "alertSender";
   public static final String ALERT_TO = "alertRecipients";
+  public static final String ALERT_CC = "ccRecipients";
+  public static final String ALERT_BCC = "bccRecipients";
   public static final String ALERT_APPLICATION = "application";
   public static final String ANOMALY_FUNCTION_CONFIG = "anomalyFuncitonConfig";
   public static final String ALERT_CONFIG = "alertConfig";
@@ -207,6 +209,12 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     }
     if (this.properties.containsKey(ALERT_TO)) {
       taskConfigs.put(taskPrefix + ALERT_TO, this.properties.get(ALERT_TO));
+    }
+    if (this.properties.containsKey(ALERT_CC)) {
+      taskConfigs.put(taskPrefix + ALERT_CC, this.properties.get(ALERT_CC));
+    }
+    if (this.properties.containsKey(ALERT_BCC)) {
+      taskConfigs.put(taskPrefix + ALERT_BCC, this.properties.get(ALERT_BCC));
     }
     if (this.properties.containsKey(ALERT_APPLICATION)) {
       taskConfigs.put(taskPrefix + ALERT_APPLICATION, this.properties.get(ALERT_APPLICATION));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -35,6 +35,7 @@ import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean.EmailConfig;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
@@ -44,6 +45,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
@@ -91,7 +93,10 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
   public static final String ALERT_CRON = DefaultDetectionOnboardJob.ALERT_CRON;
   public static final String ALERT_FROM = DefaultDetectionOnboardJob.ALERT_FROM;
   public static final String ALERT_TO = DefaultDetectionOnboardJob.ALERT_TO;
+  public static final String ALERT_CC = DefaultDetectionOnboardJob.ALERT_CC;
+  public static final String ALERT_BCC = DefaultDetectionOnboardJob.ALERT_BCC;
   public static final String ALERT_APPLICATION = DefaultDetectionOnboardJob.ALERT_APPLICATION;
+  public static final String DEFAULT_ALERT_SENDER = DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER_ADDRESS;
   public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS;
 
   public static final Boolean DEFAULT_IS_ACTIVE = true;
@@ -262,14 +267,10 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       emailConfig.getFunctionIds().add(anomalyFunction.getId());
 
       // Add recipients to existing alert group
-      String recipients = configuration.getString(ALERT_TO);
-      if (StringUtils.isNotBlank(recipients)) {
-        if (StringUtils.isNotBlank(alertConfig.getRecipients())) {
-          recipients = recipients + "," + alertConfig.getRecipients();
-        }
-        recipients = EmailUtils.getValidEmailAddresses(recipients);
-        alertConfig.setRecipients(recipients);
-      }
+      alertConfig.getReceiverAddresses().getTo().addAll(EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_TO)));
+      alertConfig.getReceiverAddresses().getCc().addAll(EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_CC)));
+      alertConfig.getReceiverAddresses().getBcc().addAll(EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_BCC)));
+
       alertConfigDAO.update(alertConfig);
     } else {
       alertConfig = new AlertConfigDTO();
@@ -277,15 +278,20 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       emailConfig.setFunctionIds(Arrays.asList(anomalyFunction.getId()));
       alertConfig.setEmailConfig(emailConfig);
       alertConfig.setName(configuration.getString(ALERT_NAME));
-      String thirdeyeDefaultEmail = configuration.getString(DEFAULT_ALERT_RECEIVER);
-      alertConfig.setFromAddress(configuration.getString(ALERT_FROM, thirdeyeDefaultEmail));
-      String alertRecipients = thirdeyeDefaultEmail;
-      if (configuration.containsKey(ALERT_TO)) {
-        alertRecipients = alertRecipients + "," + configuration.getString(ALERT_TO);
+
+      Set<String> toAddresses = EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_TO));
+      Set<String> ccAddresses = EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_CC));
+      ccAddresses.addAll(EmailUtils.getValidEmailAddresses(configuration.getString(DEFAULT_ALERT_RECEIVER)));
+      Set<String> bccAddresses = EmailUtils.getValidEmailAddresses(configuration.getString(ALERT_BCC));
+
+      Set<String> defaultSender = EmailUtils.getValidEmailAddresses(configuration.getString(DEFAULT_ALERT_SENDER));
+      if (defaultSender.isEmpty()) {
+        throw new IllegalArgumentException("No sender configured for the emails. Please set " + DEFAULT_ALERT_SENDER);
       }
-      alertRecipients = EmailUtils.getValidEmailAddresses(alertRecipients);
+      alertConfig.setFromAddress(configuration.getString(ALERT_FROM, defaultSender.iterator().next()));
+
+      alertConfig.setReceiverAddresses(new DetectionAlertFilterRecipients(toAddresses, ccAddresses, bccAddresses));
       alertConfig.setApplication(configuration.getString(ALERT_APPLICATION));
-      alertConfig.setRecipients(alertRecipients);
       alertConfig.setCronExpression(configuration.getString(ALERT_CRON, DEFAULT_ALERT_CRON));
       alertConfigDAO.save(alertConfig);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
@@ -139,7 +139,7 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask {
     context.setEnd(end);
 
     emailContentFormatter.init(new Properties(), emailFormatterConfig);
-    EmailEntity emailEntity = emailContentFormatter.getEmailEntity(alertConfig, alertConfig.getRecipients(),
+    EmailEntity emailEntity = emailContentFormatter.getEmailEntity(alertConfig, alertConfig.getReceiverAddresses(),
         subject, null, "", filteredAnomalyResults, context);
     try {
       EmailHelper.sendEmailWithEmailEntity(emailEntity, smtpConfiguration);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/EmailUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/EmailUtils.java
@@ -16,11 +16,11 @@
 
 package com.linkedin.thirdeye.anomaly.utils;
 
+import com.google.api.client.util.Sets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import org.apache.commons.lang.StringUtils;
@@ -49,23 +49,21 @@ public class EmailUtils {
   }
 
   /**
-   * Return a list of valid email addresses
+   * Parse and return a set of valid email addresses
    * @param emails comma separated list of emails
    * @return
    */
-  public static String getValidEmailAddresses(String emails) {
-    List<String> emailAddressList= new ArrayList<>();
-    Set<String> addedEmailAddresses = new HashSet<>();
+  public static Set<String> getValidEmailAddresses(String emails) {
+    Set<String> validEmailAddresses = new HashSet<>();
     List<String> invalidEmailAddresses = new ArrayList<>();
     if (StringUtils.isBlank(emails)) {
-      return null;
+      return Sets.newHashSet();
     } else {
       String[] emailArr = emails.split(",");
       for (String email : emailArr) {
         email = email.trim();
-        if (isValidEmailAddress(email) && !addedEmailAddresses.contains(email)) {
-          emailAddressList.add(email);
-          addedEmailAddresses.add(email);
+        if (isValidEmailAddress(email)) {
+          validEmailAddresses.add(email);
         } else {
           invalidEmailAddresses.add(email);
         }
@@ -74,6 +72,6 @@ public class EmailUtils {
     if (invalidEmailAddresses.size() > 0) {
       LOG.warn("Found invalid email addresses, please verify the email addresses: {}", invalidEmailAddresses);
     }
-    return StringUtils.join(emailAddressList, ",");
+    return validEmailAddresses;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -181,7 +181,7 @@ public class DetectionJobResource {
       @QueryParam("speedup") @DefaultValue("false") final Boolean speedup,
       @QueryParam("userDefinedPattern") @DefaultValue("UP") String userDefinedPattern,
       @QueryParam("sensitivity") @DefaultValue("MEDIUM") final String sensitivity, @QueryParam("from") String fromAddr,
-      @QueryParam("to") String toAddr,
+      @QueryParam("to") String toAddr, @QueryParam("cc") String ccAddr, @QueryParam("bcc") String bccAddr,
       @QueryParam("teHost") String teHost, @QueryParam("smtpHost") String smtpHost,
       @QueryParam("smtpPort") Integer smtpPort, @QueryParam("phantomJsPath") String phantomJsPath) {
 
@@ -210,8 +210,8 @@ public class DetectionJobResource {
       String replayFailureSubject =
           new StringBuilder("Replay failed on metric: " + anomalyFunctionDAO.findById(id).getMetric()).toString();
       String replayFailureText = new StringBuilder("Failed on Function: " + id + "with Job Id: " + jobId).toString();
-      emailResource.sendEmailWithText(null, null, replayFailureSubject, replayFailureText,
-          smtpHost, smtpPort);
+      emailResource.sendEmailWithText(null, null, null,  null, replayFailureSubject,
+          replayFailureText, smtpHost, smtpPort);
       return Response.status(Status.BAD_REQUEST).entity("Replay job error with job status: {}" + jobStatus).build();
     } else {
       numReplayedAnomalies =
@@ -233,8 +233,8 @@ public class DetectionJobResource {
     String subject = new StringBuilder(
         "Replay results for " + anomalyFunctionDAO.findById(id).getFunctionName() + " is ready for review!").toString();
 
-    emailResource.generateAndSendAlertForFunctions(startTime, endTime, String.valueOf(id), fromAddr, toAddr, subject,
-        false, true, teHost, smtpHost, smtpPort, phantomJsPath);
+    emailResource.generateAndSendAlertForFunctions(startTime, endTime, String.valueOf(id), fromAddr, toAddr, ccAddr,
+        bccAddr, subject, false, true, teHost, smtpHost, smtpPort, phantomJsPath);
     LOG.info("Sent out email");
 
     return Response.ok("Replay, Tuning and Notification finished!").build();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -46,7 +46,6 @@ public class AlertConfigBean extends AbstractBean {
   ReportConfigCollection reportConfigCollection;
   AlertGroupConfig alertGroupConfig;
   EmailFormatterConfig emailFormatterConfig;
-  String recipients;
   DetectionAlertFilterRecipients receiverAddresses;
   String fromAddress;
   SubjectType subjectType = SubjectType.ALERT;
@@ -69,14 +68,6 @@ public class AlertConfigBean extends AbstractBean {
 
   public void setFromAddress(String fromAddress) {
     this.fromAddress = fromAddress;
-  }
-
-  public String getRecipients() {
-    return recipients;
-  }
-
-  public void setRecipients(String recipients) {
-    this.recipients = recipients;
   }
 
   public DetectionAlertFilterRecipients getReceiverAddresses() {
@@ -389,13 +380,13 @@ public class AlertConfigBean extends AbstractBean {
         .equals(getReportConfigCollection(), that.getReportConfigCollection()) && Objects
         .equals(getAlertGroupConfig(), that.getAlertGroupConfig()) && Objects
         .equals(getEmailFormatterConfig(), that.getEmailFormatterConfig()) && Objects
-        .equals(getRecipients(), that.getRecipients()) && Objects.equals(getFromAddress(), that.getFromAddress());
+        .equals(getReceiverAddresses(), that.getReceiverAddresses()) && Objects.equals(getFromAddress(), that.getFromAddress());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getName(), getApplication(), getCronExpression(), getHolidayCronExpression(), isActive(),
         getAnomalyFeedConfig(), getEmailConfig(), getReportConfigCollection(), getAlertGroupConfig(),
-        getEmailFormatterConfig(), getRecipients(), getFromAddress());
+        getEmailFormatterConfig(), getReceiverAddresses(), getFromAddress());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/AlertUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/AlertUtils.java
@@ -21,8 +21,11 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.mysql.jdbc.StringUtils;
 import java.util.Collection;
+import java.util.Collections;
 import javax.mail.internet.InternetAddress;
+import org.apache.commons.collections.CollectionUtils;
 
 
 public class AlertUtils {
@@ -45,11 +48,14 @@ public class AlertUtils {
    * Helper to convert a collection of email strings into {@code InternetAddress} instances, filtering
    * out invalid addresses and nulls.
    *
-   * @param strings email address strings
+   * @param emailCollection collection of email address strings
    * @return filtered collection of InternetAddress objects
    */
-  public static Collection<InternetAddress> toAddress(Collection<String> strings) {
-    return Collections2.filter(Collections2.transform(strings,
+  public static Collection<InternetAddress> toAddress(Collection<String> emailCollection) {
+    if (CollectionUtils.isEmpty(emailCollection)) {
+      return Collections.emptySet();
+    }
+    return Collections2.filter(Collections2.transform(emailCollection,
         new Function<String, InternetAddress>() {
           @Override
           public InternetAddress apply(String s) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/DetectionAlertFilterRecipients.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/DetectionAlertFilterRecipients.java
@@ -16,8 +16,14 @@
 
 package com.linkedin.thirdeye.detection.alert;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import javax.validation.constraints.NotNull;
 
 
 /**
@@ -32,6 +38,10 @@ public class DetectionAlertFilterRecipients {
     this.to = to;
     this.cc = cc;
     this.bcc = bcc;
+  }
+
+  public DetectionAlertFilterRecipients(Set<String> to) {
+    this.to = to;
   }
 
   public DetectionAlertFilterRecipients() {
@@ -79,5 +89,14 @@ public class DetectionAlertFilterRecipients {
   @Override
   public int hashCode() {
     return Objects.hash(to, cc, bcc);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("TO", Arrays.toString((getTo() != null) ? getTo().toArray() : new String[]{}))
+        .add("CC", Arrays.toString((getCc() != null) ? getCc().toArray() : new String[]{}))
+        .add("BCC", Arrays.toString((getBcc() != null) ? getBcc().toArray() : new String[]{}))
+        .toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/DetectionAlertTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/DetectionAlertTaskRunner.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
@@ -170,9 +171,9 @@ public class DetectionAlertTaskRunner implements TaskRunner {
       Set<MergedAnomalyResultDTO> anomalies = entry.getValue();
 
       if (!this.thirdeyeConfig.getEmailWhitelist().isEmpty()) {
-        recipients.to.retainAll(this.thirdeyeConfig.getEmailWhitelist());
-        recipients.cc.retainAll(this.thirdeyeConfig.getEmailWhitelist());
-        recipients.bcc.retainAll(this.thirdeyeConfig.getEmailWhitelist());
+        recipients.getTo().retainAll(this.thirdeyeConfig.getEmailWhitelist());
+        recipients.getCc().retainAll(this.thirdeyeConfig.getEmailWhitelist());
+        recipients.getBcc().retainAll(this.thirdeyeConfig.getEmailWhitelist());
       }
 
       if (recipients.to.isEmpty()) {
@@ -201,9 +202,13 @@ public class DetectionAlertTaskRunner implements TaskRunner {
 
       HtmlEmail email = emailEntity.getContent();
       email.setFrom(this.detectionAlertConfig.getFrom());
-      email.setTo(AlertUtils.toAddress(recipients.to));
-      email.setCc(AlertUtils.toAddress(recipients.cc));
-      email.setBcc(AlertUtils.toAddress(recipients.bcc));
+      email.setTo(AlertUtils.toAddress(recipients.getTo()));
+      if (CollectionUtils.isNotEmpty(recipients.getCc())) {
+        email.setCc(AlertUtils.toAddress(recipients.getCc()));
+      }
+      if (CollectionUtils.isNotEmpty(recipients.getBcc())) {
+        email.setBcc(AlertUtils.toAddress(recipients.getBcc()));
+      }
 
       this.sendEmail(emailEntity);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/filter/DimensionDetectionAlertFilter.java
@@ -90,7 +90,8 @@ public class DimensionDetectionAlertFilter extends StatefulDetectionAlertFilter 
 
     // generate recipients-anomalies mapping
     for (Map.Entry<String, Collection<MergedAnomalyResultDTO>> entry : grouped.asMap().entrySet()) {
-      result.addMapping(new DetectionAlertFilterRecipients(this.makeGroupRecipients(entry.getKey()), this.cc, this.bcc), new HashSet<>(entry.getValue()));
+      result.addMapping(new DetectionAlertFilterRecipients(this.makeGroupRecipients(entry.getKey()), this.cc, this.bcc),
+          new HashSet<>(entry.getValue()));
     }
 
     return result;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/filter/LegacyAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/filter/LegacyAlertFilter.java
@@ -88,9 +88,7 @@ public class LegacyAlertFilter extends DetectionAlertFilter {
             }
           });
 
-      result.addMapping(new DetectionAlertFilterRecipients(
-          new HashSet<>(Arrays.asList(this.alertConfig.getRecipients().split(","))), Collections.<String>emptySet(), Collections.<String>emptySet()), new HashSet<>(anomalies));
-
+      result.addMapping(this.alertConfig.getReceiverAddresses(), new HashSet<>(anomalies));
     }
 
     return result;

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/onboard-notification-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/onboard-notification-email-template.ftl
@@ -67,10 +67,26 @@
               </tr>
               <tr>
                 <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
-                  Mailing list
+                  Mailing list (to)
                 </td>
                 <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
                   ${recipients}
+                </td>
+              </tr>
+              <tr>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
+                  Mailing list (cc)
+                </td>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
+                ${ccRecipients}
+                </td>
+              </tr>
+              <tr>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
+                  Mailing list (bcc)
+                </td>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
+                ${bccRecipients}
                 </td>
               </tr>
             </table>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/onboard-notification-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/onboard-notification-email-template.ftl
@@ -81,14 +81,6 @@
                 ${ccRecipients}
                 </td>
               </tr>
-              <tr>
-                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
-                  Mailing list (bcc)
-                </td>
-                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
-                ${bccRecipients}
-                </td>
-              </tr>
             </table>
             </td>
           </tr>

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestHierarchicalAnomaliesEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestHierarchicalAnomaliesEmailContentFormatter.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.alert.commons.EmailEntity;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
 import com.linkedin.thirdeye.anomaly.task.TaskDriverConfiguration;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datalayer.DaoTestUtils;
@@ -30,6 +31,7 @@ import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.lang.reflect.Field;
@@ -140,7 +142,9 @@ public class TestHierarchicalAnomaliesEmailContentFormatter {
 
     EmailContentFormatter contentFormatter = new HierarchicalAnomaliesEmailContentFormatter();
     contentFormatter.init(new Properties(), EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(thirdeyeAnomalyConfig));
-    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, "a@b.com", TEST,
+    DetectionAlertFilterRecipients recipients = new DetectionAlertFilterRecipients(
+        EmailUtils.getValidEmailAddresses("a@b.com"));
+    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, recipients, TEST,
         null, "", anomalies, null);
 
     String htmlPath = ClassLoader.getSystemResource("test-hierarchical-anomalies-email-content-formatter.html").getPath();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestMultipleAnomaliesEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestMultipleAnomaliesEmailContentFormatter.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.alert.commons.EmailEntity;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
 import com.linkedin.thirdeye.anomaly.task.TaskDriverConfiguration;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datalayer.DaoTestUtils;
@@ -32,6 +33,7 @@ import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.lang.reflect.Field;
@@ -120,7 +122,9 @@ public class TestMultipleAnomaliesEmailContentFormatter {
 
     EmailContentFormatter contentFormatter = new MultipleAnomaliesEmailContentFormatter();
     contentFormatter.init(new Properties(), EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(thirdeyeAnomalyConfig));
-    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, "a@b.com", TEST,
+    DetectionAlertFilterRecipients recipients = new DetectionAlertFilterRecipients(
+        EmailUtils.getValidEmailAddresses("a@b.com"));
+    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, recipients, TEST,
         null, "", anomalies, null);
 
     String htmlPath = ClassLoader.getSystemResource("test-multiple-anomalies-email-content-formatter.html").getPath();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestOnboardingNotificationContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/alert/content/TestOnboardingNotificationContentFormatter.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.alert.commons.EmailEntity;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
 import com.linkedin.thirdeye.anomaly.task.TaskDriverConfiguration;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datalayer.DaoTestUtils;
@@ -31,6 +32,7 @@ import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.lang.reflect.Field;
@@ -115,7 +117,9 @@ public class TestOnboardingNotificationContentFormatter {
     context.setAlertConfig(alertConfigDTO);
     EmailContentFormatter contentFormatter = new OnboardingNotificationEmailContentFormatter();
     contentFormatter.init(new Properties(), EmailContentFormatterConfiguration.fromThirdEyeAnomalyConfiguration(thirdeyeAnomalyConfig));
-    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, "a@b.com", TEST,
+    DetectionAlertFilterRecipients recipients = new DetectionAlertFilterRecipients(
+        EmailUtils.getValidEmailAddresses("a@b.com"));
+    EmailEntity emailEntity = contentFormatter.getEmailEntity(alertConfigDTO, recipients, TEST,
         null, "", anomalies, context);
 
     String htmlPath = ClassLoader.getSystemResource("test-onboard-notification-email-content-formatter.html").getPath();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/utils/TestEmailUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/utils/TestEmailUtils.java
@@ -16,6 +16,8 @@
 
 package com.linkedin.thirdeye.anomaly.utils;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,9 +37,14 @@ public class TestEmailUtils {
   @Test
   public void testGetValidEmailAddresses() {
     String emailAddresses = "user1@host1.domain1,user2@host1.domain1";
-    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses), emailAddresses);
-    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses + ",user"), emailAddresses);
-    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses + ",user1@host1.domain1"), emailAddresses);
-    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses + ",, , user1@host1.domain1,  "), emailAddresses);
+
+    Set<String> emailAddressesExpected = new HashSet<>();
+    emailAddressesExpected.add("user1@host1.domain1");
+    emailAddressesExpected.add("user2@host1.domain1");
+
+    Assert.assertTrue(EmailUtils.getValidEmailAddresses(emailAddresses).equals(emailAddressesExpected));
+    Assert.assertTrue(EmailUtils.getValidEmailAddresses(emailAddresses + ",user").equals(emailAddressesExpected));
+    Assert.assertTrue(EmailUtils.getValidEmailAddresses(emailAddresses + ",user1@host1.domain1").equals(emailAddressesExpected));
+    Assert.assertTrue(EmailUtils.getValidEmailAddresses(emailAddresses + ",, , user1@host1.domain1,  ").equals(emailAddressesExpected));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -26,6 +26,7 @@ import com.linkedin.thirdeye.alert.commons.AnomalySource;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.anomalydetection.context.RawAnomalyResult;
 import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluationMethod;
@@ -47,10 +48,10 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
-import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.linkedin.thirdeye.detector.email.filter.AlphaBetaAlertFilter;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
@@ -103,7 +104,12 @@ public class DaoTestUtils {
     alertConfigDTO.setActive(true);
     alertConfigDTO.setApplication("test");
     alertConfigDTO.setFromAddress("te@linkedin.com");
-    alertConfigDTO.setRecipients("anomaly@linedin.com");
+
+    DetectionAlertFilterRecipients recipients = new DetectionAlertFilterRecipients(
+        EmailUtils.getValidEmailAddresses("anomaly-to@linedin.com"),
+        EmailUtils.getValidEmailAddresses("anomaly-cc@linedin.com"),
+        EmailUtils.getValidEmailAddresses("anomaly-bcc@linedin.com"));
+    alertConfigDTO.setReceiverAddresses(recipients);
     alertConfigDTO.setCronExpression("0/10 * * * * ?");
     AlertConfigBean.EmailConfig emailConfig = new AlertConfigBean.EmailConfig();
     emailConfig.setAnomalyWatermark(0l);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/filter/LegacyAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/filter/LegacyAlertFilterTest.java
@@ -24,7 +24,6 @@ import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterResult;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,10 +41,14 @@ public class LegacyAlertFilterTest {
   private static final String PROP_LEGACY_ALERT_FILTER_CONFIG = "legacyAlertFilterConfig";
   private static final String PROP_LEGACY_ALERT_CONFIG = "legacyAlertConfig";
   private static final String PROP_LEGACY_ALERT_FILTER_CLASS_NAME = "legacyAlertFilterClassName";
-  private static final String RECIPIENTS_VALUES = "test@example.com,mytest@example.org";
+  private static final String TO_RECIPIENTS_VALUES = "test@example.com,mytest@example.org";
+  private static final String CC_RECIPIENTS_VALUES = "iamcc@host.domain,iamcc2@host.domain";
+  private static final String BCC_RECIPIENTS_VALUES = "iambcc@host.domain";
 
-  private static final DetectionAlertFilterRecipients RECIPIENTS =
-      new DetectionAlertFilterRecipients(new HashSet<>(Arrays.asList("test@example.com", "mytest@example.org")), Collections.<String>emptySet(), Collections.<String>emptySet());
+  private static final DetectionAlertFilterRecipients RECEIVER_ADDRESSES = new DetectionAlertFilterRecipients(
+      new HashSet<>(Arrays.asList(TO_RECIPIENTS_VALUES)),
+      new HashSet<>(Arrays.asList(CC_RECIPIENTS_VALUES)),
+      new HashSet<>(Arrays.asList(BCC_RECIPIENTS_VALUES)));
 
   private List<MergedAnomalyResultDTO> detectedAnomalies;
   private LegacyAlertFilter legacyAlertFilter;
@@ -66,7 +69,7 @@ public class LegacyAlertFilterTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put(PROP_DETECTION_CONFIG_IDS, PROP_ID_VALUE);
     Map<String, Object> alertConfig = new HashMap<>();
-    alertConfig.put("recipients", RECIPIENTS_VALUES);
+    alertConfig.put("receiverAddresses", RECEIVER_ADDRESSES);
     properties.put(PROP_LEGACY_ALERT_CONFIG, alertConfig);
     properties.put(PROP_LEGACY_ALERT_FILTER_CLASS_NAME, "com.linkedin.thirdeye.detector.email.filter.DummyAlertFilter");
     properties.put(PROP_LEGACY_ALERT_FILTER_CONFIG, "");
@@ -80,7 +83,7 @@ public class LegacyAlertFilterTest {
   @Test
   public void testRun() throws Exception {
     DetectionAlertFilterResult result = this.legacyAlertFilter.run();
-    Assert.assertEquals(result.getResult().get(RECIPIENTS),
+    Assert.assertEquals(result.getResult().get(RECEIVER_ADDRESSES),
         new HashSet<>(this.detectedAnomalies.subList(0, 4)));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/filter/ToAllRecipientsDetectionAlertFilterTest.java
@@ -51,7 +51,8 @@ public class ToAllRecipientsDetectionAlertFilterTest {
   private static final List<Long> PROP_ID_VALUE = Arrays.asList(1001L, 1002L);
   private static final String PROP_SEND_ONCE = "sendOnce";
 
-  private static final DetectionAlertFilterRecipients RECIPIENTS = new DetectionAlertFilterRecipients(new HashSet<>(PROP_TO_VALUE), new HashSet<>(PROP_CC_VALUE), new HashSet<>(PROP_BCC_VALUE));
+  private static final DetectionAlertFilterRecipients RECIPIENTS = new DetectionAlertFilterRecipients(
+      new HashSet<>(PROP_TO_VALUE), new HashSet<>(PROP_CC_VALUE), new HashSet<>(PROP_BCC_VALUE));
 
   private DetectionAlertFilter alertFilter;
   private List<MergedAnomalyResultDTO> detectedAnomalies;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/AnomalyReportConfig.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/AnomalyReportConfig.java
@@ -16,13 +16,16 @@
 
 package com.linkedin.thirdeye.tools.anomaly.report;
 
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
+
+
 public class AnomalyReportConfig {
   private String startTimeIso;
   private String endTimeIso;
   private String thirdEyeConfigDirectoryPath;
   private String datasets;
   private String teBaseUrl;
-  private String emailRecipients;
+  private DetectionAlertFilterRecipients emailRecipients;
   private boolean includeNotifiedOnly = true;
 
   public String getEndTimeIso() {
@@ -65,11 +68,11 @@ public class AnomalyReportConfig {
     this.thirdEyeConfigDirectoryPath = thirdEyeConfigDirectoryPath;
   }
 
-  public String getEmailRecipients() {
+  public DetectionAlertFilterRecipients getEmailRecipients() {
     return emailRecipients;
   }
 
-  public void setEmailRecipients(String emailRecipients) {
+  public void setEmailRecipients(DetectionAlertFilterRecipients emailRecipients) {
     this.emailRecipients = emailRecipients;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/GenerateAnomalyReport.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/GenerateAnomalyReport.java
@@ -34,6 +34,7 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
@@ -69,11 +70,11 @@ public class GenerateAnomalyReport {
   List<String> collections;
   String dashboardUrl;
   SmtpConfiguration smtpConfiguration;
-  String emailRecipients;
+  DetectionAlertFilterRecipients emailRecipients;
 
   public GenerateAnomalyReport(Date startTime, Date endTime, File persistenceConfig,
       List<String> datasets, String dashboardUrl, SmtpConfiguration smtpConfiguration,
-      String emailRecipients) {
+      DetectionAlertFilterRecipients emailRecipients) {
     DaoProviderUtil.init(persistenceConfig);
     anomalyResultManager = DaoProviderUtil.getInstance(MergedAnomalyResultManagerImpl.class);
     metricConfigManager = DaoProviderUtil.getInstance(MetricConfigManagerImpl.class);

--- a/thirdeye/thirdeye-pinot/src/test/resources/test-onboard-notification-email-content-formatter.html
+++ b/thirdeye/thirdeye-pinot/src/test/resources/test-onboard-notification-email-content-formatter.html
@@ -67,10 +67,26 @@
               </tr>
               <tr>
                 <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
-                  Mailing list
+                  Mailing list (to)
                 </td>
                 <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
-                  anomaly@linedin.com
+                  anomaly-to@linedin.com
+                </td>
+              </tr>
+              <tr>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
+                  Mailing list (cc)
+                </td>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
+                  anomaly-cc@linedin.com
+                </td>
+              </tr>
+              <tr>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
+                  Mailing list (bcc)
+                </td>
+                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
+                  anomaly-bcc@linedin.com
                 </td>
               </tr>
             </table>

--- a/thirdeye/thirdeye-pinot/src/test/resources/test-onboard-notification-email-content-formatter.html
+++ b/thirdeye/thirdeye-pinot/src/test/resources/test-onboard-notification-email-content-formatter.html
@@ -81,14 +81,6 @@
                   anomaly-cc@linedin.com
                 </td>
               </tr>
-              <tr>
-                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px;">
-                  Mailing list (bcc)
-                </td>
-                <td colspan="1" style="color: #606060; font-size: 14px; line-height: 20px; font-weight: bold;">
-                  anomaly-bcc@linedin.com
-                </td>
-              </tr>
             </table>
           </td>
         </tr>


### PR DESCRIPTION
**Changes:**
* Added cc & bcc support in the backend legacy pipeline.
* Support to configure cc & bcc fields in the Edit Notification Settings.
* Display the recipients (to, cc & bcc) on the Alert Creation Page. No option added to configure cc & bcc from here.
* Alert config example:
```
    "receiverAddresses": {
        "to": [
            "abc@linkedin.com",
            "def@linkedin.com"
        ],
        "cc": [
            "xyz@linkedin.com",
            "pqr@linkedin.com"
        ],
        "bcc": []
    },
```
* Instance is deployed on my machine. ('http://\<you-know-my-user-id\>-ld2:4200')

**Testing:**
* Unit tests updated
* Verified emails are sent correctly through local deployment