### PR TITLE
[TE] THIRDEYE-1997: disable dimensions in graph

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
@@ -77,6 +77,7 @@
       availableDimensions=availableDimensions
       selectedDimension=alertDimension
       graphMailtoLink=graphMailtoLink
+      isTopDimensionsAllowed=false
       isDimensionError=false
       isMetricSelected=true
       metricData=metricData

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -1,5 +1,5 @@
 <div class="te-graph-alert {{if isMetricDataPending 'te-graph-alert--pending'}}">
-  {{#if (or isFetchingDimensions isDimensionFetchDone)}}
+  {{#if (and (or isFetchingDimensions isDimensionFetchDone) isTopDimensionsAllowed)}}
     {{#if isDimensionError}}
       <div class="te-form__super-label">... error loading subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
     {{else}}
@@ -18,7 +18,7 @@
         primaryMetric=metricData
         selectedDimensions=selectedDimensions
         dimensions=topDimensions
-        showDimensions=true
+        showDimensions=false
         isLoading=loading
         showSubchart=true
         showLegend=true

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -138,6 +138,7 @@
         isMetricSelected=true
         componentId='alert-page'
         topDimensions=topDimensions
+        isTopDimensionsAllowed=false
         selectedDimension=alertDimension
         selectedDimensions=selectedDimensions
         graphMailtoLink=graphMailtoLink

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -100,6 +100,7 @@
       metricData=selectedMetric
       componentId='create-alert'
       topDimensions=topDimensions
+      isTopDimensionsAllowed=false
       graphMailtoLink=graphMailtoLink
       selectedDimension=selectedDimension
       selectedDimensions=selectedDimensions


### PR DESCRIPTION
Following up on the PR by @apucher to disable timeseries fetching by dimension, I'm conditionally displaying dimension-related UI elements in the `self-serve-graph` component.

Tests passing.