### PR TITLE
Improve the way we get instances with a tag from helix

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/partition/StreamPartitionAssignmentGenerator.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/partition/StreamPartitionAssignmentGenerator.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -168,8 +169,9 @@ public class StreamPartitionAssignmentGenerator {
   protected List<String> getConsumingTaggedInstances(TableConfig tableConfig) {
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
     String consumingServerTag = realtimeTagConfig.getConsumingServerTag();
-    List<String> consumingTaggedInstances = _helixManager.getClusterManagmentTool()
-        .getInstancesInClusterWithTag(_helixManager.getClusterName(), consumingServerTag);
+    List<String> consumingTaggedInstances =
+        HelixHelper.getInstancesWithTag(_helixManager.getClusterManagmentTool(), _helixManager.getClusterName(),
+            consumingServerTag);
     if (consumingTaggedInstances.isEmpty()) {
       throw new IllegalStateException("No instances found with tag " + consumingServerTag);
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/partition/StreamPartitionAssignmentGenerator.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/partition/StreamPartitionAssignmentGenerator.java
@@ -169,9 +169,7 @@ public class StreamPartitionAssignmentGenerator {
   protected List<String> getConsumingTaggedInstances(TableConfig tableConfig) {
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig);
     String consumingServerTag = realtimeTagConfig.getConsumingServerTag();
-    List<String> consumingTaggedInstances =
-        HelixHelper.getInstancesWithTag(_helixManager.getClusterManagmentTool(), _helixManager.getClusterName(),
-            consumingServerTag);
+    List<String> consumingTaggedInstances = HelixHelper.getInstancesWithTag(_helixManager, consumingServerTag);
     if (consumingTaggedInstances.isEmpty()) {
       throw new IllegalStateException("No instances found with tag " + consumingServerTag);
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -410,4 +410,22 @@ public class HelixHelper {
     }
     return enabledInstances;
   }
+
+  public static List<String> getInstancesWithTag(HelixAdmin helixAdmin, String helixClusterName,
+      String instanceTag) {
+    List<String> instances = helixAdmin.getInstancesInCluster(helixClusterName);
+    List<String> instancesWithTag = new ArrayList<>();
+    for (String instance : instances) {
+      try {
+        InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(helixClusterName, instance);
+        if (instanceConfig.containsTag(instanceTag)) {
+          instancesWithTag.add(instance);
+        }
+      } catch (Exception e) {
+        LOGGER.error("Caught exception while fetching instance config for instance: {}", instance, e);
+      }
+    }
+    return instancesWithTag;
+  }
+
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -394,35 +394,41 @@ public class HelixHelper {
     updateIdealState(helixManager, tableNameWithType, updater, DEFAULT_RETRY_POLICY);
   }
 
-  public static List<String> getEnabledInstancesWithTag(HelixAdmin helixAdmin, String helixClusterName,
-      String instanceTag) {
-    List<String> instances = helixAdmin.getInstancesInCluster(helixClusterName);
-    List<String> enabledInstances = new ArrayList<>();
-    for (String instance : instances) {
-      try {
-        InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(helixClusterName, instance);
-        if (instanceConfig.containsTag(instanceTag) && instanceConfig.getInstanceEnabled()) {
-          enabledInstances.add(instance);
-        }
-      } catch (Exception e) {
-        LOGGER.error("Caught exception while fetching instance config for instance: {}", instance, e);
+  /**
+   * Helper method which fetches all instance configs and returns the instance names which contain the instance tag and are enabled
+   * @param helixManager
+   * @param instanceTag
+   * @return
+   */
+  public static List<String> getEnabledInstancesWithTag(final HelixManager helixManager, String instanceTag) {
+    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
+    List<InstanceConfig> instanceConfigs =
+        helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs());
+
+    List<String> enabledInstancesWithTag = new ArrayList<>();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      if (instanceConfig.getInstanceEnabled() && instanceConfig.containsTag(instanceTag)) {
+        enabledInstancesWithTag.add(instanceConfig.getInstanceName());
       }
     }
-    return enabledInstances;
+    return enabledInstancesWithTag;
   }
 
-  public static List<String> getInstancesWithTag(HelixAdmin helixAdmin, String helixClusterName,
-      String instanceTag) {
-    List<String> instances = helixAdmin.getInstancesInCluster(helixClusterName);
+  /**
+   * Helper method which fetches all instance configs and returns the instance names which contain the instance tag
+   * @param helixManager
+   * @param instanceTag
+   * @return
+   */
+  public static List<String> getInstancesWithTag(final HelixManager helixManager, String instanceTag) {
+    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
+    List<InstanceConfig> instanceConfigs =
+        helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs());
+
     List<String> instancesWithTag = new ArrayList<>();
-    for (String instance : instances) {
-      try {
-        InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(helixClusterName, instance);
-        if (instanceConfig.containsTag(instanceTag)) {
-          instancesWithTag.add(instance);
-        }
-      } catch (Exception e) {
-        LOGGER.error("Caught exception while fetching instance config for instance: {}", instance, e);
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      if (instanceConfig.containsTag(instanceTag)) {
+        instancesWithTag.add(instanceConfig.getInstanceName());
       }
     }
     return instancesWithTag;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -395,32 +395,32 @@ public class HelixHelper {
   }
 
   /**
-   * Helper method which fetches all instance configs and returns the instance names which contain the instance tag and are enabled
+   * Helper method which gets all instances which are enabled and contains the instanceTag
    * @param helixManager
    * @param instanceTag
    * @return
    */
   public static List<String> getEnabledInstancesWithTag(final HelixManager helixManager, String instanceTag) {
-    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
-    List<InstanceConfig> instanceConfigs =
-        helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs());
-
-    List<String> enabledInstancesWithTag = new ArrayList<>();
-    for (InstanceConfig instanceConfig : instanceConfigs) {
-      if (instanceConfig.getInstanceEnabled() && instanceConfig.containsTag(instanceTag)) {
-        enabledInstancesWithTag.add(instanceConfig.getInstanceName());
-      }
-    }
-    return enabledInstancesWithTag;
+    return getInstancesWithTag(helixManager, instanceTag, true);
   }
 
   /**
-   * Helper method which fetches all instance configs and returns the instance names which contain the instance tag
+   * Helper method which gets all instances which contain the instanceTag
    * @param helixManager
    * @param instanceTag
    * @return
    */
   public static List<String> getInstancesWithTag(final HelixManager helixManager, String instanceTag) {
+    return getInstancesWithTag(helixManager, instanceTag, false);
+  }
+
+  /**
+   * Helper method which fetches all instance configs and applies instanceTag and enabled filtering
+   * @param helixManager
+   * @param instanceTag
+   * @return
+   */
+  private static List<String> getInstancesWithTag(final HelixManager helixManager, String instanceTag, boolean isEnabled) {
     HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
     List<InstanceConfig> instanceConfigs =
         helixDataAccessor.getChildValues(helixDataAccessor.keyBuilder().instanceConfigs());
@@ -428,7 +428,9 @@ public class HelixHelper {
     List<String> instancesWithTag = new ArrayList<>();
     for (InstanceConfig instanceConfig : instanceConfigs) {
       if (instanceConfig.containsTag(instanceTag)) {
-        instancesWithTag.add(instanceConfig.getInstanceName());
+        if (!isEnabled || (isEnabled && instanceConfig.getInstanceEnabled())) {
+          instancesWithTag.add(instanceConfig.getInstanceName());
+        }
       }
     }
     return instancesWithTag;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -305,8 +305,7 @@ public class PinotHelixResourceManager {
         brokerTenantName = realtimeTableConfig.getTenantConfig().getBroker();
       }
     }
-    return HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName,
-        TagNameUtils.getBrokerTagForTenant(brokerTenantName));
+    return HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getBrokerTagForTenant(brokerTenantName));
   }
 
   /**
@@ -540,7 +539,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse updateBrokerTenant(Tenant tenant) {
     String brokerTenantTag = TagNameUtils.getBrokerTagForTenant(tenant.getTenantName());
     List<String> instancesInClusterWithTag =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantTag);
+        HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantTag);
     if (instancesInClusterWithTag.size() > tenant.getNumberOfInstances()) {
       return scaleDownBroker(tenant, brokerTenantTag, instancesInClusterWithTag);
     }
@@ -667,9 +666,9 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse updateServerTenant(Tenant serverTenant) {
     String realtimeServerTag = TagNameUtils.getRealtimeTagForTenant(serverTenant.getTenantName());
-    List<String> taggedRealtimeServers = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeServerTag);
+    List<String> taggedRealtimeServers = HelixHelper.getInstancesWithTag(_helixZkManager, realtimeServerTag);
     String offlineServerTag = TagNameUtils.getOfflineTagForTenant(serverTenant.getTenantName());
-    List<String> taggedOfflineServers = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineServerTag);
+    List<String> taggedOfflineServers = HelixHelper.getInstancesWithTag(_helixZkManager, offlineServerTag);
     Set<String> allServingServers = new HashSet<>();
     allServingServers.addAll(taggedOfflineServers);
     allServingServers.addAll(taggedRealtimeServers);
@@ -766,15 +765,15 @@ public class PinotHelixResourceManager {
   }
 
   public boolean isTenantExisted(String tenantName) {
-    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getBrokerTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
-    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getOfflineTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
-    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getRealtimeTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
@@ -783,7 +782,7 @@ public class PinotHelixResourceManager {
 
   public boolean isBrokerTenantDeletable(String tenantName) {
     String brokerTag = TagNameUtils.getBrokerTagForTenant(tenantName);
-    Set<String> taggedInstances = new HashSet<>(HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTag));
+    Set<String> taggedInstances = new HashSet<>(HelixHelper.getInstancesWithTag(_helixZkManager, brokerTag));
     String brokerName = CommonConstants.Helix.BROKER_RESOURCE_INSTANCE;
     IdealState brokerIdealState = _helixAdmin.getResourceIdealState(_helixClusterName, brokerName);
     for (String partition : brokerIdealState.getPartitionSet()) {
@@ -798,9 +797,9 @@ public class PinotHelixResourceManager {
 
   public boolean isServerTenantDeletable(String tenantName) {
     Set<String> taggedInstances = new HashSet<>(
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getOfflineTagForTenant(tenantName)));
     taggedInstances.addAll(
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getRealtimeTagForTenant(tenantName)));
     for (String resourceName : getAllResources()) {
       if (!TableNameBuilder.isTableResource(resourceName)) {
         continue;
@@ -926,7 +925,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse deleteOfflineServerTenantFor(String tenantName) {
     String offlineTenantTag = TagNameUtils.getOfflineTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineTenantTag);
+        HelixHelper.getInstancesWithTag(_helixZkManager, offlineTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
       _helixAdmin.removeInstanceTag(_helixClusterName, instanceName, offlineTenantTag);
       if (getTagsForInstance(instanceName).isEmpty()) {
@@ -939,7 +938,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse deleteRealtimeServerTenantFor(String tenantName) {
     String realtimeTenantTag = TagNameUtils.getRealtimeTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeTenantTag);
+        HelixHelper.getInstancesWithTag(_helixZkManager, realtimeTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
       _helixAdmin.removeInstanceTag(_helixClusterName, instanceName, realtimeTenantTag);
       if (getTagsForInstance(instanceName).isEmpty()) {
@@ -951,7 +950,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse deleteBrokerTenantFor(String tenantName) {
     String brokerTag = TagNameUtils.getBrokerTagForTenant(tenantName);
-    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTag);
+    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(_helixZkManager, brokerTag);
     for (String instance : instancesInClusterWithTag) {
       retagInstance(instance, brokerTag, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     }
@@ -961,16 +960,16 @@ public class PinotHelixResourceManager {
   public Set<String> getAllInstancesForServerTenant(String tenantName) {
     Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getOfflineTagForTenant(tenantName)));
     instancesSet.addAll(
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getRealtimeTagForTenant(tenantName)));
     return instancesSet;
   }
 
   public Set<String> getAllInstancesForBrokerTenant(String tenantName) {
     Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixZkManager, TagNameUtils.getBrokerTagForTenant(tenantName)));
     return instancesSet;
   }
 
@@ -1044,14 +1043,14 @@ public class PinotHelixResourceManager {
     // Check if tenant exists before creating the table
     TableType tableType = tableConfig.getTableType();
     String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tenantConfig.getBroker());
-    List<String> brokersForTenant = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantName);
+    List<String> brokersForTenant = HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantName);
     if (brokersForTenant.isEmpty()) {
       throw new InvalidTableConfigException(
           "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
     }
     String serverTenantName =
         TagNameUtils.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
-    if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, serverTenantName).isEmpty()) {
+    if (HelixHelper.getInstancesWithTag(_helixZkManager, serverTenantName).isEmpty()) {
       throw new InvalidTableConfigException(
           "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
     }
@@ -1063,7 +1062,7 @@ public class PinotHelixResourceManager {
           throw new InvalidTableConfigException(
               "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
         }
-        if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeConsumingTag).isEmpty()) {
+        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeConsumingTag).isEmpty()) {
           throw new InvalidTableConfigException(
               "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
                   + tableNameWithType);
@@ -1076,7 +1075,7 @@ public class PinotHelixResourceManager {
           throw new InvalidTableConfigException(
               "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
         }
-        if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeCompletedTag).isEmpty()) {
+        if (HelixHelper.getInstancesWithTag(_helixZkManager, realtimeCompletedTag).isEmpty()) {
           throw new InvalidTableConfigException(
               "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
                   + tableNameWithType);
@@ -1244,9 +1243,8 @@ public class PinotHelixResourceManager {
   private void createHelixEntriesForHighLevelConsumer(TableConfig config, String realtimeTableName,
       IdealState idealState) {
     if (idealState == null) {
-      idealState =
-          PinotTableIdealStateBuilder.buildInitialHighLevelRealtimeIdealStateFor(realtimeTableName, config, _helixAdmin,
-              _helixClusterName, _propertyStore);
+      idealState = PinotTableIdealStateBuilder.buildInitialHighLevelRealtimeIdealStateFor(realtimeTableName, config,
+          _helixZkManager, _propertyStore);
       LOGGER.info("Adding helix resource with empty HLC IdealState for {}", realtimeTableName);
       _helixAdmin.addResource(_helixClusterName, realtimeTableName, idealState);
     } else {
@@ -1644,8 +1642,8 @@ public class PinotHelixResourceManager {
     SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory.getSegmentAssignmentStrategy(
         offlineTableConfig.getValidationConfig().getSegmentAssignmentStrategy());
     List<String> assignedInstances =
-        segmentAssignmentStrategy.getAssignedInstances(_helixAdmin, _propertyStore, _helixClusterName, segmentMetadata,
-            numReplicas, serverTenant);
+        segmentAssignmentStrategy.getAssignedInstances(_helixZkManager, _helixAdmin, _propertyStore, _helixClusterName,
+            segmentMetadata, numReplicas, serverTenant);
 
     HelixHelper.addSegmentToIdealState(_helixZkManager, offlineTableName, segmentName, assignedInstances);
   }
@@ -1945,13 +1943,13 @@ public class PinotHelixResourceManager {
     if (TableType.OFFLINE.equals(tableType)) {
       OfflineTagConfig tagConfig = new OfflineTagConfig(tableConfig);
       serverInstances.addAll(
-          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getOfflineServerTag()));
+          HelixHelper.getInstancesWithTag(_helixZkManager, tagConfig.getOfflineServerTag()));
     } else if (TableType.REALTIME.equals(tableType)) {
       RealtimeTagConfig tagConfig = new RealtimeTagConfig(tableConfig);
       serverInstances.addAll(
-          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getConsumingServerTag()));
+          HelixHelper.getInstancesWithTag(_helixZkManager, tagConfig.getConsumingServerTag()));
       serverInstances.addAll(
-          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getCompletedServerTag()));
+          HelixHelper.getInstancesWithTag(_helixZkManager, tagConfig.getCompletedServerTag()));
     }
     return Lists.newArrayList(serverInstances);
   }
@@ -1959,7 +1957,7 @@ public class PinotHelixResourceManager {
   public List<String> getBrokerInstancesForTable(String tableName, TableType tableType) {
     TableConfig tableConfig = getTableConfig(tableName, tableType);
     String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
-    List<String> serverInstances = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantName);
+    List<String> serverInstances = HelixHelper.getInstancesWithTag(_helixZkManager, brokerTenantName);
     return serverInstances;
   }
 
@@ -2121,7 +2119,7 @@ public class PinotHelixResourceManager {
   public List<String> getOnlineUnTaggedBrokerInstanceList() {
 
     final List<String> instanceList =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
+        HelixHelper.getInstancesWithTag(_helixZkManager, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     final List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
     instanceList.retainAll(liveInstances);
     return instanceList;
@@ -2133,7 +2131,7 @@ public class PinotHelixResourceManager {
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
     final List<String> instanceList =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
+        HelixHelper.getInstancesWithTag(_helixZkManager, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
     final List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
     instanceList.retainAll(liveInstances);
     return instanceList;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -305,7 +305,7 @@ public class PinotHelixResourceManager {
         brokerTenantName = realtimeTableConfig.getTenantConfig().getBroker();
       }
     }
-    return _helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
+    return HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName,
         TagNameUtils.getBrokerTagForTenant(brokerTenantName));
   }
 
@@ -540,7 +540,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse updateBrokerTenant(Tenant tenant) {
     String brokerTenantTag = TagNameUtils.getBrokerTagForTenant(tenant.getTenantName());
     List<String> instancesInClusterWithTag =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantTag);
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantTag);
     if (instancesInClusterWithTag.size() > tenant.getNumberOfInstances()) {
       return scaleDownBroker(tenant, brokerTenantTag, instancesInClusterWithTag);
     }
@@ -667,9 +667,9 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse updateServerTenant(Tenant serverTenant) {
     String realtimeServerTag = TagNameUtils.getRealtimeTagForTenant(serverTenant.getTenantName());
-    List<String> taggedRealtimeServers = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeServerTag);
+    List<String> taggedRealtimeServers = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeServerTag);
     String offlineServerTag = TagNameUtils.getOfflineTagForTenant(serverTenant.getTenantName());
-    List<String> taggedOfflineServers = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineServerTag);
+    List<String> taggedOfflineServers = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineServerTag);
     Set<String> allServingServers = new HashSet<>();
     allServingServers.addAll(taggedOfflineServers);
     allServingServers.addAll(taggedRealtimeServers);
@@ -766,15 +766,15 @@ public class PinotHelixResourceManager {
   }
 
   public boolean isTenantExisted(String tenantName) {
-    if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
-    if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
-    if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName))
+    if (!HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName))
         .isEmpty()) {
       return true;
     }
@@ -783,7 +783,7 @@ public class PinotHelixResourceManager {
 
   public boolean isBrokerTenantDeletable(String tenantName) {
     String brokerTag = TagNameUtils.getBrokerTagForTenant(tenantName);
-    Set<String> taggedInstances = new HashSet<>(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTag));
+    Set<String> taggedInstances = new HashSet<>(HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTag));
     String brokerName = CommonConstants.Helix.BROKER_RESOURCE_INSTANCE;
     IdealState brokerIdealState = _helixAdmin.getResourceIdealState(_helixClusterName, brokerName);
     for (String partition : brokerIdealState.getPartitionSet()) {
@@ -798,9 +798,9 @@ public class PinotHelixResourceManager {
 
   public boolean isServerTenantDeletable(String tenantName) {
     Set<String> taggedInstances = new HashSet<>(
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
     taggedInstances.addAll(
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
     for (String resourceName : getAllResources()) {
       if (!TableNameBuilder.isTableResource(resourceName)) {
         continue;
@@ -926,7 +926,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse deleteOfflineServerTenantFor(String tenantName) {
     String offlineTenantTag = TagNameUtils.getOfflineTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineTenantTag);
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
       _helixAdmin.removeInstanceTag(_helixClusterName, instanceName, offlineTenantTag);
       if (getTagsForInstance(instanceName).isEmpty()) {
@@ -939,7 +939,7 @@ public class PinotHelixResourceManager {
   public PinotResourceManagerResponse deleteRealtimeServerTenantFor(String tenantName) {
     String realtimeTenantTag = TagNameUtils.getRealtimeTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeTenantTag);
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
       _helixAdmin.removeInstanceTag(_helixClusterName, instanceName, realtimeTenantTag);
       if (getTagsForInstance(instanceName).isEmpty()) {
@@ -951,7 +951,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse deleteBrokerTenantFor(String tenantName) {
     String brokerTag = TagNameUtils.getBrokerTagForTenant(tenantName);
-    List<String> instancesInClusterWithTag = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTag);
+    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTag);
     for (String instance : instancesInClusterWithTag) {
       retagInstance(instance, brokerTag, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     }
@@ -961,16 +961,16 @@ public class PinotHelixResourceManager {
   public Set<String> getAllInstancesForServerTenant(String tenantName) {
     Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getOfflineTagForTenant(tenantName)));
     instancesSet.addAll(
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getRealtimeTagForTenant(tenantName)));
     return instancesSet;
   }
 
   public Set<String> getAllInstancesForBrokerTenant(String tenantName) {
     Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName)));
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, TagNameUtils.getBrokerTagForTenant(tenantName)));
     return instancesSet;
   }
 
@@ -1044,14 +1044,14 @@ public class PinotHelixResourceManager {
     // Check if tenant exists before creating the table
     TableType tableType = tableConfig.getTableType();
     String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tenantConfig.getBroker());
-    List<String> brokersForTenant = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantName);
+    List<String> brokersForTenant = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantName);
     if (brokersForTenant.isEmpty()) {
       throw new InvalidTableConfigException(
           "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
     }
     String serverTenantName =
         TagNameUtils.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
-    if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, serverTenantName).isEmpty()) {
+    if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, serverTenantName).isEmpty()) {
       throw new InvalidTableConfigException(
           "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
     }
@@ -1063,7 +1063,7 @@ public class PinotHelixResourceManager {
           throw new InvalidTableConfigException(
               "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
         }
-        if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeConsumingTag).isEmpty()) {
+        if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeConsumingTag).isEmpty()) {
           throw new InvalidTableConfigException(
               "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
                   + tableNameWithType);
@@ -1076,7 +1076,7 @@ public class PinotHelixResourceManager {
           throw new InvalidTableConfigException(
               "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
         }
-        if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeCompletedTag).isEmpty()) {
+        if (HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, realtimeCompletedTag).isEmpty()) {
           throw new InvalidTableConfigException(
               "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
                   + tableNameWithType);
@@ -1945,13 +1945,13 @@ public class PinotHelixResourceManager {
     if (TableType.OFFLINE.equals(tableType)) {
       OfflineTagConfig tagConfig = new OfflineTagConfig(tableConfig);
       serverInstances.addAll(
-          _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getOfflineServerTag()));
+          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getOfflineServerTag()));
     } else if (TableType.REALTIME.equals(tableType)) {
       RealtimeTagConfig tagConfig = new RealtimeTagConfig(tableConfig);
       serverInstances.addAll(
-          _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getConsumingServerTag()));
+          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getConsumingServerTag()));
       serverInstances.addAll(
-          _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getCompletedServerTag()));
+          HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tagConfig.getCompletedServerTag()));
     }
     return Lists.newArrayList(serverInstances);
   }
@@ -1959,7 +1959,7 @@ public class PinotHelixResourceManager {
   public List<String> getBrokerInstancesForTable(String tableName, TableType tableType) {
     TableConfig tableConfig = getTableConfig(tableName, tableType);
     String brokerTenantName = TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
-    List<String> serverInstances = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantName);
+    List<String> serverInstances = HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, brokerTenantName);
     return serverInstances;
   }
 
@@ -2121,7 +2121,7 @@ public class PinotHelixResourceManager {
   public List<String> getOnlineUnTaggedBrokerInstanceList() {
 
     final List<String> instanceList =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     final List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
     instanceList.retainAll(liveInstances);
     return instanceList;
@@ -2133,7 +2133,7 @@ public class PinotHelixResourceManager {
    */
   public List<String> getOnlineUnTaggedServerInstanceList() {
     final List<String> instanceList =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
     final List<String> liveInstances = _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
     instanceList.retainAll(liveInstances);
     return instanceList;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
@@ -103,8 +104,8 @@ public class PinotTableIdealStateBuilder {
       TableConfig realtimeTableConfig, HelixAdmin helixAdmin, String helixClusterName,
       ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore) {
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(realtimeTableConfig);
-    final List<String> realtimeInstances = helixAdmin.getInstancesInClusterWithTag(helixClusterName,
-        realtimeTagConfig.getConsumingServerTag());
+    final List<String> realtimeInstances =
+        HelixHelper.getInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getConsumingServerTag());
     IdealState idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, 1);
     if (realtimeInstances.size() % Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()) != 0) {
       throw new RuntimeException(

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.builder.CustomModeISBuilder;
@@ -101,11 +102,10 @@ public class PinotTableIdealStateBuilder {
   }
 
   public static IdealState buildInitialHighLevelRealtimeIdealStateFor(String realtimeTableName,
-      TableConfig realtimeTableConfig, HelixAdmin helixAdmin, String helixClusterName,
-      ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore) {
+      TableConfig realtimeTableConfig, HelixManager helixManager, ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore) {
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(realtimeTableConfig);
     final List<String> realtimeInstances =
-        HelixHelper.getInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getConsumingServerTag());
+        HelixHelper.getInstancesWithTag(helixManager, realtimeTagConfig.getConsumingServerTag());
     IdealState idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, 1);
     if (realtimeInstances.size() % Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()) != 0) {
       throw new RuntimeException(

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -369,7 +369,7 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
       OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig);
       tag = offlineTagConfig.getOfflineServerTag();
     }
-    servingInstances.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tag));
+    servingInstances.addAll(HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tag));
     enabledServingInstances.addAll(HelixHelper.getEnabledInstancesWithTag(_helixAdmin, _helixClusterName, tag));
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -369,7 +369,7 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
       OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig);
       tag = offlineTagConfig.getOfflineServerTag();
     }
