### PR TITLE
Optimize TDigest tests

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/ObjectCustomSerDe.java
@@ -43,7 +43,6 @@ public class ObjectCustomSerDe {
   private ObjectCustomSerDe() {
   }
 
-
   /**
    * Given an object, serialize it into a byte array.
    */
@@ -105,7 +104,7 @@ public class ObjectCustomSerDe {
       case IntOpenHashSet:
         return (T) deserializeIntOpenHashSet(bytes);
       case TDigest:
-        return (T) MergingDigest.fromBytes(ByteBuffer.wrap(bytes));
+        return (T) deserializeTDigest(bytes);
       default:
         throw new IllegalArgumentException("Illegal object type for de-serialization: " + objectType);
     }
@@ -360,12 +359,6 @@ public class ObjectCustomSerDe {
     return byteArrayOutputStream.toByteArray();
   }
 
-  private static byte[] serializeTDigest(TDigest tDigest) {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(tDigest.byteSize());
-    tDigest.asBytes(byteBuffer);
-    return byteBuffer.array(); // Only works since the byte-buffer is on-heap.
-  }
-
   /**
    * Helper method to de-serialize an {@link IntOpenHashSet} from a ByteBuffer.
    */
@@ -385,5 +378,15 @@ public class ObjectCustomSerDe {
    */
   private static IntOpenHashSet deserializeIntOpenHashSet(byte[] bytes) {
     return deserializeIntOpenHashSet(ByteBuffer.wrap(bytes));
+  }
+
+  public static byte[] serializeTDigest(TDigest tDigest) {
+    byte[] bytes = new byte[tDigest.byteSize()];
+    tDigest.asBytes(ByteBuffer.wrap(bytes));
+    return bytes;
+  }
+
+  public static TDigest deserializeTDigest(byte[] bytes) {
+    return MergingDigest.fromBytes(ByteBuffer.wrap(bytes));
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -77,7 +77,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
 
   protected static final int NUM_ROWS = 1000;
   protected static final double VALUE_RANGE = Integer.MAX_VALUE;
-  protected static final double DELTA = 0.15 * VALUE_RANGE; // Allow 15% quantile error
+  protected static final double DELTA = 0.05 * VALUE_RANGE; // Allow 5% quantile error
   protected static final String DOUBLE_COLUMN = "doubleColumn";
   protected static final String TDIGEST_COLUMN = "tDigestColumn";
   protected static final String GROUP_BY_COLUMN = "groupByColumn";
@@ -156,27 +156,16 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testInnerSegmentAggregation() {
-    for (int percentile = 0; percentile <= 100; percentile++) {
-      AggregationOperator aggregationOperator = getOperatorForQuery(getAggregationQuery(percentile));
-      IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
-      List<Object> aggregationResult = resultsBlock.getAggregationResult();
-      Assert.assertNotNull(aggregationResult);
-      Assert.assertEquals(aggregationResult.size(), 3);
-      DoubleList doubleList = (DoubleList) aggregationResult.get(0);
-      Collections.sort(doubleList);
-      double expected;
-      if (percentile == 100) {
-        expected = doubleList.getDouble(doubleList.size() - 1);
-      } else {
-        expected = doubleList.getDouble(doubleList.size() * percentile / 100);
-      }
-      TDigest tDigestForDoubleColumn = (TDigest) aggregationResult.get(1);
-      Assert.assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigestForDoubleColumn, percentile),
-          expected, DELTA, ERROR_MESSAGE);
-      TDigest tDigestForTDigestColumn = (TDigest) aggregationResult.get(2);
-      Assert.assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigestForTDigestColumn, percentile),
-          expected, DELTA, ERROR_MESSAGE);
-    }
+    // For inner segment case, percentile does not affect the intermediate result
+    AggregationOperator aggregationOperator = getOperatorForQuery(getAggregationQuery(0));
+    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+    List<Object> aggregationResult = resultsBlock.getAggregationResult();
+    Assert.assertNotNull(aggregationResult);
+    Assert.assertEquals(aggregationResult.size(), 3);
+    DoubleList doubleList = (DoubleList) aggregationResult.get(0);
+    Collections.sort(doubleList);
+    assertTDigest((TDigest) aggregationResult.get(1), doubleList);
+    assertTDigest((TDigest) aggregationResult.get(2), doubleList);
   }
 
   @Test
@@ -196,31 +185,18 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testInnerSegmentGroupBy() {
-    for (int percentile = 0; percentile <= 100; percentile++) {
-      AggregationGroupByOperator groupByOperator = getOperatorForQuery(getGroupByQuery(percentile));
-      IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
-      AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
-      Assert.assertNotNull(groupByResult);
-      Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
-      while (groupKeyIterator.hasNext()) {
-        GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-        DoubleList doubleList = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
-        Collections.sort(doubleList);
-        double expected;
-        if (percentile == 100) {
-          expected = doubleList.getDouble(doubleList.size() - 1);
-        } else {
-          expected = doubleList.getDouble(doubleList.size() * percentile / 100);
-        }
-        TDigest tDigestForDoubleColumn = (TDigest) groupByResult.getResultForKey(groupKey, 1);
-        Assert.assertEquals(
-            PercentileTDigestAggregationFunction.calculatePercentile(tDigestForDoubleColumn, percentile), expected,
-            DELTA, ERROR_MESSAGE);
-        TDigest tDigestForTDigestColumn = (TDigest) groupByResult.getResultForKey(groupKey, 2);
-        Assert.assertEquals(
-            PercentileTDigestAggregationFunction.calculatePercentile(tDigestForTDigestColumn, percentile), expected,
-            DELTA, ERROR_MESSAGE);
-      }
+    // For inner segment case, percentile does not affect the intermediate result
+    AggregationGroupByOperator groupByOperator = getOperatorForQuery(getGroupByQuery(0));
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
+    Assert.assertNotNull(groupByResult);
+    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+    while (groupKeyIterator.hasNext()) {
+      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      DoubleList doubleList = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
+      Collections.sort(doubleList);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 1), doubleList);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 2), doubleList);
     }
   }
 
@@ -257,6 +233,19 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
 
   private String getGroupByQuery(int percentile) {
     return String.format("%s GROUP BY %s", getAggregationQuery(percentile), GROUP_BY_COLUMN);
+  }
+
+  private void assertTDigest(TDigest tDigest, DoubleList doubleList) {
+    for (int percentile = 0; percentile <= 100; percentile++) {
+      double expected;
+      if (percentile == 100) {
+        expected = doubleList.getDouble(doubleList.size() - 1);
+      } else {
+        expected = doubleList.getDouble(doubleList.size() * percentile / 100);
+      }
+      Assert.assertEquals(PercentileTDigestAggregationFunction.calculatePercentile(tDigest, percentile), expected,
+          DELTA, ERROR_MESSAGE);
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
For inner segment test, avoid calculating TDigest for all the percentiles.
Reduce quantile error to 5% for the new library (MergingDigest)