### PR TITLE
Add crypter is SegmentZKMetadata, so server can decrypt segments at download.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -53,6 +53,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private SegmentPartitionMetadata _partitionMetadata;
   private long _segmentUploadStartTime = -1;
   private Map<String, String> _customMap;
+  private String _crypterName;
 
   public SegmentZKMetadata() {
   }
@@ -60,6 +61,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   public SegmentZKMetadata(ZNRecord znRecord) {
     _segmentName = znRecord.getSimpleField(CommonConstants.Segment.SEGMENT_NAME);
     _tableName = znRecord.getSimpleField(CommonConstants.Segment.TABLE_NAME);
+    _crypterName = znRecord.getSimpleField(CommonConstants.Segment.CRYPTER_NAME);
     _segmentType = znRecord.getEnumField(CommonConstants.Segment.SEGMENT_TYPE, SegmentType.class, SegmentType.OFFLINE);
     _startTime = znRecord.getLongField(CommonConstants.Segment.START_TIME, -1);
     _endTime = znRecord.getLongField(CommonConstants.Segment.END_TIME, -1);
@@ -158,6 +160,14 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _segmentType = segmentType;
   }
 
+  public String getCrypterName() {
+    return _crypterName;
+  }
+
+  public void setCrypterName(String crypterName) {
+    _crypterName = crypterName;
+  }
+
   public long getTotalRawDocs() {
     return _totalRawDocs;
   }
@@ -217,18 +227,19 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
 
     SegmentZKMetadata metadata = (SegmentZKMetadata) segmentMetadata;
-    return isEqual(_segmentName, metadata._segmentName) && isEqual(_tableName, metadata._tableName) && isEqual(
-        _indexVersion, metadata._indexVersion) && isEqual(_timeUnit, metadata._timeUnit) && isEqual(_startTime,
-        metadata._startTime) && isEqual(_endTime, metadata._endTime) && isEqual(_segmentType, metadata._segmentType)
-        && isEqual(_totalRawDocs, metadata._totalRawDocs) && isEqual(_crc, metadata._crc) && isEqual(_creationTime,
-        metadata._creationTime) && isEqual(_partitionMetadata, metadata._partitionMetadata) && isEqual(
-        _segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap);
+    return isEqual(_segmentName, metadata._segmentName) && isEqual(_crypterName, metadata._crypterName) && isEqual(_tableName,
+        metadata._tableName) && isEqual(_indexVersion, metadata._indexVersion) && isEqual(_timeUnit, metadata._timeUnit)
+        && isEqual(_startTime, metadata._startTime) && isEqual(_endTime, metadata._endTime) && isEqual(_segmentType,
+        metadata._segmentType) && isEqual(_totalRawDocs, metadata._totalRawDocs) && isEqual(_crc, metadata._crc)
+        && isEqual(_creationTime, metadata._creationTime) && isEqual(_partitionMetadata, metadata._partitionMetadata)
+        && isEqual(_segmentUploadStartTime, metadata._segmentUploadStartTime) && isEqual(_customMap, metadata._customMap);
   }
 
   @Override
   public int hashCode() {
     int result = hashCodeOf(_segmentName);
     result = hashCodeOf(result, _tableName);
+    result = hashCodeOf(result, _crypterName);
     result = hashCodeOf(result, _segmentType);
     result = hashCodeOf(result, _startTime);
     result = hashCodeOf(result, _endTime);
@@ -248,6 +259,11 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     ZNRecord znRecord = new ZNRecord(_segmentName);
     znRecord.setSimpleField(CommonConstants.Segment.SEGMENT_NAME, _segmentName);
     znRecord.setSimpleField(CommonConstants.Segment.TABLE_NAME, _tableName);
+
+    if (_crypterName != null) {
+      znRecord.setSimpleField(CommonConstants.Segment.CRYPTER_NAME, _crypterName);
+    }
+
     znRecord.setEnumField(CommonConstants.Segment.SEGMENT_TYPE, _segmentType);
     if (_timeUnit == null) {
       znRecord.setSimpleField(CommonConstants.Segment.TIME_UNIT, NULL);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -342,6 +342,7 @@ public class CommonConstants {
     public static final String SEGMENT_NAME = "segment.name";
     public static final String TABLE_NAME = "segment.table.name";
     public static final String SEGMENT_TYPE = "segment.type";
+    public static final String CRYPTER_NAME = "segment.crypter";
     public static final String INDEX_VERSION = "segment.index.version";
     public static final String START_TIME = "segment.start.time";
     public static final String END_TIME = "segment.end.time";

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -33,6 +33,8 @@ import org.apache.helix.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
 
 public class SegmentZKMetadataTest {
 
@@ -48,14 +50,15 @@ public class SegmentZKMetadataTest {
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(inProgressZnRecord, inProgressSegmentMetadata.toZNRecord()));
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(doneZnRecord, doneSegmentMetadata.toZNRecord()));
 
-    Assert.assertTrue(inProgressSegmentMetadata.equals(new RealtimeSegmentZKMetadata(inProgressZnRecord)));
-    Assert.assertTrue(doneSegmentMetadata.equals(new RealtimeSegmentZKMetadata(doneZnRecord)));
+    assertEquals(inProgressSegmentMetadata, new RealtimeSegmentZKMetadata(inProgressZnRecord));
+    assertEquals(doneSegmentMetadata, new RealtimeSegmentZKMetadata(doneZnRecord));
 
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(inProgressZnRecord, new RealtimeSegmentZKMetadata(inProgressZnRecord).toZNRecord()));
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(doneZnRecord, new RealtimeSegmentZKMetadata(doneZnRecord).toZNRecord()));
 
-    Assert.assertTrue(inProgressSegmentMetadata.equals(new RealtimeSegmentZKMetadata(inProgressSegmentMetadata.toZNRecord())));
-    Assert.assertTrue(doneSegmentMetadata.equals(new RealtimeSegmentZKMetadata(doneSegmentMetadata.toZNRecord())));
+    assertEquals(inProgressSegmentMetadata,
+        new RealtimeSegmentZKMetadata(inProgressSegmentMetadata.toZNRecord()));
+    assertEquals(doneSegmentMetadata, new RealtimeSegmentZKMetadata(doneSegmentMetadata.toZNRecord()));
 
   }
 