-    servingInstances.addAll(HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, tag));
-    enabledServingInstances.addAll(HelixHelper.getEnabledInstancesWithTag(_helixAdmin, _helixClusterName, tag));
+    servingInstances.addAll(HelixHelper.getInstancesWithTag(_helixManager, tag));
+    enabledServingInstances.addAll(HelixHelper.getEnabledInstancesWithTag(_helixManager, tag));
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -369,7 +369,18 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
       OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig);
       tag = offlineTagConfig.getOfflineServerTag();
     }
-    servingInstances.addAll(HelixHelper.getInstancesWithTag(_helixManager, tag));
-    enabledServingInstances.addAll(HelixHelper.getEnabledInstancesWithTag(_helixManager, tag));
+    servingInstances.addAll(getInstancesWithTag(tag));
+    enabledServingInstances.addAll(getEnabledInstancesWithTag(tag));
   }
+
+  @VisibleForTesting
+  protected List<String> getInstancesWithTag(String tag) {
+    return HelixHelper.getInstancesWithTag(_helixManager, tag);
+  }
+
+  @VisibleForTesting
+  protected List<String> getEnabledInstancesWithTag(String tag) {
+    return HelixHelper.getEnabledInstancesWithTag(_helixManager, tag);
+  }
+
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
@@ -162,7 +162,7 @@ public class ReplicaGroupRebalanceSegmentStrategy implements RebalanceSegmentStr
 
     OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig);
     List<String> serverInstances =
