### PR TITLE
CSV Reader Config when Creating Segments from CSV using Hadoop

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -19,7 +19,7 @@ package com.linkedin.pinot.hadoop.job;
 public class JobConfigConstants {
   public static final String PATH_TO_INPUT = "path.to.input";
   public static final String PATH_TO_OUTPUT = "path.to.output";
-
+  public static final String PATH_TO_READER_CONFIG = "path.to.reader.config";
   // Leave this for backward compatibility. We prefer to use the schema fetched from the controller.
   public static final String PATH_TO_SCHEMA = "path.to.schema";
 

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -60,6 +60,8 @@ public class SegmentCreationJob extends Configured {
   private final String _depsJarPath;
   private final String _outputDir;
   private final String _tableName;
+  
+  private final String _readerConfigFile;
 
   private String[] _hosts;
   private int _port;
@@ -75,6 +77,7 @@ public class SegmentCreationJob extends Configured {
     _outputDir = getOutputDir();
     _stagingDir = new File(_outputDir, TEMP).getAbsolutePath();
     _depsJarPath = _properties.getProperty(PATH_TO_DEPS_JAR, null);
+    String _readerConfigFile = _properties.getProperty(JobConfigConstants.PATH_TO_READER_CONFIG);
     String hostsString = _properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS);
     String portString = _properties.getProperty(JobConfigConstants.PUSH_TO_PORT);
 
@@ -93,6 +96,9 @@ public class SegmentCreationJob extends Configured {
     LOGGER.info("path.to.deps.jar: {}", _depsJarPath);
     LOGGER.info("path.to.output: {}", _outputDir);
     LOGGER.info("path.to.schema: {}", schemaFilePath);
+    if (_readerConfigFile != null){
+      LOGGER.info("path.to.reader.config: {}", _readerConfigFile);
+    }
     if (schemaFilePath != null) {
       _dataSchema = Schema.fromFile(new File(schemaFilePath));
     } else {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -77,7 +77,7 @@ public class SegmentCreationJob extends Configured {
     _outputDir = getOutputDir();
     _stagingDir = new File(_outputDir, TEMP).getAbsolutePath();
     _depsJarPath = _properties.getProperty(PATH_TO_DEPS_JAR, null);
-    String _readerConfigFile = _properties.getProperty(JobConfigConstants.PATH_TO_READER_CONFIG);
+    _readerConfigFile = _properties.getProperty(JobConfigConstants.PATH_TO_READER_CONFIG);
     String hostsString = _properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS);
     String portString = _properties.getProperty(JobConfigConstants.PUSH_TO_PORT);
 
@@ -96,7 +96,7 @@ public class SegmentCreationJob extends Configured {
     LOGGER.info("path.to.deps.jar: {}", _depsJarPath);
     LOGGER.info("path.to.output: {}", _outputDir);
     LOGGER.info("path.to.schema: {}", schemaFilePath);
-    if (_readerConfigFile != null){
+    if (_readerConfigFile != null) {
       LOGGER.info("path.to.reader.config: {}", _readerConfigFile);
     }
     if (schemaFilePath != null) {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/mapper/HadoopSegmentCreationMapReduceJob.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.codehaus.jackson.map.ObjectMapper;
 
 public class HadoopSegmentCreationMapReduceJob {
 
@@ -56,6 +56,7 @@ public class HadoopSegmentCreationMapReduceJob {
     private String _outputPath;
     private String _tableName;
     private String _postfix;
+    private String _readerConfigFile;
 
     // Temporary local disk path for current working directory
     private String _currentDiskWorkDir;
@@ -95,7 +96,7 @@ public class HadoopSegmentCreationMapReduceJob {
       _outputPath = _properties.get(JobConfigConstants.PATH_TO_OUTPUT);
       _tableName = _properties.get(JobConfigConstants.SEGMENT_TABLE_NAME);
       _postfix = _properties.get(SEGMENT_NAME_POSTFIX, null);
-
+      _readerConfigFile = _properties.get(JobConfigConstants.PATH_TO_READER_CONFIG);
       if (_outputPath == null || _tableName == null) {
         throw new RuntimeException(
             "Missing configs: " + "\n\toutputPath: " + _properties.get(JobConfigConstants.PATH_TO_OUTPUT)
@@ -273,12 +274,18 @@ public class HadoopSegmentCreationMapReduceJob {
       return segmentName;
     }
 
-    private RecordReaderConfig getReaderConfig(FileFormat fileFormat) {
+    private RecordReaderConfig getReaderConfig(FileFormat fileFormat) throws IOException {
       RecordReaderConfig readerConfig = null;
       switch (fileFormat) {
         case CSV:
-          readerConfig = new CSVRecordReaderConfig();
-          break;
+          if(_readerConfigFile == null) {
+            readerConfig = new CSVRecordReaderConfig();
+	  }
+	  else {
+	    LOGGER.info("Reading CSV Record Reader Config from: {}", _readerConfigFile);
+	    readerConfig = new ObjectMapper().readValue(new File(_readerConfigFile), CSVRecordReaderConfig.class);
+	  }
+	  break;
         case AVRO:
           break;
         case JSON:


### PR DESCRIPTION
Currently you can specify a readerconfig when creating segments using pinot-admin.sh, but this argument is not available when creating segments using the hadoop jar command. I added code so that you can specify a readerconfig filepath in job.properties. Not sure why the spacing ended up off within getReaderConfig.

It may be a good idea to also allow job.properties to specify the expected file format. The current way that Hadoop SegmentCreation reads file formats gives problems e.g. when uploading a .tsv file; this PR now allows reading files with any delimiter, but they still have to have a .csv file extension.