### PR TITLE
Adding local temp dir parameter to distinguish between local and remote fs

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
@@ -54,12 +54,10 @@ public class SegmentFetcherFactory {
   public static final String FETCHER_CLASS_KEY_SUFFIX = ".class";
 
   private final Map<String, SegmentFetcher> _segmentFetcherMap = new HashMap<>();
-  private Configuration _pinotFSConfig;
 
   /**
    * Initiate the segment fetcher factory. This method should only be called once.
    * @param segmentFetcherClassConfig Segment fetcher factory config
-   * @param pinotFSConfig
    *
    */
   public void init(Configuration segmentFetcherClassConfig, Configuration pinotFSConfig) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
@@ -77,7 +75,6 @@ public class SegmentFetcherFactory {
       segmentFetcher.init(segmentFetcherConfig);
       _segmentFetcherMap.put(protocol, segmentFetcher);
     }
-    _pinotFSConfig = pinotFSConfig;
   }
 
   public boolean containsProtocol(String protocol) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -266,6 +266,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
+    public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.server.storage.factory";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -34,6 +34,8 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
   private static final String DATA_DIR = "controller.data.dir";
+  // Potentially same as data dir if local
+  private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
   private static final String ZK_STR = "controller.zk.str";
   private static final String UPDATE_SEGMENT_STATE_MODEL = "controller.update_segment_state_model"; // boolean: Update the statemodel on boot?
   private static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
@@ -101,6 +103,14 @@ public class ControllerConf extends PropertiesConfiguration {
       // Shouldn't happen
       throw new AssertionError("Encountered error while encoding in UTF-8 format", e);
     }
+  }
+
+  public void setLocalTempDir(String localTempDir) {
+    setProperty(LOCAL_TEMP_DIR, localTempDir);
+  }
+
+  public String getLocalTempDir() {
+    return getString(LOCAL_TEMP_DIR, null);
   }
 
   public void setPinotFSFactoryClasses(Configuration pinotFSFactoryClasses) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -301,7 +301,9 @@ public class PinotSegmentUploadRestletResource {
           if (new URI(storageURI).getScheme().equals(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
             downloadURI = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(), provider.getVip());
           } else {
-            downloadURI = storageURI;
+            LOGGER.info("Using storage dir {}", _controllerConf.getDataDir());
+            downloadURI = StringUtil.join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
+                URLEncoder.encode(segmentMetadata.getName(), "UTF-8"));
           }
           break;
         case SEGMENT:

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -271,14 +271,14 @@ public class PinotSegmentUploadRestletResource {
       crypterClassHeader = DefaultPinotCrypter.class.getName();
     }
 
-    // Get storage URI
-    String storageURI = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI);
+    // Get URI of current segment location
+    String currentSegmentLocationURI = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI);
 
     File tempEncryptedFile = null;
     File tempDecryptedFile = null;
     File tempSegmentDir = null;
     SegmentMetadata segmentMetadata;
