### PR TITLE
Forcing file permissions of staging dir to be 755 in hadoop

### DIFF
--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/JobConfigConstants.java
@@ -35,4 +35,6 @@ public class JobConfigConstants {
   public static final String PUSH_TO_PORT = "push.to.port";
 
   public static final String TABLE_CONFIG = "table.config";
+
+  public static final String DEFAULT_PERMISSIONS = "fs.permissions.umask-mode";
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -62,6 +62,8 @@ public class SegmentCreationJob extends Configured {
   private final String _outputDir;
   private final String _tableName;
 
+  private final String _defaultPermissions;
+
   private String[] _hosts;
   private int _port;
 
@@ -78,6 +80,8 @@ public class SegmentCreationJob extends Configured {
     _depsJarPath = _properties.getProperty(PATH_TO_DEPS_JAR, null);
     String hostsString = _properties.getProperty(JobConfigConstants.PUSH_TO_HOSTS);
     String portString = _properties.getProperty(JobConfigConstants.PUSH_TO_PORT);
+
+    _defaultPermissions = _properties.getProperty(JobConfigConstants.DEFAULT_PERMISSIONS, null);
 
     // For backwards compatibility, we want to allow users to create segments without setting push location parameters
     // in their creation jobs.
@@ -128,7 +132,9 @@ public class SegmentCreationJob extends Configured {
       fs.delete(stagingDir, true);
     }
     fs.mkdirs(stagingDir);
-    FileSystem.get(getConf()).setPermission(stagingDir, new FsPermission("755"));
+    if (_defaultPermissions != null) {
+      FileSystem.get(getConf()).setPermission(stagingDir, new FsPermission(_defaultPermissions));
+    }
     fs.mkdirs(new Path(_stagingDir + "/input/"));
 
     if (fs.exists(outputDir)) {

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentCreationJob.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobContext;
@@ -119,19 +120,22 @@ public class SegmentCreationJob extends Configured {
 
     FileSystem fs = FileSystem.get(getConf());
     Path inputPathPattern = new Path(_inputSegmentDir);
+    Path stagingDir = new Path(_stagingDir);
+    Path outputDir = new Path(_outputDir);
 
-    if (fs.exists(new Path(_stagingDir))) {
+    if (fs.exists(stagingDir)) {
       LOGGER.warn("Found the temp folder, deleting it");
-      fs.delete(new Path(_stagingDir), true);
+      fs.delete(stagingDir, true);
     }
-    fs.mkdirs(new Path(_stagingDir));
+    fs.mkdirs(stagingDir);
+    FileSystem.get(getConf()).setPermission(stagingDir, new FsPermission("755"));
     fs.mkdirs(new Path(_stagingDir + "/input/"));
 
-    if (fs.exists(new Path(_outputDir))) {
+    if (fs.exists(outputDir)) {
       LOGGER.warn("Found the output folder {}, deleting it", _outputDir);
-      fs.delete(new Path(_outputDir), true);
+      fs.delete(outputDir, true);
     }
-    fs.mkdirs(new Path(_outputDir));
+    fs.mkdirs(outputDir);
 
     List<FileStatus> inputDataFiles = new ArrayList<FileStatus>();
     FileStatus[] fileStatusArr = fs.globStatus(inputPathPattern);


### PR DESCRIPTION
* Forcing the staging directory upon segment creation to have the permission that the user sets in fs.permissions.umask-mode. Defaults to null if not set.
* Thanks to Jonathan Hung for the investigation:
Due to some FileSystem caching that hadoop does, we have problems setting permissions on files. When FileSystem.get is called, it will search for a cached instance in its internal map, but it doesn’t use the conf when generating the key. So probably somewhere before this code is called there was already a FileSystem created (with default umask 027) which is being used when the staging dir is created.