-        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineTagConfig.getOfflineServerTag());
+        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineTagConfig.getOfflineServerTag());
 
     // Perform the basic validation
     if (targetNumReplicaGroup <= 0 || targetNumInstancesPerPartition <= 0

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
@@ -162,7 +162,7 @@ public class ReplicaGroupRebalanceSegmentStrategy implements RebalanceSegmentStr
 
     OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig);
     List<String> serverInstances =
-        HelixHelper.getInstancesWithTag(_helixAdmin, _helixClusterName, offlineTagConfig.getOfflineServerTag());
+        HelixHelper.getInstancesWithTag(_helixManager, offlineTagConfig.getOfflineServerTag());
 
     // Perform the basic validation
     if (targetNumReplicaGroup <= 0 || targetNumInstancesPerPartition <= 0

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -142,13 +142,13 @@ public class RealtimeSegmentRelocator {
     final String helixClusterName = _pinotHelixResourceManager.getHelixClusterName();
 
     List<String> consumingServers =
-        helixAdmin.getInstancesInClusterWithTag(helixClusterName, realtimeTagConfig.getConsumingServerTag());
+        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getConsumingServerTag());
     if (consumingServers.isEmpty()) {
       throw new IllegalStateException(
           "Found no realtime consuming servers with tag " + realtimeTagConfig.getConsumingServerTag());
     }
     List<String> completedServers =
-        helixAdmin.getInstancesInClusterWithTag(helixClusterName, realtimeTagConfig.getCompletedServerTag());
+        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getCompletedServerTag());
     if (completedServers.isEmpty()) {
       throw new IllegalStateException(
           "Found no realtime completed servers with tag " + realtimeTagConfig.getCompletedServerTag());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/relocation/RealtimeSegmentRelocator.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.core.relocation;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.MinMaxPriorityQueue;
 import com.linkedin.pinot.common.config.RealtimeTagConfig;
@@ -35,7 +36,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.MapUtils;
-import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,17 +139,14 @@ public class RealtimeSegmentRelocator {
    */
   protected void relocateSegments(RealtimeTagConfig realtimeTagConfig, IdealState idealState) {
 
-    final HelixAdmin helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
-    final String helixClusterName = _pinotHelixResourceManager.getHelixClusterName();
+    final HelixManager helixManager = _pinotHelixResourceManager.getHelixZkManager();
 
-    List<String> consumingServers =
-        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getConsumingServerTag());
+    List<String> consumingServers = getInstancesWithTag(helixManager, realtimeTagConfig.getConsumingServerTag());
     if (consumingServers.isEmpty()) {
       throw new IllegalStateException(
           "Found no realtime consuming servers with tag " + realtimeTagConfig.getConsumingServerTag());
     }
-    List<String> completedServers =
-        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, realtimeTagConfig.getCompletedServerTag());
+    List<String> completedServers = getInstancesWithTag(helixManager, realtimeTagConfig.getCompletedServerTag());
     if (completedServers.isEmpty()) {
       throw new IllegalStateException(
           "Found no realtime completed servers with tag " + realtimeTagConfig.getCompletedServerTag());
@@ -180,6 +178,11 @@ public class RealtimeSegmentRelocator {
 
     // get new mapping for segments that need relocation
     createNewIdealState(realtimeTagConfig, idealState, consumingServers, completedServersQueue);
+  }
+
+  @VisibleForTesting
+  protected List<String> getInstancesWithTag(HelixManager helixManager, String instanceTag) {
+    return HelixHelper.getInstancesWithTag(helixManager, instanceTag);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -42,15 +43,15 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
   private static final Logger LOGGER = LoggerFactory.getLogger(BalanceNumSegmentAssignmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
+      int numReplicas, String tenantName) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
 
     List<String> selectedInstances = new ArrayList<>();
     Map<String, Integer> currentNumSegmentsPerInstanceMap = new HashMap<>();
-    List<String> allTaggedInstances =
-        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
+    List<String> allTaggedInstances = HelixHelper.getEnabledInstancesWithTag(helixManager, serverTenantName);
 
     for (String instance : allTaggedInstances) {
       currentNumSegmentsPerInstanceMap.put(instance, 0);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
@@ -37,11 +38,12 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(BucketizedSegmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
+      int numReplicas, String tenantName) {
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
 
-    List<String> allInstances = HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
+    List<String> allInstances = HelixHelper.getEnabledInstancesWithTag(helixManager, serverTenantName);
     List<String> selectedInstanceList = new ArrayList<>();
     if (segmentMetadata.getShardingKey() != null) {
       for (String instance : allInstances) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
@@ -39,13 +40,14 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(RandomAssignmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
+      int numReplicas, String tenantName) {
     String serverTenantName = TagNameUtils.getOfflineTagForTenant(tenantName);
     final Random random = new Random(System.currentTimeMillis());
 
     List<String> allInstanceList =
-        HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
+        HelixHelper.getEnabledInstancesWithTag(helixManager, serverTenantName);
     List<String> selectedInstanceList = new ArrayList<>();
     for (int i = 0; i < numReplicas; ++i) {
       final int idx = random.nextInt(allInstanceList.size());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
   private static final Random RANDOM = new Random();
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+  public List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
       String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.controller.helix.core.sharding;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import java.util.List;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
@@ -29,8 +30,9 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
  */
 public interface SegmentAssignmentStrategy {
 
-  List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName);
+  List<String> getAssignedInstances(HelixManager helixManager, HelixAdmin helixAdmin,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String helixClusterName, SegmentMetadata segmentMetadata,
+      int numReplicas, String tenantName);
 
 }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -161,9 +161,9 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     AutoRebalanceStrategy rebalanceStrategy = new AutoRebalanceStrategy(tableName, partitions, states);
 
     String serverTenant = TableNameBuilder.forType(tableType).tableNameWithType(tenantName);
-    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(helixAdmin, clusterName, serverTenant);
+    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(helixManager, serverTenant);
     List<String> enabledInstancesWithTag =
-        HelixHelper.getEnabledInstancesWithTag(helixAdmin, clusterName, serverTenant);
+        HelixHelper.getEnabledInstancesWithTag(helixManager, serverTenant);
     LOGGER.info("Current nodes: {}", currentHosts);
     LOGGER.info("New nodes: {}", instancesInClusterWithTag);
     LOGGER.info("Enabled nodes: {}", enabledInstancesWithTag);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -161,7 +161,7 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     AutoRebalanceStrategy rebalanceStrategy = new AutoRebalanceStrategy(tableName, partitions, states);
 
     String serverTenant = TableNameBuilder.forType(tableType).tableNameWithType(tenantName);
-    List<String> instancesInClusterWithTag = helixAdmin.getInstancesInClusterWithTag(clusterName, serverTenant);
+    List<String> instancesInClusterWithTag = HelixHelper.getInstancesWithTag(helixAdmin, clusterName, serverTenant);
     List<String> enabledInstancesWithTag =
         HelixHelper.getEnabledInstancesWithTag(helixAdmin, clusterName, serverTenant);
     LOGGER.info("Current nodes: {}", currentHosts);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/MoveReplicaGroup.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/MoveReplicaGroup.java
@@ -439,7 +439,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
     if (destHostsFile.isEmpty()) {
       String serverTenant = getServerTenantName(tableName) + "_OFFLINE";
       LOGGER.debug("Using server tenant: {}", serverTenant);
-      return HelixHelper.getEnabledInstancesWithTag(helix, zkPath, serverTenant);
+      return HelixHelper.getEnabledInstancesWithTag(zkChanger.getHelixManager(), serverTenant);
     } else {
       return readHostsFromFile(destHostsFile);
     }


### PR DESCRIPTION
Get all instance configs in one shot, and then filter out the instance configs based on tags/enabled. This will avoid exceptions we encounter if an instances is in an inconsistent state (for example present in INSTANCES but not in PARTICIPANTS). This is also more efficient than fetching all instances from INSTANCES first and then fetching each instance config