### PR TITLE
[PINOT-7088] Emit metrics to track when servers are not found segments during query processing

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -87,7 +87,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     _timeBoundaryService = new HelixExternalViewBasedTimeBoundaryService(propertyStore);
     _routingTableBuilderMap = new HashMap<>();
     _helixManager = helixManager;
-    _routingTableBuilderFactory = new RoutingTableBuilderFactory(_configuration, propertyStore);
+    _routingTableBuilderFactory = new RoutingTableBuilderFactory(_configuration, propertyStore, _brokerMetrics);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     String tableName = tableConfig.getTableName();
 
     RoutingTableBuilder routingTableBuilder = _routingTableBuilderFactory.createRoutingTableBuilder(tableConfig);
-    routingTableBuilder.init(_configuration, tableConfig, _propertyStore);
+    routingTableBuilder.init(_configuration, tableConfig, _propertyStore, _brokerMetrics);
     LOGGER.info("Initialized routingTableBuilder: {} for table {}", routingTableBuilder.getClass().getName(), tableName);
     _routingTableBuilderMap.put(tableName, routingTableBuilder);
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -15,25 +15,25 @@
  */
 package com.linkedin.pinot.broker.routing;
 
-import com.linkedin.pinot.broker.routing.builder.PartitionAwareOfflineRoutingTableBuilder;
-import com.linkedin.pinot.broker.routing.builder.PartitionAwareRealtimeRoutingTableBuilder;
-import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import org.apache.commons.configuration.Configuration;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.broker.routing.builder.BalancedRandomRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.DefaultOfflineRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.DefaultRealtimeRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.KafkaLowLevelConsumerRoutingTableBuilder;
+import com.linkedin.pinot.broker.routing.builder.PartitionAwareOfflineRoutingTableBuilder;
+import com.linkedin.pinot.broker.routing.builder.PartitionAwareRealtimeRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.RoutingTableBuilder;
+import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class RoutingTableBuilderFactory {
@@ -42,6 +42,8 @@ public class RoutingTableBuilderFactory {
   private Configuration _configuration;
 
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  private BrokerMetrics _brokerMetrics;
 
   enum RoutingTableBuilderName {
     DefaultOffline,
@@ -53,9 +55,10 @@ public class RoutingTableBuilderFactory {
     PartitionAwareRealtime
   }
 
-  public RoutingTableBuilderFactory(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public RoutingTableBuilderFactory(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
     _configuration = configuration;
     _propertyStore = propertyStore;
+    _brokerMetrics = brokerMetrics;
   }
 
   public RoutingTableBuilder createRoutingTableBuilder(TableConfig tableConfig) {
@@ -135,7 +138,7 @@ public class RoutingTableBuilderFactory {
         }
         break;
     }
-    builder.init(_configuration, tableConfig, _propertyStore);
+    builder.init(_configuration, tableConfig, _propertyStore, _brokerMetrics);
     return builder;
   }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,11 +36,13 @@ public class BalancedRandomRoutingTableBuilder extends BaseRoutingTableBuilder {
   private static final int DEFAULT_NUM_ROUTING_TABLES = 10;
   private static final String NUM_ROUTING_TABLES_KEY = "numOfRoutingTables";
 
+  private BrokerMetrics _brokerMetrics;
   private int _numRoutingTables = DEFAULT_NUM_ROUTING_TABLES;
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
     _numRoutingTables = configuration.getInt(NUM_ROUTING_TABLES_KEY, DEFAULT_NUM_ROUTING_TABLES);
+    _brokerMetrics = brokerMetrics;
   }
 
   @Override
@@ -67,6 +70,8 @@ public class BalancedRandomRoutingTableBuilder extends BaseRoutingTableBuilder {
           // Assign the segment to the server with least segments assigned
           routingTable.get(getServerWithLeastSegmentsAssigned(servers, routingTable)).add(segmentName);
         }
+      } else {
+        handleNoServingHost(tableName, segmentName, _brokerMetrics);
       }
     }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BaseRoutingTableBuilder.java
@@ -16,17 +16,22 @@
 package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.common.metrics.BrokerMeter;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base routing table builder class to share common methods between routing table builders.
  */
 public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseRoutingTableBuilder.class);
+
   protected final Random _random = new Random();
 
   // Set variable as volatile so all threads can get the up-to-date routing tables
