### PR TITLE
[PINOT-7011] Log errors caught during query processing

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -122,6 +122,8 @@ public abstract class QueryScheduler {
     try {
       dataTable = queryExecutor.processQuery(queryRequest, executorService);
     } catch (Exception e) {
+      LOGGER.error("Encountered exception while processing requestId {} from broker {}",
+          queryRequest.getRequestId(), queryRequest.getBrokerId(), e);
       // For not handled exceptions
       serverMetrics.addMeteredGlobalValue(ServerMeter.UNCAUGHT_EXCEPTIONS, 1);
       dataTable = new DataTableImplV2();


### PR DESCRIPTION
Most server query processing errors get sent back to the broker; the broker logging may not always have the server context when it logs the errors. This change logs the errors locally on the server as well.