### PR TITLE
[PINOT-7047] Emit metrics for docs scanned per query on server

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -35,7 +35,6 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   KAFKA_PARTITION_OFFSET_LAG("messages", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   RUNNING_QUERIES("runningQueries", false),
-  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false),
   REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false);
 
   private final String gaugeName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -52,9 +52,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LLC_CONTROLLER_RESPONSE_COMMIT_CONTINUE("messages", true),
   LLC_CONTROLLER_RESPONSE_PROCESSED("messages", true),
   LLC_CONTROLLER_RESPONSE_UPLOAD_SUCCESS("messages", true),
-  NUM_DOCS_SCANNED("rows", true),
-  NUM_DOCS_SCANNED_IN_FILTER("rows", true),
-  NUM_DOCS_SCANNED_POST_FILTER("rows", true);
+  NUM_DOCS_SCANNED("rows", false),
+  NUM_ENTRIES_SCANNED_IN_FILTER("entries", false),
+  NUM_ENTRIES_SCANNED_POST_FILTER("entries", false),
+  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false);
 
   private final String meterName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -51,7 +51,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   LLC_CONTROLLER_RESPONSE_COMMIT_SUCCESS("messages", true),
   LLC_CONTROLLER_RESPONSE_COMMIT_CONTINUE("messages", true),
   LLC_CONTROLLER_RESPONSE_PROCESSED("messages", true),
-  LLC_CONTROLLER_RESPONSE_UPLOAD_SUCCESS("messages", true);
+  LLC_CONTROLLER_RESPONSE_UPLOAD_SUCCESS("messages", true),
+  NUM_DOCS_SCANNED("rows", true),
+  NUM_DOCS_SCANNED_IN_FILTER("rows", true),
+  NUM_DOCS_SCANNED_POST_FILTER("rows", true);
 
   private final String meterName;
   private final String unit;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -135,27 +135,28 @@ public abstract class QueryScheduler {
 
     // Log the statistics
     long numDocsScanned = 0;
-    long numDocsScannedInFilter = 0;
-    long numDocsScannedPostFilter = 0;
+    long numEntriesScannedInFilter = 0;
+    long numEntriesScannedPostFilter = 0;
     try {
       numDocsScanned = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_DOCS_SCANNED_METADATA_KEY));
-      numDocsScannedInFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY));
-      numDocsScannedPostFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY));
-    } catch (NumberFormatException ignored) {
-      // best effort conversion only
+      numEntriesScannedInFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY));
+      numEntriesScannedPostFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY));
+      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
+      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
+      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
+    } catch (NumberFormatException e) {
+      LOGGER.error("Encountered error converting to long ", e);
     }
+
     TimerContext timerContext = queryRequest.getTimerContext();
     LOGGER.info(
         "Processed requestId={},table={},reqSegments={},prunedToSegmentCount={},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
         requestId, queryRequest.getTableNameWithType(), queryRequest.getSegmentsToQuery().size(),
         queryRequest.getSegmentCountAfterPruning(), timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(),
-        numDocsScanned, numDocsScannedInFilter, numDocsScannedPostFilter, name());
-    serverMetrics.setValueOfTableGauge(queryRequest.getTableNameWithType(), ServerGauge.NUM_SEGMENTS_SEARCHED,
+        numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
+    serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_SEGMENTS_SEARCHED,
         queryRequest.getSegmentCountAfterPruning());
-    serverMetrics.addMeteredGlobalValue(ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
-    serverMetrics.addMeteredGlobalValue(ServerMeter.NUM_DOCS_SCANNED_IN_FILTER, numDocsScannedInFilter);
-    serverMetrics.addMeteredGlobalValue(ServerMeter.NUM_DOCS_SCANNED_POST_FILTER, numDocsScannedPostFilter);
 
     return responseData;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.linkedin.pinot.common.exception.QueryException;
-import com.linkedin.pinot.common.metrics.ServerGauge;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
@@ -137,13 +136,14 @@ public abstract class QueryScheduler {
     long numDocsScanned = 0;
     long numEntriesScannedInFilter = 0;
     long numEntriesScannedPostFilter = 0;
+    String tableNameWithType = queryRequest.getTableNameWithType();
     try {
       numDocsScanned = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_DOCS_SCANNED_METADATA_KEY));
       numEntriesScannedInFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY));
       numEntriesScannedPostFilter = Long.parseLong(getMetadataValue(dataTableMetadata, DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY));
-      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
-      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
-      serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
     } catch (NumberFormatException e) {
       LOGGER.error("Encountered error converting to long ", e);
     }
@@ -151,11 +151,11 @@ public abstract class QueryScheduler {
     TimerContext timerContext = queryRequest.getTimerContext();
     LOGGER.info(
         "Processed requestId={},table={},reqSegments={},prunedToSegmentCount={},totalExecMs={},totalTimeMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={}",
-        requestId, queryRequest.getTableNameWithType(), queryRequest.getSegmentsToQuery().size(),
+        requestId, tableNameWithType, queryRequest.getSegmentsToQuery().size(),
         queryRequest.getSegmentCountAfterPruning(), timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
         timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), queryRequest.getBrokerId(),
         numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, name());
-    serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.NUM_SEGMENTS_SEARCHED,
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_SEGMENTS_SEARCHED,
         queryRequest.getSegmentCountAfterPruning());
 
     return responseData;


### PR DESCRIPTION
The values are currently only logged per query. Exposing as metrics can help correlate with CPU usage and other graphs.