### PR TITLE
Fix the bug for "select * ... order by" queries

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -65,7 +65,12 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     _selectionColumns.addAll(_selection.getSelectionColumns());
     if ((_selectionColumns.size() == 1) && ((_selectionColumns.toArray(new String[0]))[0].equals("*"))) {
       _selectionColumns.clear();
-      _selectionColumns.addAll(indexSegment.getColumnNames());
+      for (String columnName : indexSegment.getColumnNames()) {
+        // Filter out columns that start with $ (virtual columns)
+        if (!columnName.startsWith("$")) {
+          _selectionColumns.add(columnName);
+        }
+      }
     }
     if (_selection.getSelectionSortSequence() != null) {
       for (SelectionSort selectionSort : _selection.getSelectionSortSequence()) {


### PR DESCRIPTION
After we introduced virtual column, we did not filter out virtual columns
in SelectionOrderByOperator when computing selection columns. This led
ArrayIndexOutOfBoundsException for queries with select * ... order by.
This pr fixes the issue.