### PR TITLE
[TE] pinot - support topk limit for groupby queries

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
@@ -55,6 +55,7 @@ public class ThirdEyeRequest {
   private final List<String> metricNames;
   private final String dataSource;
   private final String requestReference;
+  private final int limit;
 
   private ThirdEyeRequest(String requestReference, ThirdEyeRequestBuilder builder) {
     this.requestReference = requestReference;
@@ -70,6 +71,7 @@ public class ThirdEyeRequest {
     for (MetricFunction metric : metricFunctions) {
       metricNames.add(metric.toString());
     }
+    this.limit = builder.limit;
   }
 
   public static ThirdEyeRequestBuilder newBuilder() {
@@ -118,6 +120,10 @@ public class ThirdEyeRequest {
     return dataSource;
   }
 
+  public int getLimit() {
+    return limit;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -131,13 +137,14 @@ public class ThirdEyeRequest {
         .equals(endTime, that.endTime) && Objects.equals(filterSet, that.filterSet) && Objects.equals(filterClause,
         that.filterClause) && Objects.equals(groupByDimensions, that.groupByDimensions) && Objects.equals(
         groupByTimeGranularity, that.groupByTimeGranularity) && Objects.equals(metricNames, that.metricNames) && Objects
-        .equals(dataSource, that.dataSource) && Objects.equals(requestReference, that.requestReference);
+        .equals(dataSource, that.dataSource) && Objects.equals(requestReference, that.requestReference) &&
+        Objects.equals(requestReference, that.requestReference);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(metricFunctions, startTime, endTime, filterSet, filterClause, groupByDimensions,
-        groupByTimeGranularity, metricNames, dataSource, requestReference);
+        groupByTimeGranularity, metricNames, dataSource, requestReference, limit);
   }
 
   @Override
@@ -145,7 +152,8 @@ public class ThirdEyeRequest {
     return "ThirdEyeRequest{" + "metricFunctions=" + metricFunctions + ", startTime=" + startTime + ", endTime="
         + endTime + ", filterSet=" + filterSet + ", filterClause='" + filterClause + '\'' + ", groupByDimensions="
         + groupByDimensions + ", groupByTimeGranularity=" + groupByTimeGranularity + ", metricNames=" + metricNames
-        + ", dataSource='" + dataSource + '\'' + ", requestReference='" + requestReference + '\'' + '}';
+        + ", dataSource='" + dataSource + '\'' + ", requestReference='" + requestReference + '\'' +
+        ", limit='" + limit + '\'' + '}';
   }
 
   public static class ThirdEyeRequestBuilder {
@@ -159,6 +167,7 @@ public class ThirdEyeRequest {
     private final List<String> groupBy;
     private TimeGranularity groupByTimeGranularity;
     private String dataSource = PinotThirdEyeDataSource.DATA_SOURCE_NAME;
+    private int limit;
 
     public ThirdEyeRequestBuilder() {
       this.filterSet = LinkedListMultimap.create();
@@ -257,6 +266,11 @@ public class ThirdEyeRequest {
 
     public ThirdEyeRequestBuilder setDataSource(String dataSource) {
       this.dataSource = dataSource;
+      return this;
+    }
+
+    public ThirdEyeRequestBuilder setLimit(int limit) {
+      this.limit = limit;
       return this;
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
@@ -86,13 +86,13 @@ public class PqlUtils {
     // TODO handle request.getFilterClause()
 
     return getPql(metricFunction, request.getStartTimeInclusive(), request.getEndTimeExclusive(), filterSet,
-        request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec);
+        request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec, request.getLimit());
   }
 
 
   private static String getPql(MetricFunction metricFunction, DateTime startTime,
       DateTime endTimeExclusive, Multimap<String, String> filterSet, List<String> groupBy,
-      TimeGranularity timeGranularity, TimeSpec dataTimeSpec) throws ExecutionException {
+      TimeGranularity timeGranularity, TimeSpec dataTimeSpec, int limit) throws ExecutionException {
 
     MetricConfigDTO metricConfig = ThirdEyeUtils.getMetricConfigFromId(metricFunction.getMetricId());
     String dataset = metricFunction.getDataset();
@@ -111,10 +111,14 @@ public class PqlUtils {
       sb.append(" AND ").append(dimensionWhereClause);
     }
 
+    if (limit <= 0) {
+      limit = DEFAULT_TOP;
+    }
+
     String groupByClause = getDimensionGroupByClause(groupBy, timeGranularity, dataTimeSpec);
     if (StringUtils.isNotBlank(groupByClause)) {
       sb.append(" ").append(groupByClause);
-      sb.append(" TOP ").append(DEFAULT_TOP);
+      sb.append(" TOP ").append(limit);
     }
 
     return sb.toString();
@@ -172,7 +176,7 @@ public class PqlUtils {
     String dimensionAsMetricPql = getDimensionAsMetricPql(metricFunction,
         request.getStartTimeInclusive(), request.getEndTimeExclusive(), filterSet,
         request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec,
-        metricNamesList, metricNamesColumnsList, metricValuesColumn);
+        metricNamesList, metricNamesColumnsList, metricValuesColumn, request.getLimit());
 
     return dimensionAsMetricPql;
   }
@@ -180,8 +184,8 @@ public class PqlUtils {
 
   private static String getDimensionAsMetricPql(MetricFunction metricFunction, DateTime startTime,
       DateTime endTimeExclusive, Multimap<String, String> filterSet, List<String> groupBy,
-      TimeGranularity timeGranularity, TimeSpec dataTimeSpec,
-      List<String> metricNames, List<String> metricNamesColumns, String metricValuesColumn)
+      TimeGranularity timeGranularity, TimeSpec dataTimeSpec, List<String> metricNames, List<String> metricNamesColumns,
+      String metricValuesColumn, int limit)
           throws ExecutionException {
 
     MetricConfigDTO metricConfig = metricFunction.getMetricConfig();
@@ -204,10 +208,14 @@ public class PqlUtils {
       sb.append(" AND ").append(dimensionWhereClause);
     }
 
+    if (limit <= 0) {
+      limit = DEFAULT_TOP;
+    }
+
     String groupByClause = getDimensionGroupByClause(groupBy, timeGranularity, dataTimeSpec);
     if (StringUtils.isNotBlank(groupByClause)) {
       sb.append(" ").append(groupByClause);
-      sb.append(" TOP ").append(DEFAULT_TOP);
+      sb.append(" TOP ").append(limit);
     }
 
     return sb.toString();


### PR DESCRIPTION
ThirdEye's Pinot connector currently does not allow us to dynamically change the TOP K limit, which is hard-coded to 100000 elements. This becomes a huge performance burden on de-aggregation queries of data sets with high cardinality, e.g. for rendering the heat map. This PR adds support to limit the number of elements in the response