### PR TITLE
Create abstraction for PartitionOffsetFetcher and PartitionCountFetcher

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -25,14 +25,10 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
-import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactoryProvider;
+import com.linkedin.pinot.core.realtime.stream.PartitionCountFetcher;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
-import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
@@ -142,14 +138,14 @@ public class PinotTableIdealStateBuilder {
     }
   }
 
-  public static int getPartitionCount(StreamMetadata kafkaMetadata) {
-    KafkaPartitionsCountFetcher fetcher = new KafkaPartitionsCountFetcher(kafkaMetadata);
+  public static int getPartitionCount(StreamMetadata streamMetadata) {
+    PartitionCountFetcher partitionCountFetcher = new PartitionCountFetcher(streamMetadata);
     try {
-      RetryPolicies.noDelayRetryPolicy(3).attempt(fetcher);
-      return fetcher.getPartitionCount();
+      RetryPolicies.noDelayRetryPolicy(3).attempt(partitionCountFetcher);
+      return partitionCountFetcher.getPartitionCount();
     } catch (Exception e) {
-      Exception fetcherException = fetcher.getException();
-      LOGGER.error("Could not get partition count for {}", kafkaMetadata.getKafkaTopicName(), fetcherException);
+      Exception fetcherException = partitionCountFetcher.getException();
+      LOGGER.error("Could not get partition count for {}", streamMetadata.getKafkaTopicName(), fetcherException);
       throw new RuntimeException(fetcherException);
     }
   }
@@ -204,56 +200,5 @@ public class PinotTableIdealStateBuilder {
       groupId = streamProviderConfig.get(keyOfGroupId);
     }
     return groupId;
-  }
-
-  // TODO: move this class to kafka specific package
-  private static class KafkaPartitionsCountFetcher implements Callable<Boolean> {
-    private int _partitionCount = -1;
-    private final StreamMetadata _streamMetadata;
-    private StreamConsumerFactory _streamConsumerFactory;
-    private Exception _exception;
-
-    private KafkaPartitionsCountFetcher(StreamMetadata streamMetadata) {
-      _streamMetadata = streamMetadata;
-      _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamMetadata);
-    }
-
-    private int getPartitionCount() {
-      return _partitionCount;
-    }
-
-    private Exception getException() {
-      return _exception;
-    }
-
-    @Override
-    public Boolean call() throws Exception {
-      final String bootstrapHosts = _streamMetadata.getBootstrapHosts();
-      final String kafkaTopicName = _streamMetadata.getKafkaTopicName();
-      if (bootstrapHosts == null || bootstrapHosts.isEmpty()) {
-        LOGGER.warn("Could not get partition count for topic {}. Invalid config for bootstrap hosts:'{}'",
-            kafkaTopicName, bootstrapHosts);
-        throw new RuntimeException(
-            "Invalid value for " + Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST + ":'" + bootstrapHosts + "'");
-      }
-
-      String clientId = PinotTableIdealStateBuilder.class.getSimpleName() + "-" + kafkaTopicName;
-      try (StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createStreamMetadataProvider(clientId)) {
-        _partitionCount = streamMetadataProvider.fetchPartitionCount(/*maxWaitTimeMs=*/5000L);
-        if (_exception != null) {
-          // We had at least one failure, but succeeded now. Log an info
-          LOGGER.info("Successfully retrieved partition count as {} for topic {}", _partitionCount, kafkaTopicName);
-        }
-        return Boolean.TRUE;
-      } catch (TransientConsumerException e) {
-        LOGGER.warn("Could not get partition count for topic {}", kafkaTopicName, e);
-        _exception = e;
-        return Boolean.FALSE;
-      } catch (Exception e) {
-        LOGGER.warn("Could not get partition count for topic {}", kafkaTopicName, e);
-        _exception = e;
-        throw e;
-      }
-    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -53,11 +53,8 @@ import com.linkedin.pinot.controller.helix.core.realtime.segment.FlushThresholdU
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.realtime.segment.ConsumingSegmentAssignmentStrategy;
 import com.linkedin.pinot.core.realtime.segment.RealtimeSegmentAssignmentStrategy;
-import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
-import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactoryProvider;
+import com.linkedin.pinot.core.realtime.stream.PartitionOffsetFetcher;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
-import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
@@ -77,7 +74,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -100,7 +96,6 @@ import org.slf4j.LoggerFactory;
 
 public class PinotLLCRealtimeSegmentManager {
   public static final Logger LOGGER = LoggerFactory.getLogger(PinotLLCRealtimeSegmentManager.class);
-  private static final int STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS = 10000;
   private static final String KAFKA_SMALLEST_OFFSET = "smallest";
   protected static final int STARTING_SEQUENCE_NUMBER = 0; // Initial sequence number for new table segments
   protected static final long END_OFFSET_FOR_CONSUMING_SEGMENTS = Long.MAX_VALUE;
@@ -699,16 +694,16 @@ public class PinotLLCRealtimeSegmentManager {
     return getPartitionOffset(offsetCriteria, partitionId, streamMetadata);
   }
 
-  private long getPartitionOffset(final String offsetCriteria, int partitionId,
-      StreamMetadata streamMetadata) {
-    KafkaOffsetFetcher kafkaOffsetFetcher = new KafkaOffsetFetcher(offsetCriteria, partitionId, streamMetadata);
+  private long getPartitionOffset(final String offsetCriteria, int partitionId, StreamMetadata streamMetadata) {
+    PartitionOffsetFetcher partitionOffsetFetcher =
+        new PartitionOffsetFetcher(offsetCriteria, partitionId, streamMetadata);
     try {
-      RetryPolicies.fixedDelayRetryPolicy(3, 1000L).attempt(kafkaOffsetFetcher);
-      return kafkaOffsetFetcher.getOffset();
+      RetryPolicies.fixedDelayRetryPolicy(3, 1000L).attempt(partitionOffsetFetcher);
+      return partitionOffsetFetcher.getOffset();
     } catch (Exception e) {
-      Exception fetcherException = kafkaOffsetFetcher.getException();
-      LOGGER.error("Could not get offset for topic {} partition {}, criteria {}",
-          streamMetadata.getKafkaTopicName(), partitionId, offsetCriteria, fetcherException);
+      Exception fetcherException = partitionOffsetFetcher.getException();
+      LOGGER.error("Could not get offset for topic {} partition {}, criteria {}", streamMetadata.getKafkaTopicName(),
+          partitionId, offsetCriteria, fetcherException);
       throw new RuntimeException(fetcherException);
     }
   }
@@ -1316,57 +1311,5 @@ public class PinotLLCRealtimeSegmentManager {
     }
 
     return idealState;
-  }
-
-  // TODO: move this class to kafka specific package
-  private static class KafkaOffsetFetcher implements Callable<Boolean> {
-    private final String _topicName;
-    private final String _offsetCriteria;
-    private final int _partitionId;
-
-    private Exception _exception = null;
-    private long _offset = -1;
-    private StreamConsumerFactory _streamConsumerFactory;
-    StreamMetadata _streamMetadata;
-
-    private KafkaOffsetFetcher(final String offsetCriteria, int partitionId, StreamMetadata streamMetadata) {
-      _offsetCriteria = offsetCriteria;
-      _partitionId = partitionId;
-      _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamMetadata);
-      _streamMetadata = streamMetadata;
-      _topicName = streamMetadata.getKafkaTopicName();
-    }
-
-    private long getOffset() {
-      return _offset;
-    }
-
-    private Exception getException() {
-      return _exception;
-    }
-
-    @Override
-    public Boolean call() throws Exception {
-
-      String clientId = PinotLLCRealtimeSegmentManager.class.getSimpleName() + "-" + _topicName + "-" + _partitionId;
-      try (StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createPartitionMetadataProvider(
-          clientId, _partitionId)) {
-        _offset =
-            streamMetadataProvider.fetchPartitionOffset(_offsetCriteria, STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
-        if (_exception != null) {
-          LOGGER.info("Successfully retrieved offset({}) for stream topic {} partition {}", _offset, _topicName,
-              _partitionId);
-        }
-        return Boolean.TRUE;
-      } catch (TransientConsumerException e) {
-        LOGGER.warn("Temporary exception when fetching offset for topic {} partition {}:{}", _topicName, _partitionId,
-            e.getMessage());
-        _exception = e;
-        return Boolean.FALSE;
-      } catch (Exception e) {
-        _exception = e;
-        throw e;
-      }
-    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -31,6 +31,7 @@ import kafka.javaapi.PartitionMetadata;
 import kafka.javaapi.TopicMetadataRequest;
 import kafka.javaapi.TopicMetadataResponse;
 import kafka.javaapi.consumer.SimpleConsumer;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,14 +135,14 @@ public class KafkaConnectionHandler {
   }
 
   void initializeBootstrapNodeList(String bootstrapNodes) {
-    ArrayList<String> hostsAndPorts =
-        Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(bootstrapNodes));
 
-    final int bootstrapHostCount = hostsAndPorts.size();
-    if (bootstrapHostCount < 1) {
+    if (StringUtils.isBlank(bootstrapNodes)) {
       throw new IllegalArgumentException("Need at least one bootstrap host");
     }
 
+    ArrayList<String> hostsAndPorts =
+        Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(bootstrapNodes));
+    final int bootstrapHostCount = hostsAndPorts.size();
     _bootstrapHosts = new String[bootstrapHostCount];
     _bootstrapPorts = new int[bootstrapHostCount];
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.stream;
+
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fetches the partition count of a stream using the {@link StreamMetadataProvider}
+ */
+public class PartitionCountFetcher implements Callable<Boolean> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionCountFetcher.class);
+
+  private int _partitionCount = -1;
+  private final StreamMetadata _streamMetadata;
+  private StreamConsumerFactory _streamConsumerFactory;
+  private Exception _exception;
+  private final String _topicName;
+
+  public PartitionCountFetcher(StreamMetadata streamMetadata) {
+    _streamMetadata = streamMetadata;
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamMetadata);
+    _topicName = streamMetadata.getKafkaTopicName();
+  }
+
+  public int getPartitionCount() {
+    return _partitionCount;
+  }
+
+  public Exception getException() {
+    return _exception;
+  }
+
+  /**
+   * Callable to fetch the number of partitions of the stream given the stream metadata
+   * @return
+   * @throws Exception
+   */
+  @Override
+  public Boolean call() throws Exception {
+
+    String clientId = PartitionCountFetcher.class.getSimpleName() + "-" + _topicName;
+    try (
+        StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createStreamMetadataProvider(clientId)) {
+      _partitionCount = streamMetadataProvider.fetchPartitionCount(/*maxWaitTimeMs=*/5000L);
+      if (_exception != null) {
+        // We had at least one failure, but succeeded now. Log an info
+        LOGGER.info("Successfully retrieved partition count as {} for topic {}", _partitionCount, _topicName);
+      }
+      return Boolean.TRUE;
+    } catch (TransientConsumerException e) {
+      LOGGER.warn("Could not get partition count for topic {}", _topicName, e);
+      _exception = e;
+      return Boolean.FALSE;
+    } catch (Exception e) {
+      LOGGER.warn("Could not get partition count for topic {}", _topicName, e);
+      _exception = e;
+      throw e;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.stream;
+
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Fetches the partition offset for a stream given the offset criteria, using the {@link StreamMetadataProvider}
+ */
+public class PartitionOffsetFetcher implements Callable<Boolean> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionOffsetFetcher.class);
+  private static final int STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS = 10000;
+
+  private final String _topicName;
+  private final String _offsetCriteria;
+  private final int _partitionId;
+
+  private Exception _exception = null;
+  private long _offset = -1;
+  private StreamConsumerFactory _streamConsumerFactory;
+  StreamMetadata _streamMetadata;
+
+  public PartitionOffsetFetcher(final String offsetCriteria, int partitionId, StreamMetadata streamMetadata) {
+    _offsetCriteria = offsetCriteria;
+    _partitionId = partitionId;
+    _streamMetadata = streamMetadata;
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamMetadata);
+    _topicName = streamMetadata.getKafkaTopicName();
+  }
+
+  public long getOffset() {
+    return _offset;
+  }
+
+  public Exception getException() {
+    return _exception;
+  }
+
+  /**
+   * Callable to fetch the offset of the partition given the stream metadata and offset criteria
+   * @return
+   * @throws Exception
+   */
+  @Override
+  public Boolean call() throws Exception {
+    String clientId = PartitionOffsetFetcher.class.getSimpleName() + "-" + _topicName + "-" + _partitionId;
+    try (
+        StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createPartitionMetadataProvider(clientId,
+            _partitionId)) {
+      _offset =
+          streamMetadataProvider.fetchPartitionOffset(_offsetCriteria, STREAM_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
+      if (_exception != null) {
+        LOGGER.info("Successfully retrieved offset({}) for stream topic {} partition {}", _offset, _topicName,
+            _partitionId);
+      }
+      return Boolean.TRUE;
+    } catch (TransientConsumerException e) {
+      LOGGER.warn("Temporary exception when fetching offset for topic {} partition {}:{}", _topicName, _partitionId,
+          e.getMessage());
+      _exception = e;
+      return Boolean.FALSE;
+    } catch (Exception e) {
+      _exception = e;
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
As part of https://github.com/linkedin/pinot/issues/2583, moving KafkaOffsetFetcher and KafkaPartitionCountFetcher to generic implementations i.e. PartitionOffsetFetcher and PartitionCountFetcher
There is no change in the logic for the implementations, simply a movement from Kafka specific classes to generic ones