@@ -64,9 +67,9 @@ public class SegmentZKMetadataTest {
     ZNRecord offlineZNRecord = getTestOfflineSegmentZNRecord();
     OfflineSegmentZKMetadata offlineSegmentMetadata = getTestOfflineSegmentMetadata();
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(offlineZNRecord, offlineSegmentMetadata.toZNRecord()));
-    Assert.assertTrue(offlineSegmentMetadata.equals(new OfflineSegmentZKMetadata(offlineZNRecord)));
+    assertEquals(offlineSegmentMetadata, new OfflineSegmentZKMetadata(offlineZNRecord));
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(offlineZNRecord, new OfflineSegmentZKMetadata(offlineZNRecord).toZNRecord()));
-    Assert.assertTrue(offlineSegmentMetadata.equals(new OfflineSegmentZKMetadata(offlineSegmentMetadata.toZNRecord())));
+    assertEquals(offlineSegmentMetadata, new OfflineSegmentZKMetadata(offlineSegmentMetadata.toZNRecord()));
   }
 
   @Test
@@ -79,7 +82,7 @@ public class SegmentZKMetadataTest {
             + "\"column1\":{\"functionName\":\"func1\",\"numPartitions\":7,\"partitionRanges\":\"[5 5],[7 7]\"},"
             + "\"column2\":{\"functionName\":\"func2\",\"numPartitions\":11,\"partitionRanges\":\"[11 11],[13 13]\"}}}";
 
-    Assert.assertEquals(SegmentPartitionMetadata.fromJsonString(expectedMetadataString).toJsonString(),
+    assertEquals(SegmentPartitionMetadata.fromJsonString(expectedMetadataString).toJsonString(),
         expectedMetadataString);
 
     Map<String, ColumnPartitionMetadata> columnPartitionMetadataMap = new HashMap<>();
@@ -91,8 +94,8 @@ public class SegmentZKMetadataTest {
     znRecord.setSimpleField(CommonConstants.Segment.PARTITION_METADATA, expectedPartitionMetadata.toJsonString());
     SegmentZKMetadata expectedSegmentMetadata = new OfflineSegmentZKMetadata(znRecord);
     SegmentPartitionMetadata actualPartitionMetadata = expectedSegmentMetadata.getPartitionMetadata();
-    Assert.assertEquals(actualPartitionMetadata, expectedPartitionMetadata);
-    Assert.assertEquals(expectedSegmentMetadata, new OfflineSegmentZKMetadata(expectedSegmentMetadata.toZNRecord()));
+    assertEquals(actualPartitionMetadata, expectedPartitionMetadata);
+    assertEquals(expectedSegmentMetadata, new OfflineSegmentZKMetadata(expectedSegmentMetadata.toZNRecord()));
 
     // Test partition metadata in RealtimeSegmentZkMetadata
     znRecord = getTestDoneRealtimeSegmentZNRecord();
@@ -100,8 +103,8 @@ public class SegmentZKMetadataTest {
     expectedSegmentMetadata = new RealtimeSegmentZKMetadata(znRecord);
 
     actualPartitionMetadata = expectedSegmentMetadata.getPartitionMetadata();
-    Assert.assertEquals(actualPartitionMetadata, expectedPartitionMetadata);
-    Assert.assertEquals(expectedSegmentMetadata, new RealtimeSegmentZKMetadata(expectedSegmentMetadata.toZNRecord()));
+    assertEquals(actualPartitionMetadata, expectedPartitionMetadata);
+    assertEquals(expectedSegmentMetadata, new RealtimeSegmentZKMetadata(expectedSegmentMetadata.toZNRecord()));
   }
 
   private ZNRecord getTestDoneRealtimeSegmentZNRecord() {
@@ -183,6 +186,7 @@ public class SegmentZKMetadataTest {
     ZNRecord record = new ZNRecord(segmentName);
     record.setSimpleField(CommonConstants.Segment.SEGMENT_NAME, segmentName);
     record.setSimpleField(CommonConstants.Segment.TABLE_NAME, "testTable");
+    record.setSimpleField(CommonConstants.Segment.CRYPTER_NAME, "testCrypter");
     record.setSimpleField(CommonConstants.Segment.INDEX_VERSION, "v1");
     record.setEnumField(CommonConstants.Segment.SEGMENT_TYPE, CommonConstants.Segment.SegmentType.OFFLINE);
     record.setLongField(CommonConstants.Segment.START_TIME, 1000);
@@ -201,6 +205,7 @@ public class SegmentZKMetadataTest {
     OfflineSegmentZKMetadata offlineSegmentMetadata = new OfflineSegmentZKMetadata();
     offlineSegmentMetadata.setSegmentName("testTable_O_3000_4000");
     offlineSegmentMetadata.setTableName("testTable");
+    offlineSegmentMetadata.setCrypterName("testCrypter");
     offlineSegmentMetadata.setSegmentType(SegmentType.OFFLINE);
     offlineSegmentMetadata.setIndexVersion("v1");
     offlineSegmentMetadata.setStartTime(1000);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadDownloadClientTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadDownloadClientTest.java
@@ -24,9 +24,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeader;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.testng.Assert;
@@ -40,6 +45,7 @@ public class FileUploadDownloadClientTest {
   private static final String TEST_HOST = "localhost";
   private static final int TEST_PORT = new Random().nextInt(10000) + 10000;
   private static final String TEST_URI = "http://testhost/segments/testSegment";
+  private static final String TEST_CRYPTER = "testCrypter";
   private static HttpServer TEST_SERVER;
 
   @BeforeClass
@@ -59,6 +65,8 @@ public class FileUploadDownloadClientTest {
       FileUploadType uploadType = FileUploadType.valueOf(uploadTypeStr);
 
       String downloadUri = null;
+      String crypter = null;
+
       if (uploadType == FileUploadType.JSON) {
         InputStream bodyStream = httpExchange.getRequestBody();
         try {
@@ -70,6 +78,8 @@ public class FileUploadDownloadClientTest {
         Assert.assertEquals(downloadUri, TEST_URI);
       } else if (uploadType == FileUploadType.URI) {
         downloadUri = requestHeaders.getFirst(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI);
+        crypter = requestHeaders.getFirst(FileUploadDownloadClient.CustomHeaders.CRYPTER);
+        Assert.assertEquals(crypter, TEST_CRYPTER);
       } else {
         Assert.fail();
       }
@@ -86,10 +96,17 @@ public class FileUploadDownloadClientTest {
   }
 
   @Test
-  public void testSendFileWithUri() throws Exception {
+  public void testSendFileWithUriAndCrypter() throws Exception {
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
+      Header crypterClassHeader =
+          new BasicHeader(FileUploadDownloadClient.CustomHeaders.CRYPTER, TEST_CRYPTER);
+
+      List<Header> headers = Collections.singletonList(crypterClassHeader);
+      List<NameValuePair> params = null;
+
       SimpleHttpResponse response = fileUploadDownloadClient.sendSegmentUri(
-          FileUploadDownloadClient.getUploadSegmentHttpURI(TEST_HOST, TEST_PORT), TEST_URI);
+          FileUploadDownloadClient.getUploadSegmentHttpURI(TEST_HOST, TEST_PORT), TEST_URI, headers, params,
+          FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
       Assert.assertEquals(response.getStatusCode(), HttpStatus.SC_OK);
       Assert.assertEquals(response.getResponse(), "OK");
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -321,7 +321,7 @@ public class PinotSegmentUploadRestletResource {
           .validateSegment(segmentMetadata, tempSegmentDir);
 
       // Zk operations
-      completeZkOperations(enableParallelPushProtection, headers, tempDecryptedFile, provider, segmentMetadata,
+      completeZkOperations(enableParallelPushProtection, headers, tempEncryptedFile, provider, segmentMetadata,
           segmentName, zkDownloadUri);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentMetadata.getName() + " of table: " + segmentMetadata.getTableName());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1452,6 +1452,10 @@ public class PinotHelixResourceManager {
   }
 
   public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl) {
+    addNewSegment(segmentMetadata, downloadUrl, null);
+  }
+
+  public void addNewSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull String downloadUrl, String crypter) {
     String segmentName = segmentMetadata.getName();
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
 
@@ -1460,6 +1464,7 @@ public class PinotHelixResourceManager {
     OfflineSegmentZKMetadata offlineSegmentZKMetadata = new OfflineSegmentZKMetadata();
     offlineSegmentZKMetadata = ZKMetadataUtils.updateSegmentMetadata(offlineSegmentZKMetadata, segmentMetadata);
     offlineSegmentZKMetadata.setDownloadUrl(downloadUrl);
+    offlineSegmentZKMetadata.setCrypterName(crypter);
     offlineSegmentZKMetadata.setPushTime(System.currentTimeMillis());
     if (!ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineSegmentZKMetadata)) {
       throw new RuntimeException(
@@ -1485,7 +1490,7 @@ public class PinotHelixResourceManager {
   }
 
   public void refreshSegment(@Nonnull SegmentMetadata segmentMetadata,
-      @Nonnull OfflineSegmentZKMetadata offlineSegmentZKMetadata, @Nonnull String downloadUrl) {
+      @Nonnull OfflineSegmentZKMetadata offlineSegmentZKMetadata) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
     String segmentName = segmentMetadata.getName();
 
@@ -1493,7 +1498,6 @@ public class PinotHelixResourceManager {
     // latest segment ZK metadata and compare with local segment metadata to decide whether to download the new
     // segment or load from local
     offlineSegmentZKMetadata = ZKMetadataUtils.updateSegmentMetadata(offlineSegmentZKMetadata, segmentMetadata);
-    offlineSegmentZKMetadata.setDownloadUrl(downloadUrl);
     offlineSegmentZKMetadata.setRefreshTime(System.currentTimeMillis());
     if (!ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineSegmentZKMetadata)) {
       throw new RuntimeException(

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -142,7 +142,7 @@ public class ValidationManagerTest {
 
     // Refresh the segment
     Mockito.when(segmentMetadata.getCrc()).thenReturn(Long.toString(System.nanoTime()));
-    _pinotHelixResourceManager.refreshSegment(segmentMetadata, offlineSegmentZKMetadata, "http://dummy/");
+    _pinotHelixResourceManager.refreshSegment(segmentMetadata, offlineSegmentZKMetadata);
 
     offlineSegmentZKMetadata =
         _pinotHelixResourceManager.getOfflineSegmentZKMetadata(TEST_TABLE_NAME, TEST_SEGMENT_NAME);


### PR DESCRIPTION
1. Added crypter to SegmentZKMetadata, so server can decrypt segments after downloading.
2. Enhanced SegmentFetcherAndLoader to also decrypt segments if specified.
3. Fixed bug where decrypted segment was being copied over to permanent directory.
4. Updated unit test for SegmentZKMetadata.