-    String downloadURI = null;
+    String zkDownloadUri = null;
     try {
       FileUploadPathProvider provider = new FileUploadPathProvider(_controllerConf);
       String tempFileName = TMP_DIR_PREFIX + System.nanoTime();
@@ -291,28 +291,28 @@ public class PinotSegmentUploadRestletResource {
 
       switch (uploadType) {
         case URI:
-          if (storageURI == null || storageURI.isEmpty()) {
+          if (currentSegmentLocationURI == null || currentSegmentLocationURI.isEmpty()) {
             throw new ControllerApplicationException(LOGGER, "Failed to get downloadURI, needed for URI upload",
                 Response.Status.BAD_REQUEST);
           }
           segmentMetadata =
-              getSegmentMetadata(crypterClassHeader, storageURI, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
+              getSegmentMetadata(crypterClassHeader, currentSegmentLocationURI, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
                   metadataProviderClass);
-          if (new URI(storageURI).getScheme().equals(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
-            downloadURI = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(), provider.getVip());
+          if (new URI(currentSegmentLocationURI).getScheme().equals(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
+            zkDownloadUri = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(), provider.getVip());
           } else {
-            LOGGER.info("Using storage dir {}", _controllerConf.getDataDir());
-            downloadURI = StringUtil.join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
+            LOGGER.info("Using configured data dir {}", _controllerConf.getDataDir());
+            zkDownloadUri = StringUtil.join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
                 URLEncoder.encode(segmentMetadata.getName(), "UTF-8"));
           }
           break;
         case SEGMENT:
           getFileFromMultipart(multiPart, tempDecryptedFile);
-          storageURI = tempDecryptedFile.toURI().toString();
+          currentSegmentLocationURI = tempDecryptedFile.toURI().toString();
           segmentMetadata =
-              getSegmentMetadata(crypterClassHeader, storageURI, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
+              getSegmentMetadata(crypterClassHeader, currentSegmentLocationURI, tempEncryptedFile, tempDecryptedFile, tempSegmentDir,
                   metadataProviderClass);
-          downloadURI = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(), provider.getVip());
+          zkDownloadUri = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(), provider.getVip());
           break;
         default:
           throw new UnsupportedOperationException("Unsupported upload type: " + uploadType);
@@ -331,7 +331,7 @@ public class PinotSegmentUploadRestletResource {
 
       // Zk operations
       completeZkOperations(enableParallelPushProtection, headers, tempDecryptedFile, provider, segmentMetadata,
-          segmentName, downloadURI);
+          segmentName, zkDownloadUri);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentMetadata.getName() + " of table: " + segmentMetadata.getTableName());
     } catch (WebApplicationException e) {
@@ -347,9 +347,9 @@ public class PinotSegmentUploadRestletResource {
     }
   }
 
-  private SegmentMetadata getSegmentMetadata(String crypterClassHeader, String downloadURI, File tempEncryptedFile,
+  private SegmentMetadata getSegmentMetadata(String crypterClassHeader, String currentSegmentLocationURI, File tempEncryptedFile,
       File tempDecryptedFile, File tempSegmentDir, String metadataProviderClass) throws Exception {
-    SegmentFetcherFactory.getInstance().getSegmentFetcherBasedOnURI(downloadURI).fetchSegmentToLocal(downloadURI, tempEncryptedFile);
+    SegmentFetcherFactory.getInstance().getSegmentFetcherBasedOnURI(currentSegmentLocationURI).fetchSegmentToLocal(currentSegmentLocationURI, tempEncryptedFile);
 
     decryptFile(crypterClassHeader, tempEncryptedFile, tempDecryptedFile);
 
@@ -358,13 +358,13 @@ public class PinotSegmentUploadRestletResource {
   }
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File tempDecryptedFile,
-      FileUploadPathProvider provider, SegmentMetadata segmentMetadata, String segmentName, String downloadURI) throws Exception {
+      FileUploadPathProvider provider, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI) throws Exception {
     String finalSegmentPath = StringUtil.join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
         URLEncoder.encode(segmentName, "UTF-8"));
     URI finalSegmentLocationURI = new URI(finalSegmentPath);
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator.completeSegmentOperations(segmentMetadata, finalSegmentLocationURI, tempDecryptedFile, enableParallelPushProtection, headers,
-        downloadURI);
+        zkDownloadURI);
   }
 
   private void decryptFile(String crypterClassHeader, File tempEncryptedFile, File tempDecryptedFile) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
@@ -53,7 +53,7 @@ public class ZKOperator {
   }
 
   public void completeSegmentOperations(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection, HttpHeaders headers,
-      String downloadURI) throws Exception {
+      String zkDownloadURI) throws Exception {
     String rawTableName = segmentMetadata.getTableName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
     String segmentName = segmentMetadata.getName();
@@ -63,7 +63,7 @@ public class ZKOperator {
     // Brand new segment, not refresh, directly add the segment
     if (znRecord == null) {
       LOGGER.info("Adding new segment: {}", segmentName);
-      processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, downloadURI, rawTableName,
+      processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, rawTableName,
           segmentName);
       return;
     }
@@ -71,7 +71,7 @@ public class ZKOperator {
     LOGGER.info("Segment {} already exists, refreshing if necessary", segmentName);
 
     processExistingSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation,
-        enableParallelPushProtection, headers, downloadURI, rawTableName, offlineTableName, segmentName, znRecord);
+        enableParallelPushProtection, headers, zkDownloadURI, rawTableName, offlineTableName, segmentName, znRecord);
   }
 
   private void processExistingSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
@@ -178,7 +178,7 @@ public class ZKOperator {
   }
 
   private void processNewSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
-      File currentSegmentLocation, String downloadURI, String rawTableName, String segmentName) {
+      File currentSegmentLocation, String zkDownloadURI, String rawTableName, String segmentName) {
     try {
       moveSegmentToPermanentDirectory(currentSegmentLocation, finalSegmentLocationURI);
       LOGGER.info("Moved segment {} from temp location {} to {}", segmentName, currentSegmentLocation.getAbsolutePath(), finalSegmentLocationURI.getPath());
@@ -186,7 +186,7 @@ public class ZKOperator {
       LOGGER.error("Could not move segment {} from table {} to permanent directory", segmentName, rawTableName, e);
       throw new RuntimeException(e);
     }
-    _pinotHelixResourceManager.addNewSegment(segmentMetadata, downloadURI);
+    _pinotHelixResourceManager.addNewSegment(segmentMetadata, zkDownloadURI);
   }
 
   private void moveSegmentToPermanentDirectory(File currentSegmentLocation, URI finalSegmentLocationURI) throws Exception {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -52,7 +52,7 @@ public class SegmentFetcherAndLoader {
     _instanceDataManager = instanceDataManager;
     _propertyStore = propertyStore;
 
-    Configuration pinotFSConfig = config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
+    Configuration pinotFSConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     Configuration segmentFetcherFactoryConfig =
         config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
 


### PR DESCRIPTION
* Adding a new local temp dir parameter that determines the final location of segment upload
* If local.temp.dir is not set, we will default to data.dir
* Adding support for copyFromLocal in Azure
* Changing fileUploadPath provider to allow different schemes for final storage directory and local temp dir
* Fixing server pinot fs factory config
* Changing variable names to clarify intent