### PR TITLE
Remove the lower bounded wildcards for value readers since they are not valid

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/MultiValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/MultiValueBlock.java
@@ -21,7 +21,6 @@ import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 import com.linkedin.pinot.core.operator.docvalsets.MultiValueSet;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
@@ -31,7 +30,7 @@ public final class MultiValueBlock implements Block {
   private final BlockValSet _blockValSet;
   private final BlockMetadata _blockMetadata;
 
-  public MultiValueBlock(SingleColumnMultiValueReader<? super ReaderContext> reader, int numDocs, int maxNumMultiValues,
+  public MultiValueBlock(SingleColumnMultiValueReader reader, int numDocs, int maxNumMultiValues,
       FieldSpec.DataType dataType, Dictionary dictionary) {
     _blockValSet = new MultiValueSet(reader, numDocs, dataType);
     _blockMetadata = new BlockMetadataImpl(numDocs, false, maxNumMultiValues, dataType, dictionary);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/SingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/SingleValueBlock.java
@@ -21,25 +21,24 @@ import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.docvalsets.SingleValueSet;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
 public final class SingleValueBlock implements Block {
-  private final SingleColumnSingleValueReader<? super ReaderContext> _reader;
+  private final SingleColumnSingleValueReader _reader;
   private final BlockValSet _blockValSet;
   private final BlockMetadata _blockMetadata;
 
-  public SingleValueBlock(SingleColumnSingleValueReader<? super ReaderContext> reader, int numDocs,
-      FieldSpec.DataType dataType, Dictionary dictionary) {
+  public SingleValueBlock(SingleColumnSingleValueReader reader, int numDocs, FieldSpec.DataType dataType,
+      Dictionary dictionary) {
     _reader = reader;
     _blockValSet = new SingleValueSet(reader, numDocs, dataType);
     _blockMetadata = new BlockMetadataImpl(numDocs, true, 0, dataType, dictionary);
   }
 
-  public SingleColumnSingleValueReader<? extends ReaderContext> getReader() {
+  public SingleColumnSingleValueReader getReader() {
     return _reader;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/MultiValueIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/MultiValueIterator.java
@@ -20,17 +20,18 @@ import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 
 
+@SuppressWarnings("unchecked")
 public final class MultiValueIterator extends BlockMultiValIterator {
-  private final SingleColumnMultiValueReader<? super ReaderContext> _reader;
+  private final SingleColumnMultiValueReader _reader;
   private final int _numDocs;
   private final ReaderContext _context;
+
   private int _nextDocId;
 
-  public MultiValueIterator(SingleColumnMultiValueReader<? super ReaderContext> reader, int numDocs) {
+  public MultiValueIterator(SingleColumnMultiValueReader reader, int numDocs) {
     _reader = reader;
     _numDocs = numDocs;
     _context = _reader.createContext();
-    _nextDocId = 0;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/SingleValueIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/SingleValueIterator.java
@@ -20,17 +20,18 @@ import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 
 
+@SuppressWarnings("unchecked")
 public final class SingleValueIterator extends BlockSingleValIterator {
-  private SingleColumnSingleValueReader<? super ReaderContext> _reader;
+  private final SingleColumnSingleValueReader _reader;
   private final int _numDocs;
   private final ReaderContext _context;
+
   private int _nextDocId;
 
-  public SingleValueIterator(SingleColumnSingleValueReader<? super ReaderContext> reader, int numDocs) {
+  public SingleValueIterator(SingleColumnSingleValueReader reader, int numDocs) {
     _reader = reader;
     _numDocs = numDocs;
     _context = _reader.createContext();
-    _nextDocId = 0;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
@@ -18,17 +18,16 @@ package com.linkedin.pinot.core.operator.docvalsets;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.MultiValueIterator;
 
 
 public final class MultiValueSet extends BaseBlockValSet {
-  private final SingleColumnMultiValueReader<? super ReaderContext> _reader;
+  private final SingleColumnMultiValueReader _reader;
   private final int _numDocs;
   private final DataType _dataType;
 
-  public MultiValueSet(SingleColumnMultiValueReader<? super ReaderContext> reader, int numDocs, DataType dataType) {
+  public MultiValueSet(SingleColumnMultiValueReader reader, int numDocs, DataType dataType) {
     _reader = reader;
     _numDocs = numDocs;
     _dataType = dataType;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
@@ -23,12 +23,13 @@ import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.SingleValueIterator;
 
 
+@SuppressWarnings("unchecked")
 public final class SingleValueSet extends BaseBlockValSet {
-  private final SingleColumnSingleValueReader<? super ReaderContext> _reader;
+  private final SingleColumnSingleValueReader _reader;
   private final int _numDocs;
   private final DataType _dataType;
 
-  public SingleValueSet(SingleColumnSingleValueReader<? super ReaderContext> reader, int numDocs, DataType dataType) {
+  public SingleValueSet(SingleColumnSingleValueReader reader, int numDocs, DataType dataType) {
     _reader = reader;
     _numDocs = numDocs;
     _dataType = dataType;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSource.java
@@ -22,7 +22,6 @@ import com.linkedin.pinot.core.common.Constants;
 import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
-import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
@@ -133,7 +132,9 @@ public final class ColumnDataSource extends DataSource {
       }
 
       @Override
-      public int getCardinality() { return _cardinality;}
+      public int getCardinality() {
+        return _cardinality;
+      }
     };
   }
 
@@ -152,15 +153,13 @@ public final class ColumnDataSource extends DataSource {
     return _dictionary;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   protected Block getNextBlock() {
     if (_isSingleValue) {
-      return new SingleValueBlock((SingleColumnSingleValueReader<? super ReaderContext>) _forwardIndex, _numDocs,
-          _dataType, _dictionary);
+      return new SingleValueBlock((SingleColumnSingleValueReader) _forwardIndex, _numDocs, _dataType, _dictionary);
     } else {
-      return new MultiValueBlock((SingleColumnMultiValueReader<? super ReaderContext>) _forwardIndex, _numDocs,
-          _maxNumMultiValues, _dataType, _dictionary);
+      return new MultiValueBlock((SingleColumnMultiValueReader) _forwardIndex, _numDocs, _maxNumMultiValues, _dataType,
+          _dictionary);
     }
   }
 


### PR DESCRIPTION
For the value reader, the generic type always extends ReaderContext, so we should not pass in value readers with type "? super ReaderContext"