@@ -66,5 +71,13 @@ public abstract class BaseRoutingTableBuilder implements RoutingTableBuilder {
   @Override
   public List<Map<String, List<String>>> getRoutingTables() {
     return _routingTables;
+  }
+
+  protected void handleNoServingHost(String tableName, String segmentName, BrokerMetrics brokerMetrics) {
+
+    LOGGER.error("Found no server hosting segment {} for table {}", segmentName, tableName);
+    if (brokerMetrics != null) {
+      brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.NO_SERVING_HOST_FOR_SEGMENT, 1);
+    }
   }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class DefaultOfflineRoutingTableBuilder extends BaseRoutingTableBuilder {
   private int _minReplicaCountForLargeCluster = 4;
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
     _largeClusterRoutingTableBuilder = new LargeClusterRoutingTableBuilder();
     _smallClusterRoutingTableBuilder = new BalancedRandomRoutingTableBuilder();
     if (configuration.containsKey("minServerCountForLargeCluster")) {
@@ -77,8 +78,8 @@ public class DefaultOfflineRoutingTableBuilder extends BaseRoutingTableBuilder {
       LOGGER.info("Using default value for large cluster min replica count of {}", _minReplicaCountForLargeCluster);
     }
 
-    _largeClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
-    _smallClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
+    _largeClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
+    _smallClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.utils.SegmentName;
 import java.util.Collections;
 import java.util.List;
@@ -39,11 +40,11 @@ public class DefaultRealtimeRoutingTableBuilder extends BaseRoutingTableBuilder 
   private boolean _hasLLC;
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
     _realtimeHLCRoutingTableBuilder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
     _realtimeLLCRoutingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    _realtimeHLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
-    _realtimeLLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
+    _realtimeHLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
+    _realtimeLLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerBasedRoutingTableBuilder.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
@@ -33,7 +34,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 public class KafkaHighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableBuilder {
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignment;
 import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignmentGenerator;
 import com.linkedin.pinot.common.utils.CommonConstants;
@@ -70,8 +71,8 @@ public class PartitionAwareOfflineRoutingTableBuilder extends BasePartitionAware
   private boolean _isPartitionLevelReplicaGroupAssignment;
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    super.init(configuration, tableConfig, propertyStore);
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
+    super.init(configuration, tableConfig, propertyStore, brokerMetrics);
     String partitionColumn = tableConfig.getValidationConfig().getReplicaGroupStrategyConfig().getPartitionColumn();
     _isPartitionLevelReplicaGroupAssignment = (partitionColumn != null);
     _numReplicas = tableConfig.getValidationConfig().getReplicationNumber();

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.broker.routing.builder;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.LLCUtils;
@@ -47,8 +48,8 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwareRoutingTableBuilder {
 
   @Override
-  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    super.init(configuration, tableConfig, propertyStore);
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
+    super.init(configuration, tableConfig, propertyStore, brokerMetrics);
     _numReplicas = Integer.valueOf(tableConfig.getValidationConfig().getReplicasPerPartition());
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RoutingTableBuilder.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
@@ -34,7 +35,7 @@ public interface RoutingTableBuilder {
   /**
    * Initiate the routing table builder.
    */
-  void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore);
+  void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics);
 
   /**
    * Compute routing tables (map from server to list of segments) that are used for query routing from ExternalView.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -84,7 +84,11 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   GROUP_BY_SIZE("queries", false),
   TOTAL_SERVER_RESPONSE_SIZE("queries", false),
 
-  QUERY_QUOTA_EXCEEDED("exceptions", false);
+  QUERY_QUOTA_EXCEEDED("exceptions", false),
+
+  // tracks a case a segment is not hosted by any server
+  // this is different from NO_SERVER_FOUND_EXCEPTIONS which tracks unavailability across all segments
+  NO_SERVING_HOST_FOR_SEGMENT("badResponses", false);
 
 
   private final String brokerMeterName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -55,7 +55,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_DOCS_SCANNED("rows", false),
   NUM_ENTRIES_SCANNED_IN_FILTER("entries", false),
   NUM_ENTRIES_SCANNED_POST_FILTER("entries", false),
-  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false);
+  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false),
+  MISSING_SEGMENT_COUNT("segments", false);
 
   private final String meterName;
   private final String unit;


### PR DESCRIPTION
This change is related to https://github.com/linkedin/pinot/pull/3217. 

This change updates broker and server code to indicate the following errors:
1. If a server gets a request for a segment its not hosting. This can happen when broker hasn't processed EV update indicating that the segment has moved off the server.
2. On the broker side, when a EV update results in routing table entries that have no servers for some segments. This could happen during table rebalance when Helix removes a segment from all servers temporarily.

Testing done:
None at this time