### PR TITLE
[TE] Make PqlUtils percentile function method public for use globally

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
@@ -395,7 +395,7 @@ public class PqlUtils {
    * @param aggFunction function enum to convert
    * @return a valid pinot function name
    */
-  private static String convertAggFunction(MetricAggFunction aggFunction) {
+  public static String convertAggFunction(MetricAggFunction aggFunction) {
     if (aggFunction.isPercentile()) {
       return aggFunction.name().replaceFirst(MetricAggFunction.PERCENTILE_PREFIX, PERCENTILE_TDIGEST_PREFIX);
     }


### PR DESCRIPTION
Allows the source of truth for converting percentile MetricAggFunction types to live in one place