### PR TITLE
[TE] rootcause - faster heatmap via end-to-end topk limit support

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions-table/component.js
@@ -18,6 +18,7 @@ import DIMENSIONS_TABLE_COLUMNS from 'thirdeye-frontend/shared/dimensionsTableCo
 import _ from 'lodash';
 
 const ROOTCAUSE_TRUNCATION_FRACTION = 0.0001;
+const ROOTCAUSE_VALUE_OTHER = 'OTHER';
 
 export default Component.extend({
   classNames: ['rootcause-metrics'],
@@ -122,6 +123,8 @@ export default Component.extend({
         const baseTotal = this._sum(baseline, name);
 
         Object.keys(current[name]).forEach(value => {
+          if (value === ROOTCAUSE_VALUE_OTHER) { return; }
+
           const urn = appendFilters(metricUrn, [[name, value]]);
           const curr = (current[name] || {})[value] || 0;
           const base = (baseline[name] || {})[value] || 0;

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
@@ -32,6 +32,8 @@ const ROOTCAUSE_ROLE_TAIL = 'tail';
 const ROOTCAUSE_ROLLUP_RANGE = [0, 100];
 const ROOTCAUSE_ROLLUP_EXPLAIN_FRACTION = 0.95;
 
+const ROOTCAUSE_VALUE_OTHER = 'OTHER';
+
 const ROOTCAUSE_MODE_MAPPING = {
   'Percentage Change': ROOTCAUSE_ROLLUP_MODE_CHANGE,
   'Change in Contribution': ROOTCAUSE_ROLLUP_MODE_CONTRIBUTION_DIFF,
@@ -273,8 +275,10 @@ export default Component.extend({
         let sum = this._sum(head.map(v => sizeMetricCurrent[n][v]));
         let i = range[0];
         while (i < range[1] && sum < cutoff) {
-          sum += sizeMetricCurrent[n][all[i]];
-          visible.push(all[i]);
+          if (all[i] !== ROOTCAUSE_VALUE_OTHER) {
+            sum += sizeMetricCurrent[n][all[i]];
+            visible.push(all[i]);
+          }
           i++;
         }
 

--- a/thirdeye/thirdeye-frontend/app/pods/services/rootcause-breakdowns-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/rootcause-breakdowns-cache/service.js
@@ -88,8 +88,9 @@ export default Service.extend({
     const range = context.anomalyRange;
     const offset = toAbsoluteUrn(urn, context.compareMode).split(':')[2].toLowerCase();
     const timezone = 'America/Los_Angeles';
+    const limit = offset === 'current' ? 100 : 200; // heuristically over-fetch baseline for heat map
 
-    const url = `/rootcause/metric/breakdown?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&timezone=${timezone}`;
+    const url = `/rootcause/metric/breakdown?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&timezone=${timezone}&limit=${limit}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractBreakdowns(res, urn))

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -1117,10 +1117,10 @@ public class AnomaliesResource {
     Collection<MetricSlice> slicesAnomalyBaseline = baseline.scatter(sliceAnomalyCurrent);
     Map<MetricSlice, DataFrame> anomalyBaselineMap = new HashMap<>();
     for (MetricSlice slice : slicesAnomalyBaseline) {
-      anomalyBaselineMap.put(slice, fixTimestamp(this.aggregationLoader.loadAggregate(slice, Collections.<String>emptyList()), slice.getStart()));
+      anomalyBaselineMap.put(slice, fixTimestamp(this.aggregationLoader.loadAggregate(slice, Collections.<String>emptyList(), -1), slice.getStart()));
     }
 
-    details.setCurrent(makeStringValue(this.aggregationLoader.loadAggregate(sliceAnomalyCurrent, Collections.<String>emptyList())));
+    details.setCurrent(makeStringValue(this.aggregationLoader.loadAggregate(sliceAnomalyCurrent, Collections.<String>emptyList(), -1)));
     details.setBaseline(makeStringValue(baseline.gather(sliceAnomalyCurrent, anomalyBaselineMap)));
 
     AnomalyOffset offsets = BaseAnomalyFunction.getDefaultOffsets(dataset);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
@@ -189,7 +189,7 @@ public class DataFrameUtils {
    * {@code COL_TIME} by default, and creates columns for each groupBy attribute and for each
    * MetricFunction specified in the request. It further evaluates expressions for derived
    * metrics.
-   * @see DataFrameUtils#makeAggregateRequest(MetricSlice, List, String, MetricConfigManager, DatasetConfigManager)
+   * @see DataFrameUtils#makeAggregateRequest(MetricSlice, List, int, String, MetricConfigManager, DatasetConfigManager)
    * @see DataFrameUtils#makeTimeSeriesRequest(MetricSlice, String, MetricConfigManager, DatasetConfigManager)
    *
    * @param response thirdeye client response
@@ -381,22 +381,40 @@ public class DataFrameUtils {
   public static RequestContainer makeAggregateRequest(MetricSlice slice, List<String> dimensions, String reference) throws Exception {
     MetricConfigManager metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
     DatasetConfigManager datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
-    return makeAggregateRequest(slice, dimensions, reference, metricDAO, datasetDAO);
+    return makeAggregateRequest(slice, dimensions, -1, reference, metricDAO, datasetDAO);
   }
 
-   /**
+  /**
    * Constructs and wraps a request for a metric with derived expressions. Resolves all
    * required dependencies from the Thirdeye database.
    *
    * @param slice metric data slice
    * @param dimensions dimensions to group by
+   * @param limit top k element limit ({@code -1} for default)
+   * @param reference unique identifier for request
+   * @return RequestContainer
+   * @throws Exception
+   */
+  public static RequestContainer makeAggregateRequest(MetricSlice slice, List<String> dimensions, int limit, String reference) throws Exception {
+    MetricConfigManager metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
+    DatasetConfigManager datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
+    return makeAggregateRequest(slice, dimensions, limit, reference, metricDAO, datasetDAO);
+  }
+
+  /**
+   * Constructs and wraps a request for a metric with derived expressions. Resolves all
+   * required dependencies from the Thirdeye database.
+   *
+   * @param slice metric data slice
+   * @param dimensions dimensions to group by
+   * @param limit top k element limit ({@code -1} for default)
    * @param reference unique identifier for request
    * @param metricDAO metric config DAO
    * @param datasetDAO dataset config DAO
    * @return RequestContainer
    * @throws Exception
    */
-  public static RequestContainer makeAggregateRequest(MetricSlice slice, List<String> dimensions, String reference, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) throws Exception {
+  public static RequestContainer makeAggregateRequest(MetricSlice slice, List<String> dimensions, int limit, String reference, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) throws Exception {
     MetricConfigDTO metric = metricDAO.findById(slice.metricId);
     if(metric == null)
       throw new IllegalArgumentException(String.format("Could not resolve metric id %d", slice.metricId));
@@ -410,6 +428,7 @@ public class DataFrameUtils {
 
     ThirdEyeRequest request = makeThirdEyeRequestBuilder(slice, metric, dataset, expressions, metricDAO)
         .setGroupBy(dimensions)
+        .setLimit(limit)
         .build(reference);
 
     return new RequestContainer(request, expressions);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/loader/AggregationLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/loader/AggregationLoader.java
@@ -27,7 +27,25 @@ public interface AggregationLoader {
   String COL_DIMENSION_VALUE = "dimValue";
   String COL_VALUE = DataFrameUtils.COL_VALUE;
 
-  DataFrame loadBreakdown(MetricSlice slice) throws Exception;
+  /**
+   * Returns a de-aggregation data frame for a given slice with 3 columns:
+   * dimension name, dimension value, and metric value.
+   *
+   * @param slice metric slice
+   * @param limit top k element limit per dimension name ({@code -1} for default)
+   * @return de-aggregation data frame
+   * @throws Exception
+   */
+  DataFrame loadBreakdown(MetricSlice slice, int limit) throws Exception;
 
-  DataFrame loadAggregate(MetricSlice slice, List<String> dimensions) throws Exception;
+  /**
+   * Returns metric aggregates grouped by the given dimensions (or none).
+   *
+   * @param slice metric slice
+   * @param dimensions dimension names to group by
+   * @param limit top k element limit ({@code -1} for default)
+   * @return aggregates data frame
+   * @throws Exception
+   */
+  DataFrame loadAggregate(MetricSlice slice, List<String> dimensions, int limit) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/loader/DefaultAggregationLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/loader/DefaultAggregationLoader.java
@@ -57,7 +57,7 @@ public class DefaultAggregationLoader implements AggregationLoader {
   }
 
   @Override
-  public DataFrame loadBreakdown(MetricSlice slice) throws Exception {
+  public DataFrame loadBreakdown(MetricSlice slice, int limit) throws Exception {
     final long metricId = slice.getMetricId();
 
     // fetch meta data
@@ -86,7 +86,7 @@ public class DefaultAggregationLoader implements AggregationLoader {
 
     // submit requests
     for (String dimension : dimensions) {
-      RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), "ref", this.metricDAO, this.datasetDAO);
+      RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), limit, "ref", this.metricDAO, this.datasetDAO);
       Future<ThirdEyeResponse> res = this.cache.getQueryResultAsync(rc.getRequest());
 
       requests.put(dimension, rc);
@@ -112,7 +112,7 @@ public class DefaultAggregationLoader implements AggregationLoader {
   }
 
   @Override
-  public DataFrame loadAggregate(MetricSlice slice, List<String> dimensions) throws Exception {
+  public DataFrame loadAggregate(MetricSlice slice, List<String> dimensions, int limit) throws Exception {
     final long metricId = slice.getMetricId();
 
     // fetch meta data
@@ -141,7 +141,7 @@ public class DefaultAggregationLoader implements AggregationLoader {
       return dfEmpty;
     }
 
-    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, new ArrayList<>(dimensions), "ref", this.metricDAO, this.datasetDAO);
+    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, new ArrayList<>(dimensions), limit, "ref", this.metricDAO, this.datasetDAO);
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
     return DataFrameUtils.evaluateResponse(res, rc);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/CurrentAndBaselineLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/CurrentAndBaselineLoader.java
@@ -122,7 +122,7 @@ public class CurrentAndBaselineLoader {
 
   private double getAggregate(MetricSlice slice) {
     try {
-      return this.aggregationLoader.loadAggregate(slice, Collections.<String>emptyList()).getDouble(COL_VALUE, 0);
+      return this.aggregationLoader.loadAggregate(slice, Collections.<String>emptyList(), -1).getDouble(COL_VALUE, 0);
     } catch (Exception e) {
       return Double.NaN;
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DefaultDataProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/DefaultDataProvider.java
@@ -103,7 +103,7 @@ public class DefaultDataProvider implements DataProvider {
         futures.put(slice, this.executor.submit(new Callable<DataFrame>() {
           @Override
           public DataFrame call() throws Exception {
-            return DefaultDataProvider.this.aggregationLoader.loadAggregate(slice, dimensions);
+            return DefaultDataProvider.this.aggregationLoader.loadAggregate(slice, dimensions, -1);
           }
         }));
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/callgraph/CallGraphPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/callgraph/CallGraphPipeline.java
@@ -169,13 +169,13 @@ public class CallGraphPipeline extends Pipeline {
     try {
       // prepare requests
       RequestContainer rcCurrCount = DataFrameUtils
-          .makeAggregateRequest(sliceCurrCount, explore, "currCount", this.metricDAO, this.datasetDAO);
+          .makeAggregateRequest(sliceCurrCount, explore, -1, "currCount", this.metricDAO, this.datasetDAO);
       RequestContainer rcCurrLatency = DataFrameUtils
-          .makeAggregateRequest(sliceCurrLatency, explore, "currLatency", this.metricDAO, this.datasetDAO);
+          .makeAggregateRequest(sliceCurrLatency, explore, -1, "currLatency", this.metricDAO, this.datasetDAO);
       RequestContainer rcBaseCount = DataFrameUtils
-          .makeAggregateRequest(sliceBaseCount, explore, "baseCount", this.metricDAO, this.datasetDAO);
+          .makeAggregateRequest(sliceBaseCount, explore, -1, "baseCount", this.metricDAO, this.datasetDAO);
       RequestContainer rcBaseLatency = DataFrameUtils
-          .makeAggregateRequest(sliceBaseLatency, explore, "baseLatency", this.metricDAO, this.datasetDAO);
+          .makeAggregateRequest(sliceBaseLatency, explore, -1, "baseLatency", this.metricDAO, this.datasetDAO);
 
       // send requests
       Future<ThirdEyeResponse> resCurrCount = this.cache.getQueryResultAsync(rcCurrCount.getRequest());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
@@ -176,7 +176,7 @@ public class DimensionAnalysisPipeline extends Pipeline {
   private DataFrame getContribution(MetricSlice slice, String dimension) throws Exception {
     String ref = String.format("%d-%s", slice.getMetricId(), dimension);
     RequestContainer
-        rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), ref, this.metricDAO, this.datasetDAO);
+        rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), -1, ref, this.metricDAO, this.datasetDAO);
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
 
     DataFrame raw = DataFrameUtils.evaluateResponse(res, rc);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricBreakdownPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricBreakdownPipeline.java
@@ -184,7 +184,7 @@ public class MetricBreakdownPipeline extends Pipeline {
 
   private DataFrame getContribution(MetricSlice slice, String dimension) throws Exception {
     String ref = String.format("%d-%s", slice.getMetricId(), dimension);
-    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), ref, this.metricDAO, this.datasetDAO);
+    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), -1, ref, this.metricDAO, this.datasetDAO);
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
 
     DataFrame raw = DataFrameUtils.evaluateResponse(res, rc);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricComponentAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricComponentAnalysisPipeline.java
@@ -217,7 +217,7 @@ public class MetricComponentAnalysisPipeline extends Pipeline {
 
   private double getTotal(MetricSlice slice) throws Exception {
     String ref = String.format("%d", slice.getMetricId());
-    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.<String>emptyList(), ref, this.metricDAO, this.datasetDAO);
+    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.<String>emptyList(), -1, ref, this.metricDAO, this.datasetDAO);
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
 
     DataFrame raw = DataFrameUtils.evaluateResponse(res, rc);
@@ -227,7 +227,7 @@ public class MetricComponentAnalysisPipeline extends Pipeline {
 
   private DataFrame getContribution(MetricSlice slice, String dimension) throws Exception {
     String ref = String.format("%d-%s", slice.getMetricId(), dimension);
-    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), ref, this.metricDAO, this.datasetDAO);
+    RequestContainer rc = DataFrameUtils.makeAggregateRequest(slice, Collections.singletonList(dimension), -1, ref, this.metricDAO, this.datasetDAO);
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
 
     DataFrame raw = DataFrameUtils.evaluateResponse(res, rc);


### PR DESCRIPTION
This PR extends topk limit support (#3207) end-to-end from frontend to data source in Thirdeye. De-aggregation (breakdown) queries can now provide an upper bound on the number of dimension values to return. The PR further adds support for the rollup of values smaller than the top k into an aggregate 'OTHER' column and adapts the UI to account for these in dimension heat map and table views.

This significantly improves the performance end-to-end from lower load on data sources such as pinot, over processing within ThirdEye's backend, to client-side rendering of dimensional data via heat map or table.