### PR TITLE
[TE] (PINOT-7089) Ability to configure multiple Metadata Sources

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
@@ -16,20 +16,21 @@
 
 package com.linkedin.thirdeye.auto.onboard;
 
-import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
+
 
 /**
  * This is the abstract parent class for all auto onboard services for various datasources
  */
 public abstract class AutoOnboard {
-  private DataSourceConfig dataSourceConfig;
+  private MetadataSourceConfig metadataSourceConfig;
 
-  public AutoOnboard(DataSourceConfig dataSourceConfig) {
-    this.dataSourceConfig = dataSourceConfig;
+  public AutoOnboard(MetadataSourceConfig metadataSourceConfig) {
+    this.metadataSourceConfig = metadataSourceConfig;
   }
 
-  public DataSourceConfig getDataSourceConfig() {
-    return dataSourceConfig;
+  public MetadataSourceConfig getMetadataSourceConfig() {
+    return metadataSourceConfig;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -88,7 +88,6 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
   }
 
   public void run() {
-    LOG.info("Running auto load for {}", AutoOnboardPinotDataSource.class.getSimpleName());
     try {
       List<String> allDatasets = new ArrayList<>();
       Map<String, Schema> allSchemas = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -30,6 +30,7 @@ import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean.DimensionAsMetricPr
 import com.linkedin.thirdeye.datalayer.util.Predicate;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -67,11 +68,11 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
 
   private AutoOnboardPinotMetricsUtils autoLoadPinotMetricsUtils;
 
-  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig)
+  public AutoOnboardPinotDataSource(MetadataSourceConfig metadataSourceConfig)
       throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
-    super(dataSourceConfig);
+    super(metadataSourceConfig);
     try {
-      autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(dataSourceConfig);
+      autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(metadataSourceConfig);
       LOG.info("Created {}", AutoOnboardPinotDataSource.class.getName());
     } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
       throw e;
@@ -80,8 +81,8 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
     this.metricDAO = DAO_REGISTRY.getMetricConfigDAO();
   }
 
-  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig, AutoOnboardPinotMetricsUtils utils) {
-    super(dataSourceConfig);
+  public AutoOnboardPinotDataSource(MetadataSourceConfig metadataSourceConfig, AutoOnboardPinotMetricsUtils utils) {
+    super(metadataSourceConfig);
     autoLoadPinotMetricsUtils = utils;
     this.datasetDAO = DAO_REGISTRY.getDatasetConfigDAO();
     this.metricDAO = DAO_REGISTRY.getMetricConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,10 +62,10 @@ public class AutoOnboardPinotMetricsUtils {
   private CloseableHttpClient pinotControllerClient;
   private HttpHost pinotControllerHost;
 
-  public AutoOnboardPinotMetricsUtils(DataSourceConfig dataSourceConfig)
+  public AutoOnboardPinotMetricsUtils(MetadataSourceConfig metadataSourceConfig)
       throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
     PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig =
-        PinotThirdEyeDataSourceConfig.createFromDataSourceConfig(dataSourceConfig);
+        PinotThirdEyeDataSourceConfig.createFromMetadataSourceConfig(metadataSourceConfig);
 
     String controllerConnectionScheme = pinotThirdeyeDataSourceConfig.getControllerConnectionScheme();
     if (PinotThirdEyeDataSourceConfig.HTTPS_SCHEME.equals(controllerConnectionScheme)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
@@ -53,8 +53,8 @@ public class AutoOnboardService implements Runnable {
     this.runFrequency = config.getAutoOnboardConfiguration().getRunFrequency();
     scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
-    Map<String, List<AutoOnboard>> dataSourceToOnboardMap = AutoOnboardUtility
-        .getDataSourceToAutoOnboardMap(config.getDataSourcesAsUrl());
+    Map<String, List<AutoOnboard>> dataSourceToOnboardMap = AutoOnboardUtility.getDataSourceToAutoOnboardMap(
+        config.getDataSourcesAsUrl());
     for (List<AutoOnboard> autoOnboards : dataSourceToOnboardMap.values()) {
       autoOnboardServices.addAll(autoOnboards);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
@@ -1,0 +1,58 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.DataSources;
+import com.linkedin.thirdeye.datasource.DataSourcesLoader;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AutoOnboardUtility {
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardUtility.class);
+
+  public static Map<String, List<AutoOnboard>> getDataSourceToAutoOnboardMap(URL dataSourcesUrl) {
+    Map<String, List<AutoOnboard>> dataSourceToOnboardMap = new HashMap<>();
+
+    DataSources dataSources = DataSourcesLoader.fromDataSourcesUrl(dataSourcesUrl);
+    if (dataSources == null) {
+      throw new IllegalStateException("Could not create data sources config from path " + dataSourcesUrl);
+    }
+    for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
+      List<MetadataSourceConfig> metadataSourceConfigs = dataSourceConfig.getMetadataSourceConfigs();
+      if (metadataSourceConfigs != null) {
+        for (MetadataSourceConfig metadataSourceConfig : metadataSourceConfigs) {
+          String metadataSourceClassName = metadataSourceConfig.getClassName();
+          if (StringUtils.isNotBlank(metadataSourceClassName)) {
+            try {
+              Constructor<?> constructor = Class.forName(metadataSourceClassName).getConstructor(DataSourceConfig.class);
+              AutoOnboard autoOnboardConstructor = (AutoOnboard) constructor.newInstance(dataSourceConfig);
+              String datasourceClassName = dataSourceConfig.getClassName();
+              String dataSource =
+                  datasourceClassName.substring(datasourceClassName.lastIndexOf(".") + 1, datasourceClassName.length());
+
+              if (dataSourceToOnboardMap.containsKey(dataSource)) {
+                dataSourceToOnboardMap.get(dataSource).add(autoOnboardConstructor);
+              } else {
+                List<AutoOnboard> autoOnboardServices = new ArrayList<>();
+                autoOnboardServices.add(autoOnboardConstructor);
+                dataSourceToOnboardMap.put(dataSource, autoOnboardServices);
+              }
+            } catch (Exception e) {
+              LOG.error("Exception in creating metadata constructor {}", metadataSourceClassName);
+            }
+          }
+        }
+      }
+    }
+
+    return dataSourceToOnboardMap;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
@@ -30,10 +30,12 @@ public class AutoOnboardUtility {
       if (metadataSourceConfigs != null) {
         for (MetadataSourceConfig metadataSourceConfig : metadataSourceConfigs) {
           String metadataSourceClassName = metadataSourceConfig.getClassName();
+          // Inherit properties from Data Source
+          metadataSourceConfig.getProperties().putAll(dataSourceConfig.getProperties());
           if (StringUtils.isNotBlank(metadataSourceClassName)) {
             try {
-              Constructor<?> constructor = Class.forName(metadataSourceClassName).getConstructor(DataSourceConfig.class);
-              AutoOnboard autoOnboardConstructor = (AutoOnboard) constructor.newInstance(dataSourceConfig);
+              Constructor<?> constructor = Class.forName(metadataSourceClassName).getConstructor(MetadataSourceConfig.class);
+              AutoOnboard autoOnboardConstructor = (AutoOnboard) constructor.newInstance(metadataSourceConfig);
               String datasourceClassName = dataSourceConfig.getClassName();
               String dataSource =
                   datasourceClassName.substring(datasourceClassName.lastIndexOf(".") + 1, datasourceClassName.length());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSources.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSources.java
@@ -31,10 +31,10 @@ public class DataSources {
   public List<DataSourceConfig> getDataSourceConfigs() {
     return dataSourceConfigs;
   }
+
   public void setDataSourceConfigs(List<DataSourceConfig> dataSourceConfigs) {
     this.dataSourceConfigs = dataSourceConfigs;
   }
-
 
   @Override
   public String toString() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/MetadataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/MetadataSourceConfig.java
@@ -16,22 +16,27 @@
 
 package com.linkedin.thirdeye.datasource;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * This class defines the config of a single datasource used in thirdeye
- * Eg: PinotThirdeyeDataSource
+ * This class defines the config of a metadata loader used in thirdeye
+ * Eg: UMPMetadataLoader
  */
-public class DataSourceConfig {
+public class MetadataSourceConfig {
 
   private String className;
   private Map<String, Object> properties = new HashMap<>();
-  private List<MetadataSourceConfig> metadataSourceConfigs = new ArrayList<>();
+
+  public MetadataSourceConfig() {
+
+  }
+
+  public MetadataSourceConfig(String className, Map<String, Object> properties) {
+    this.className = className;
+    this.properties = properties;
+  }
 
   public String getClassName() {
     return className;
@@ -47,14 +52,6 @@ public class DataSourceConfig {
 
   public void setProperties(Map<String, Object> properties) {
     this.properties = properties;
-  }
-
-  public List<MetadataSourceConfig> getMetadataSourceConfigs() {
-    return metadataSourceConfigs;
-  }
-
-  public void setMetadataSourceConfigs(List<MetadataSourceConfig> metadataSourceConfigs) {
-    this.metadataSourceConfigs = metadataSourceConfigs;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -206,16 +207,16 @@ public class PinotThirdEyeDataSourceConfig {
   /**
    * Returns pinot thirdeye datasource config given datasource config. There can be only ONE datasource of pinot type
    *
-   * @param dataSourceConfig
+   * @param metadataSourceConfig
    *
    * @return
    */
-  public static PinotThirdEyeDataSourceConfig createFromDataSourceConfig(DataSourceConfig dataSourceConfig) {
-    if (dataSourceConfig == null || !dataSourceConfig.getClassName()
+  public static PinotThirdEyeDataSourceConfig createFromMetadataSourceConfig(MetadataSourceConfig metadataSourceConfig) {
+    if (metadataSourceConfig == null || !metadataSourceConfig.getClassName()
         .equals(PinotThirdEyeDataSource.class.getCanonicalName())) {
-      throw new IllegalStateException("Data source config is not of type pinot " + dataSourceConfig);
+      throw new IllegalStateException("Metadata source config is not of type pinot " + metadataSourceConfig);
     }
-    return createFromProperties(dataSourceConfig.getProperties());
+    return createFromProperties(metadataSourceConfig.getProperties());
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherDummyDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherDummyDataSource.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.auto.onboard;
 
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,8 @@ public class AutoOnboardAnotherDummyDataSource extends AutoOnboard {
 
   private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardAnotherDummyDataSource.class);
 
-  public AutoOnboardAnotherDummyDataSource(DataSourceConfig dataSourceConfig) {
-    super(dataSourceConfig);
+  public AutoOnboardAnotherDummyDataSource(MetadataSourceConfig metadataSourceConfig) {
+    super(metadataSourceConfig);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherDummyDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherDummyDataSource.java
@@ -1,0 +1,24 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AutoOnboardAnotherDummyDataSource extends AutoOnboard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardAnotherDummyDataSource.class);
+
+  public AutoOnboardAnotherDummyDataSource(DataSourceConfig dataSourceConfig) {
+    super(dataSourceConfig);
+  }
+
+  @Override
+  public void run() {
+  }
+
+  @Override
+  public void runAdhoc() {
+
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherRandomDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherRandomDataSource.java
@@ -1,0 +1,25 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AutoOnboardAnotherRandomDataSource extends AutoOnboard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardAnotherRandomDataSource.class);
+
+  public AutoOnboardAnotherRandomDataSource(DataSourceConfig dataSourceConfig) {
+    super(dataSourceConfig);
+  }
+
+  @Override
+  public void run() {
+    throw new RuntimeException("There was an exception while executing this Source");
+  }
+
+  @Override
+  public void runAdhoc() {
+
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherRandomDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardAnotherRandomDataSource.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.auto.onboard;
 
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,8 @@ public class AutoOnboardAnotherRandomDataSource extends AutoOnboard {
 
   private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardAnotherRandomDataSource.class);
 
-  public AutoOnboardAnotherRandomDataSource(DataSourceConfig dataSourceConfig) {
-    super(dataSourceConfig);
+  public AutoOnboardAnotherRandomDataSource(MetadataSourceConfig metadataSourceConfig) {
+    super(metadataSourceConfig);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardDummyDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardDummyDataSource.java
@@ -1,0 +1,24 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AutoOnboardDummyDataSource extends AutoOnboard {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardDummyDataSource.class);
+
+  public AutoOnboardDummyDataSource(DataSourceConfig dataSourceConfig) {
+    super(dataSourceConfig);
+  }
+
+  @Override
+  public void run() {
+  }
+
+  @Override
+  public void runAdhoc() {
+
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardDummyDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardDummyDataSource.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.auto.onboard;
 
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,8 @@ public class AutoOnboardDummyDataSource extends AutoOnboard {
 
   private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardDummyDataSource.class);
 
-  public AutoOnboardDummyDataSource(DataSourceConfig dataSourceConfig) {
-    super(dataSourceConfig);
+  public AutoOnboardDummyDataSource(MetadataSourceConfig metadataSourceConfig) {
+    super(metadataSourceConfig);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardServiceTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+public class AutoOnboardServiceTest {
+
+  @Test
+  public void testAutoOnboardService() throws Exception {
+    ThirdEyeAnomalyConfiguration thirdEyeAnomalyConfiguration = new ThirdEyeAnomalyConfiguration();
+
+    AutoOnboardConfiguration autoOnboardConfiguration = new AutoOnboardConfiguration();
+    autoOnboardConfiguration.setRunFrequency(new TimeGranularity(1, TimeUnit.SECONDS));
+    thirdEyeAnomalyConfiguration.setAutoOnboardConfiguration(autoOnboardConfiguration);
+
+    URL url = AutoOnboardServiceTest.class.getResource("/data-sources/data-sources-config-1.yml");
+    thirdEyeAnomalyConfiguration.setDataSources(url.getPath());
+
+    AutoOnboardService autoOnboardService = new AutoOnboardService(thirdEyeAnomalyConfiguration);
+    autoOnboardService.start();
+
+    Thread.sleep(2000);
+
+    // Execute without exceptions
+
+    autoOnboardService.shutdown();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.MetadataSourceConfig;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AutoOnboardUtilityTest {
+
+  @Test
+  public void testDataSourceToAutoOnboardMap() {
+    URL url = AutoOnboardUtilityTest.class.getResource("/data-sources/data-sources-config-1.yml");
+
+    Map<String, List<AutoOnboard>> dsToOnboardsMap = AutoOnboardUtility.getDataSourceToAutoOnboardMap(url);
+
+    // Assert two data sources (PinotThirdEyeDataSource, CSVThirdEyeDataSource)
+    Assert.assertEquals(dsToOnboardsMap.keySet().size(), 2);
+
+    // PinotThirdEyeDataSource has 2 metadata loaders (AutoOnboardDummyDataSource, AutoOnboardAnotherDummyDataSource)
+    Assert.assertEquals(dsToOnboardsMap.get("PinotThirdEyeDataSource").size(), 2);
+
+    // CSVThirdEyeDataSource has 1 metadata loader (AutoOnboardAnotherRandomDataSource)
+    Assert.assertEquals(dsToOnboardsMap.get("CSVThirdEyeDataSource").size(), 1);
+
+    // Assertion on AutoOnboardDummyDataSource
+    MetadataSourceConfig dummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(0)
+        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    Assert.assertEquals(dummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
+    Assert.assertEquals(dummyMDSource.getProperties().size(), 2);
+    Assert.assertEquals(dummyMDSource.getProperties().get("username"), "username");
+    Assert.assertEquals(dummyMDSource.getProperties().get("password"), "password");
+
+    // Assertion on AutoOnboardAnotherDummyDataSource
+    MetadataSourceConfig anotherDummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(1)
+        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    Assert.assertEquals(anotherDummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
+    Assert.assertEquals(anotherDummyMDSource.getProperties().size(), 2);
+    Assert.assertEquals(anotherDummyMDSource.getProperties().get("username"), "username");
+    Assert.assertEquals(anotherDummyMDSource.getProperties().get("password"), "password");
+
+    // Assertion on AutoOnboardAnotherRandomDataSource
+    MetadataSourceConfig anotherRandomMDSource = dsToOnboardsMap.get("CSVThirdEyeDataSource").get(0)
+        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    Assert.assertEquals(anotherRandomMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource");
+    Assert.assertEquals(anotherRandomMDSource.getProperties().size(), 0);
+  }
+
+  @Test
+  public void testAutoOnboardClassNotFoundService() {
+    URL url = AutoOnboardUtilityTest.class.getResource("/data-sources/data-sources-config-2.yml");
+
+    Map<String, List<AutoOnboard>> dsToOnboardsMap = AutoOnboardUtility.getDataSourceToAutoOnboardMap(url);
+
+    // Assert no metadata loaders
+    Assert.assertEquals(dsToOnboardsMap.keySet().size(), 0);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
@@ -42,24 +42,21 @@ public class AutoOnboardUtilityTest {
     Assert.assertEquals(dsToOnboardsMap.get("CSVThirdEyeDataSource").size(), 1);
 
     // Assertion on AutoOnboardDummyDataSource
-    MetadataSourceConfig dummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(0)
-        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    MetadataSourceConfig dummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(0).getMetadataSourceConfig();
     Assert.assertEquals(dummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
     Assert.assertEquals(dummyMDSource.getProperties().size(), 2);
     Assert.assertEquals(dummyMDSource.getProperties().get("username"), "username");
     Assert.assertEquals(dummyMDSource.getProperties().get("password"), "password");
 
     // Assertion on AutoOnboardAnotherDummyDataSource
-    MetadataSourceConfig anotherDummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(1)
-        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    MetadataSourceConfig anotherDummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(1).getMetadataSourceConfig();
     Assert.assertEquals(anotherDummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
     Assert.assertEquals(anotherDummyMDSource.getProperties().size(), 2);
     Assert.assertEquals(anotherDummyMDSource.getProperties().get("username"), "username");
     Assert.assertEquals(anotherDummyMDSource.getProperties().get("password"), "password");
 
     // Assertion on AutoOnboardAnotherRandomDataSource
-    MetadataSourceConfig anotherRandomMDSource = dsToOnboardsMap.get("CSVThirdEyeDataSource").get(0)
-        .getDataSourceConfig().getMetadataSourceConfigs().get(0);
+    MetadataSourceConfig anotherRandomMDSource = dsToOnboardsMap.get("CSVThirdEyeDataSource").get(0).getMetadataSourceConfig();
     Assert.assertEquals(anotherRandomMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource");
     Assert.assertEquals(anotherRandomMDSource.getProperties().size(), 0);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtilityTest.java
@@ -44,21 +44,21 @@ public class AutoOnboardUtilityTest {
     // Assertion on AutoOnboardDummyDataSource
     MetadataSourceConfig dummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(0).getMetadataSourceConfig();
     Assert.assertEquals(dummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
-    Assert.assertEquals(dummyMDSource.getProperties().size(), 2);
+    Assert.assertEquals(dummyMDSource.getProperties().size(), 10);
     Assert.assertEquals(dummyMDSource.getProperties().get("username"), "username");
     Assert.assertEquals(dummyMDSource.getProperties().get("password"), "password");
 
     // Assertion on AutoOnboardAnotherDummyDataSource
     MetadataSourceConfig anotherDummyMDSource = dsToOnboardsMap.get("PinotThirdEyeDataSource").get(1).getMetadataSourceConfig();
-    Assert.assertEquals(anotherDummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource");
-    Assert.assertEquals(anotherDummyMDSource.getProperties().size(), 2);
-    Assert.assertEquals(anotherDummyMDSource.getProperties().get("username"), "username");
-    Assert.assertEquals(anotherDummyMDSource.getProperties().get("password"), "password");
+    Assert.assertEquals(anotherDummyMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherDummyDataSource");
+    Assert.assertEquals(anotherDummyMDSource.getProperties().size(), 10);
+    Assert.assertEquals(anotherDummyMDSource.getProperties().get("host"), "host");
+    Assert.assertEquals(anotherDummyMDSource.getProperties().get("port"), 9999);
 
     // Assertion on AutoOnboardAnotherRandomDataSource
     MetadataSourceConfig anotherRandomMDSource = dsToOnboardsMap.get("CSVThirdEyeDataSource").get(0).getMetadataSourceConfig();
     Assert.assertEquals(anotherRandomMDSource.getClassName(), "com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource");
-    Assert.assertEquals(anotherRandomMDSource.getProperties().size(), 0);
+    Assert.assertEquals(anotherRandomMDSource.getProperties().size(), 1);
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSourceIntergrationTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSourceIntergrationTest.java
@@ -55,7 +55,7 @@ public class CSVThirdEyeDataSourceIntergrationTest {
 
   @Test
   public void intergrationTest() throws Exception{
-    URL dataSourcesConfig = this.getClass().getResource("data-sources/data-sources-config.yml");
+    URL dataSourcesConfig = this.getClass().getResource("data-sources-config.yml");
 
     DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSourceIntergrationTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/csv/CSVThirdEyeDataSourceIntergrationTest.java
@@ -55,7 +55,7 @@ public class CSVThirdEyeDataSourceIntergrationTest {
 
   @Test
   public void intergrationTest() throws Exception{
-    URL dataSourcesConfig = this.getClass().getResource("data-sources-config.yml");
+    URL dataSourcesConfig = this.getClass().getResource("data-sources/data-sources-config.yml");
 
     DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
 

--- a/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-1.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-1.yml
@@ -16,8 +16,10 @@ dataSourceConfigs:
             password: 'password'
       - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherDummyDataSource
         properties:
-            dataSourceHost: 'host'
-            dataSourcePort: 9999'
+            host: 'host'
+            port: 9999
   - className: com.linkedin.thirdeye.datasource.csv.CSVThirdEyeDataSource
+    properties:
+        business: business.csv
     metadataSourceConfigs:
       - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource

--- a/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-1.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-1.yml
@@ -1,0 +1,23 @@
+dataSourceConfigs:
+  - className: com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource
+    properties:
+        zookeeperUrl: 'dummy-url'
+        clusterName: 'dummy-cluster'
+        controllerConnectionScheme: 'https'
+        controllerHost: 'dummy-host'
+        controllerPort: 99999
+        d2PinotProxyHost: 'dummy-host'
+        d2PinotProxyPort: 9999
+        cacheLoaderClassName: dummy-cache
+    metadataSourceConfigs:
+      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource
+        properties:
+            username: 'username'
+            password: 'password'
+      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherDummyDataSource
+        properties:
+            dataSourceHost: 'host'
+            dataSourcePort: 9999'
+  - className: com.linkedin.thirdeye.datasource.csv.CSVThirdEyeDataSource
+    metadataSourceConfigs:
+      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource

--- a/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-2.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/data-sources/data-sources-config-2.yml
@@ -1,0 +1,16 @@
+dataSourceConfigs:
+  - className: com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource
+    properties:
+        zookeeperUrl: 'dummy-url'
+        clusterName: 'dummy-cluster'
+        controllerConnectionScheme: 'https'
+        controllerHost: 'dummy-host'
+        controllerPort: 99999
+        d2PinotProxyHost: 'dummy-host'
+        d2PinotProxyPort: 9999
+        cacheLoaderClassName: dummy-cache
+    metadataSourceConfigs:
+      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardClassNotFoundDataSource
+        properties:
+            username: 'username'
+            password: 'password'


### PR DESCRIPTION
**Changes:**
* Added ability to configure multiple metadata sources for each data source.
* Each Metadata source will have their own properties along with inheriting the parent data source properties.

**New Configuration changes:**
```
dataSourceConfigs:
  - className: com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource
    properties:
        zookeeperUrl: 'dummy-url'
        clusterName: 'dummy-cluster'
        controllerConnectionScheme: 'https'
        controllerHost: 'dummy-host'
        controllerPort: 99999
        d2PinotProxyHost: 'dummy-host'
        d2PinotProxyPort: 9999
        cacheLoaderClassName: dummy-cache
    metadataSourceConfigs:
      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardDummyDataSource
        properties:
            username: 'username'
            password: 'password'
      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherDummyDataSource
        properties:
            host: 'host'
            port: 9999
  - className: com.linkedin.thirdeye.datasource.csv.CSVThirdEyeDataSource
    properties:
        business: business.csv
    metadataSourceConfigs:
      - className: com.linkedin.thirdeye.auto.onboard.AutoOnboardAnotherRandomDataSource
```

**Testing:**
* Added Unit tests