### PR TITLE
[AnomalyTimelinesView] Fix exceptions when no or shorter baseline or current values in the view

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
@@ -136,8 +136,16 @@ public class CondensedAnomalyTimelinesView {
           startTime * minBucketUnit + timestampOffset,
           (startTime + bucketMillis) * minBucketUnit + timestampOffset);
       anomalyTimelinesView.addTimeBuckets(timeBucket);
-      anomalyTimelinesView.addBaselineValues(baselineValues.get(i));
-      anomalyTimelinesView.addCurrentValues(currentValues.get(i));
+      if (i < baselineValues.size()) {
+        anomalyTimelinesView.addBaselineValues(baselineValues.get(i));
+      } else {
+        anomalyTimelinesView.addCurrentValues(Double.NaN);
+      }
+      if (i < currentValues.size()) { // In case there is no current value in view
+        anomalyTimelinesView.addCurrentValues(currentValues.get(i));
+      } else {
+        anomalyTimelinesView.addCurrentValues(Double.NaN);
+      }
     }
     for (Map.Entry<String, String> entry : summary.entrySet()) {
       anomalyTimelinesView.addSummary(entry.getKey(), entry.getValue());


### PR DESCRIPTION
When extracting the condensed view, it throws out an exception when either baseline or current values are shorter. This pull request is to fix the exception by inserting NaN in that.