### PR TITLE
Add flags to ensure server loading all segments then start serving query traffic

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -260,6 +260,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
     public static final String CONFIG_OF_NETTY_PORT = "pinot.server.netty.port";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
+    public static final String CONFIG_OF_STARTER_ENABLE_SEGMENTS_LOADING_CHECK = "pinot.server.starter.enableSegmentsLoadingCheck";
+    public static final String CONFIG_OF_STARTER_TIMEOUT_IN_SECONDS = "pinot.server.starter.timeoutInSeconds";
+
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_ENABLE_DEFAULT_COLUMNS = "pinot.server.instance.enable.default.columns";
     public static final String CONFIG_OF_ENABLE_SHUTDOWN_DELAY = "pinot.server.instance.enable.shutdown.delay";
@@ -272,6 +275,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME = "pinot.server.instance.starter.checkIntervalTime";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
+    public static final boolean DEFAULT_STARTER_ENABLE_SEGMENTS_LOADING_CHECK = false;
+    public static final int DEFAULT_STARTER_TIMEOUT_IN_SECONDS = 600;
     public static final String DEFAULT_READ_MODE = "heap";
     public static final String DEFAULT_INSTANCE_BASE_DIR =
         System.getProperty("java.io.tmpdir") + File.separator + "PinotServer";

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/HealthCheckResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/HealthCheckResource.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.server.api.resources;
+
+import com.linkedin.pinot.common.utils.ServiceStatus;
+import com.linkedin.pinot.common.utils.ServiceStatus.Status;
+import com.linkedin.pinot.server.starter.ServerInstance;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * REST API to do health check through ServiceStatus.
+ */
+@Api(tags = "Health")
+@Path("/")
+public class HealthCheckResource {
+
+  @GET
+  @Path("/health")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Checking server health")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Server is healthy"), @ApiResponse(code = 503, message = "Server is not healthy")
+  })
+  public String checkHealth() {
+    Status status = ServiceStatus.getServiceStatus();
+    if (status == Status.GOOD) {
+      return "OK";
+    }
+    throw new WebApplicationException(String.format("Pinot server status is %s", status), Response.Status.SERVICE_UNAVAILABLE);
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -203,7 +203,6 @@ public class HelixServerStarter {
           int numSegmentsLoaded = getNumSegmentLoaded();
           int numSegmentsToLoad = getNumSegmentsToLoad();
           LOGGER.warn("Waiting for all segments to be loaded, current progress: [ {} / {} ], sleep {} seconds...", numSegmentsLoaded, numSegmentsToLoad, timeToSleep);
-          logSegmentsLoadingInfo();
           Thread.sleep(TimeUnit.SECONDS.toMillis(timeToSleep));
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
@@ -214,6 +213,7 @@ public class HelixServerStarter {
       }
       if (!allSegmentsLoaded) {
         LOGGER.info("Segments are not fully loaded within {} seconds...", serverStarterTimeout);
+        logSegmentsLoadingInfo();
       }
     }
   }
@@ -270,7 +270,7 @@ public class HelixServerStarter {
       int numSegmentsLoaded = instanceDataManager.getAllSegmentsMetadata(tableName).size();
       if (currentState != null && currentState.isValid()) {
         int numSegmentsToLoad = currentState.getPartitionStateMap().size();
-        LOGGER.info("Waiting for all segments to be loaded, table: {}, progress [ {} / {} ]", tableName, numSegmentsLoaded, numSegmentsToLoad);
+        LOGGER.info("Segments are not fully loaded during server bootstrap, current progress: table: {}, segments loading progress [ {} / {} ]", tableName, numSegmentsLoaded, numSegmentsToLoad);
       }
     }
   }


### PR DESCRIPTION
1. Adding flags to start serving queries after all segments are loaded.
2. Adding a health check endpoint for pinot server.