### PR TITLE
In PinotDataBuffer, allow view() and toDirectByteBuffer() with different byte order

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
@@ -218,7 +218,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
   }
 
   @Override
-  public void copyTo(long offset, byte[] buffer, int destOffset,  int size) {
+  public void copyTo(long offset, byte[] buffer, int destOffset, int size) {
     assert offset <= Integer.MAX_VALUE;
     int intOffset = (int) offset;
     if (size <= PinotDataBuffer.BULK_BYTES_PROCESSING_THRESHOLD) {
@@ -287,25 +287,30 @@ public class PinotByteBuffer extends PinotDataBuffer {
   }
 
   @Override
-  public PinotDataBuffer view(long start, long end) {
+  public ByteOrder order() {
+    return _buffer.order();
+  }
+
+  @Override
+  public PinotDataBuffer view(long start, long end, ByteOrder byteOrder) {
     assert start <= end;
     assert end <= Integer.MAX_VALUE;
     ByteBuffer duplicate = _buffer.duplicate();
     duplicate.position((int) start).limit((int) end);
     ByteBuffer buffer = duplicate.slice();
-    buffer.order(_buffer.order());
+    buffer.order(byteOrder);
     return new PinotByteBuffer(buffer, false, false);
   }
 
   @Override
-  public ByteBuffer toDirectByteBuffer(long offset, int size) {
+  public ByteBuffer toDirectByteBuffer(long offset, int size, ByteOrder byteOrder) {
     assert offset <= Integer.MAX_VALUE;
     int start = (int) offset;
     int end = start + size;
     ByteBuffer duplicate = _buffer.duplicate();
     duplicate.position(start).limit(end);
     ByteBuffer buffer = duplicate.slice();
-    buffer.order(_buffer.order());
+    buffer.order(byteOrder);
     return buffer;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotNativeOrderLBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotNativeOrderLBuffer.java
@@ -17,11 +17,10 @@ package com.linkedin.pinot.core.segment.memory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import javax.annotation.concurrent.ThreadSafe;
 import xerial.larray.buffer.LBuffer;
 import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.buffer.WrappedLBuffer;
 import xerial.larray.mmap.MMapBuffer;
 import xerial.larray.mmap.MMapMode;
 
@@ -48,7 +47,7 @@ public class PinotNativeOrderLBuffer extends BasePinotLBuffer {
     }
   }
 
-  private PinotNativeOrderLBuffer(LBufferAPI buffer, boolean closeable, boolean flushable) {
+  PinotNativeOrderLBuffer(LBufferAPI buffer, boolean closeable, boolean flushable) {
     super(buffer, closeable, flushable);
   }
 
@@ -173,14 +172,7 @@ public class PinotNativeOrderLBuffer extends BasePinotLBuffer {
   }
 
   @Override
-  public PinotDataBuffer view(long start, long end) {
-    // Workaround to handle cases where offset is not page-aligned or view of view
-    return new PinotNativeOrderLBuffer(
-        new WrappedLBuffer(_buffer.m, start + _buffer.address() - _buffer.m.address(), end - start), false, false);
-  }
-
-  @Override
-  public ByteBuffer toDirectByteBuffer(long offset, int size) {
-    return _buffer.toDirectByteBuffer(offset, size).order(PinotDataBuffer.NATIVE_ORDER);
+  public ByteOrder order() {
+    return NATIVE_ORDER;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotNonNativeOrderLBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotNonNativeOrderLBuffer.java
@@ -17,11 +17,10 @@ package com.linkedin.pinot.core.segment.memory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import javax.annotation.concurrent.ThreadSafe;
 import xerial.larray.buffer.LBuffer;
 import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.buffer.WrappedLBuffer;
 import xerial.larray.mmap.MMapBuffer;
 import xerial.larray.mmap.MMapMode;
 
@@ -48,7 +47,7 @@ public class PinotNonNativeOrderLBuffer extends BasePinotLBuffer {
     }
   }
 
-  private PinotNonNativeOrderLBuffer(LBufferAPI buffer, boolean closeable, boolean flushable) {
+  PinotNonNativeOrderLBuffer(LBufferAPI buffer, boolean closeable, boolean flushable) {
     super(buffer, closeable, flushable);
   }
 
@@ -173,14 +172,7 @@ public class PinotNonNativeOrderLBuffer extends BasePinotLBuffer {
   }
 
   @Override
-  public PinotDataBuffer view(long start, long end) {
-    // Workaround to handle cases where offset is not page-aligned or view of view
-    return new PinotNonNativeOrderLBuffer(
-        new WrappedLBuffer(_buffer.m, start + _buffer.address() - _buffer.m.address(), end - start), false, false);
-  }
-
-  @Override
-  public ByteBuffer toDirectByteBuffer(long offset, int size) {
-    return _buffer.toDirectByteBuffer(offset, size).order(NON_NATIVE_ORDER);
+  public ByteOrder order() {
+    return NON_NATIVE_ORDER;
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/memory/PinotDataBufferTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/memory/PinotDataBufferTest.java
@@ -497,6 +497,7 @@ public class PinotDataBufferTest {
     }
   }
 
+  @SuppressWarnings("RedundantExplicitClose")
   @Test
   public void testMultipleClose() throws Exception {
     try (PinotDataBuffer buffer = PinotByteBuffer.allocateDirect(BUFFER_SIZE, PinotDataBuffer.NATIVE_ORDER)) {


### PR DESCRIPTION
Add flexibility to the pinot buffer to allow different byte orders