### PR TITLE
Have server wait until no incoming queries nor online table resources during shutdown

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -268,7 +268,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.server.storage.factory";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
-    public static final String CONFIG_OF_INSTANCE_WAIT_TIME = "pinot.server.instance.starter.waitTime";
+    public static final String CONFIG_OF_INSTANCE_MAX_SHUTDOWN_WAIT_TIME = "pinot.server.instance.starter.maxShutdownWaitTime";
+    public static final String CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME = "pinot.server.instance.starter.checkIntervalTime";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";
@@ -288,7 +289,8 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
-    public static final long DEFAULT_MAX_WAIT_TIME_MS = 60_000L;
+    public static final long DEFAULT_MAX_SHUTDOWN_WAIT_TIME_MS = 600_000L;
+    public static final long DEFAULT_CHECK_INTERVAL_TIME_MS = 10_000L;
   }
 
   public static class Controller {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -268,6 +268,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.server.storage.factory";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
+    public static final String CONFIG_OF_INSTANCE_WAIT_TIME = "pinot.server.instance.starter.waitTime";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";
@@ -287,6 +288,7 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
+    public static final long DEFAULT_MAX_WAIT_TIME_MS = 60_000L;
   }
 
   public static class Controller {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -290,7 +290,7 @@ public class CommonConstants {
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
     public static final long DEFAULT_MAX_SHUTDOWN_WAIT_TIME_MS = 600_000L;
-    public static final long DEFAULT_CHECK_INTERVAL_TIME_MS = 10_000L;
+    public static final long DEFAULT_CHECK_INTERVAL_TIME_MS = 60_000L;
   }
 
   public static class Controller {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Utility class to obtain the status of the Pinot instance running in this JVM.
  */
+@SuppressWarnings("unused")
 public class ServiceStatus {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceStatus.class);
 
@@ -88,19 +89,6 @@ public class ServiceStatus {
     }
   }
 
-  public static boolean checkServiceStatus(boolean shuttingDownStatus) {
-    if (ServiceStatus.serviceStatusCallback instanceof MultipleCallbackServiceStatusCallback) {
-      MultipleCallbackServiceStatusCallback multipleCallbackServiceStatusCallback =
-          (MultipleCallbackServiceStatusCallback)serviceStatusCallback;
-      return multipleCallbackServiceStatusCallback.checkServiceStatus(shuttingDownStatus);
-    } else if (ServiceStatus.serviceStatusCallback instanceof IdealStateAndExternalViewMatchServiceStatusCallback) {
-      IdealStateAndExternalViewMatchServiceStatusCallback idealStateAndExternalViewMatchServiceStatusCallback =
-          (IdealStateAndExternalViewMatchServiceStatusCallback)serviceStatusCallback;
-      return idealStateAndExternalViewMatchServiceStatusCallback.checkServiceStatus(shuttingDownStatus);
-    }
-    return true;
-  }
-
   public static class MultipleCallbackServiceStatusCallback implements ServiceStatusCallback {
     private final List<? extends ServiceStatusCallback> _statusCallbacks;
 
@@ -132,19 +120,6 @@ public class ServiceStatus {
             .append(";");
       }
       return statusDescription.toString();
-    }
-
-    public boolean checkServiceStatus(boolean shuttingDownStatus) {
-      boolean allGood = true;
-      for (ServiceStatusCallback statusCallback : _statusCallbacks) {
-
-        if (statusCallback instanceof IdealStateMatchServiceStatusCallback) {
-          IdealStateMatchServiceStatusCallback idealStateMatchServiceStatusCallback =
-              (IdealStateMatchServiceStatusCallback)statusCallback;
-          allGood &= idealStateMatchServiceStatusCallback.checkServiceStatus(shuttingDownStatus);
-        }
-      }
-      return allGood;
     }
   }
 
@@ -210,39 +185,6 @@ public class ServiceStatus {
     protected abstract T getState(String resourceName);
 
     protected abstract Map<String, String> getPartitionStateMap(T state);
-
-    public boolean checkServiceStatus(boolean isShutdown) {
-      if (_resourcesToMonitor.isEmpty()) {
-        return true;
-      }
-      Iterator<String> iterator = _resourcesToMonitor.iterator();
-      while (iterator.hasNext()) {
-        String resourceName = iterator.next();
-        IdealState idealState = getResourceIdealState(resourceName);
-
-        // If the resource has been removed or disabled, ignore it
-        if (idealState == null || !idealState.isEnabled()) {
-          continue;
-        }
-
-        String descriptionSuffix = String.format("resource=%s, numResourcesLeft=%d, numTotalResources=%d", resourceName,
-            _resourcesToMonitor.size(), _numTotalResourcesToMonitor);
-        T helixState = getState(resourceName);
-        if (helixState == null) {
-          _statusDescription = "Helix state does not exist: " + descriptionSuffix;
-          continue;
-        }
-
-        Map<String, String> partitionStateMap = getPartitionStateMap(helixState);
-        for (String partitionName : idealState.getPartitionSet()) {
-          String currentStateStatus = partitionStateMap.get(partitionName);
-          if (isShutdown == "ONLINE".equals(currentStateStatus)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }
 
     @Override
     public synchronized Status getServiceStatus() {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
@@ -150,10 +150,8 @@ public class MultiGetRequestTest {
       }
     }
 
-    Assert.assertEquals(2, success);
-    Assert.assertEquals(1, errors);
-    Assert.assertEquals(1, timeouts);
+    Assert.assertEquals(success, 2);
+    Assert.assertEquals(errors, 1);
+    Assert.assertEquals(timeouts, 1);
   }
-
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
@@ -30,6 +30,7 @@ import com.linkedin.pinot.core.query.scheduler.resources.QueryExecutorService;
 import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
 import java.util.List;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.LongAccumulator;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -51,8 +52,8 @@ public abstract class PriorityScheduler extends QueryScheduler {
   Thread scheduler;
 
   public PriorityScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics) {
-    super(queryExecutor, resourceManager, metrics);
+      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics, @Nonnull LongAccumulator latestQueryTime) {
+    super(queryExecutor, resourceManager, metrics, latestQueryTime);
     Preconditions.checkNotNull(queue);
     this.queryQueue = queue;
     this.numRunners = resourceManager.getNumQueryRunnerThreads();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.core.query.scheduler.SchedulerPriorityQueue;
 import com.linkedin.pinot.core.query.scheduler.TableBasedGroupMapper;
 import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
 import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import java.util.concurrent.atomic.LongAccumulator;
 import javax.annotation.Nonnull;
 import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
@@ -40,7 +41,7 @@ public class BoundedFCFSScheduler extends PriorityScheduler {
   private static Logger LOGGER = LoggerFactory.getLogger(BoundedFCFSScheduler.class);
 
   public static BoundedFCFSScheduler create(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics serverMetrics) {
+      @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
     final ResourceManager rm = new PolicyBasedResourceManager(config);
     final SchedulerGroupFactory groupFactory = new SchedulerGroupFactory() {
       @Override
@@ -49,12 +50,12 @@ public class BoundedFCFSScheduler extends PriorityScheduler {
       }
     };
     MultiLevelPriorityQueue queue = new MultiLevelPriorityQueue(config, rm, groupFactory, new TableBasedGroupMapper());
-    return new BoundedFCFSScheduler(rm , queryExecutor, queue, serverMetrics);
+    return new BoundedFCFSScheduler(rm , queryExecutor, queue, serverMetrics, latestQueryTime);
   }
 
   private BoundedFCFSScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics) {
-    super(resourceManager, queryExecutor, queue, metrics);
+      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics, @Nonnull LongAccumulator latestQueryTime) {
+    super(resourceManager, queryExecutor, queue, metrics, latestQueryTime);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.core.query.request.ServerQueryRequest;
 import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.linkedin.pinot.core.query.scheduler.resources.QueryExecutorService;
 import com.linkedin.pinot.core.query.scheduler.resources.UnboundedResourceManager;
+import java.util.concurrent.atomic.LongAccumulator;
 import javax.annotation.Nonnull;
 import org.apache.commons.configuration.Configuration;
 
@@ -37,8 +38,8 @@ import org.apache.commons.configuration.Configuration;
 public class FCFSQueryScheduler extends QueryScheduler {
 
   public FCFSQueryScheduler(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics serverMetrics) {
-    super(queryExecutor, new UnboundedResourceManager(config), serverMetrics);
+      @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
+    super(queryExecutor, new UnboundedResourceManager(config), serverMetrics, latestQueryTime);
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
@@ -24,6 +24,7 @@ import com.linkedin.pinot.core.query.scheduler.SchedulerGroupFactory;
 import com.linkedin.pinot.core.query.scheduler.TableBasedGroupMapper;
 import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
 import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import java.util.concurrent.atomic.LongAccumulator;
 import javax.annotation.Nonnull;
 import org.apache.commons.configuration.Configuration;
 
@@ -38,7 +39,7 @@ public class TokenPriorityScheduler extends PriorityScheduler {
   private static final int DEFAULT_TOKEN_LIFETIME_MS = 100;
 
   public static TokenPriorityScheduler create(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics metrics) {
+      @Nonnull ServerMetrics metrics, @Nonnull LongAccumulator latestQueryTime) {
     final ResourceManager rm = new PolicyBasedResourceManager(config);
     final SchedulerGroupFactory groupFactory =  new SchedulerGroupFactory() {
       @Override
@@ -54,12 +55,13 @@ public class TokenPriorityScheduler extends PriorityScheduler {
     };
 
     MultiLevelPriorityQueue queue = new MultiLevelPriorityQueue(config, rm, groupFactory, new TableBasedGroupMapper());
-    return new TokenPriorityScheduler(rm, queryExecutor, queue, metrics);
+    return new TokenPriorityScheduler(rm, queryExecutor, queue, metrics, latestQueryTime);
   }
 
   private TokenPriorityScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull MultiLevelPriorityQueue queue, @Nonnull ServerMetrics metrics) {
-    super(resourceManager, queryExecutor, queue, metrics);
+      @Nonnull MultiLevelPriorityQueue queue, @Nonnull ServerMetrics metrics,
+      @Nonnull LongAccumulator latestQueryTime) {
+    super(resourceManager, queryExecutor, queue, metrics, latestQueryTime);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -154,6 +154,8 @@ public abstract class ClusterTest extends ControllerTest {
             Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR + "-" + i);
         configuration.setProperty(Server.CONFIG_OF_ADMIN_API_PORT, baseAdminApiPort - i);
         configuration.setProperty(Server.CONFIG_OF_NETTY_PORT, baseNettyPort + i);
+        // Set check interval time to 5 seconds for cluster tests.
+        configuration.setProperty(Server.CONFIG_OF_INSTANCE_CHECK_INTERVAL_TIME, 5_000L);
         overrideServerConf(configuration);
         _serverStarters.add(new HelixServerStarter(_clusterName, zkStr, configuration));
       }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -29,6 +29,7 @@ import com.linkedin.pinot.transport.netty.NettyTCPServer;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.LongAccumulator;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -106,8 +107,8 @@ public class ServerBuilder {
     return queryExecutor;
   }
 
-  public QueryScheduler buildQueryScheduler(QueryExecutor queryExecutor) {
-    return QuerySchedulerFactory.create(_serverConf.getSchedulerConfig(), queryExecutor, _serverMetrics);
+  public QueryScheduler buildQueryScheduler(QueryExecutor queryExecutor, LongAccumulator latestQueryTime) {
+    return QuerySchedulerFactory.create(_serverConf.getSchedulerConfig(), queryExecutor, _serverMetrics,latestQueryTime);
   }
 
   public NettyServer buildNettyServer(NettyServer.RequestHandlerFactory requestHandlerFactory)

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -241,6 +241,13 @@ public class HelixServerStarter {
             shuttingDownStatus ? "shutting down" : "starting up", _instanceId, _maxWaitTimeMs);
         return;
       }
+
+      try {
+        // Sleep for 1 second.
+        Thread.sleep(1_000L);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
     }
     LOGGER.info("Service status change completed. Time to take: {}ms", (System.currentTimeMillis() - startTime));
   }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -232,15 +232,17 @@ public class HelixServerStarter {
   }
 
   private void waitForServiceStatusChange(boolean shuttingDownStatus) {
+    LOGGER.info("Waiting upto {}ms to have services complete their status change...", _maxWaitTimeMs);
     long startTime = System.currentTimeMillis();
 
     while (!ServiceStatus.checkServiceStatus(shuttingDownStatus)) {
       if (System.currentTimeMillis() - startTime > _maxWaitTimeMs) {
         LOGGER.error("Timeout waiting for all service status to change when {} Pinot server {}! Max waiting time: {}",
             shuttingDownStatus ? "shutting down" : "starting up", _instanceId, _maxWaitTimeMs);
-        break;
+        return;
       }
     }
+    LOGGER.info("Service status change completed. Time to take: {}ms", (System.currentTimeMillis() - startTime));
   }
 
   /**

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -221,14 +221,13 @@ public class HelixServerStarter {
 
   public void stop() {
     _adminApiApplication.stop();
+    setShuttingDownStatus(true);
     if (_helixServerConfig.getBoolean(CommonConstants.Server.CONFIG_OF_ENABLE_SHUTDOWN_DELAY, true)) {
       Uninterruptibles.sleepUninterruptibly(_maxQueryTimeMs, TimeUnit.MILLISECONDS);
     }
+    waitForServiceStatusChange(true /*shutDownStatus*/);
     _helixManager.disconnect();
     _serverInstance.shutDown();
-
-    waitForServiceStatusChange(true /*shutDownStatus*/);
-    setShuttingDownStatus(true);
   }
 
   private void waitForServiceStatusChange(boolean shuttingDownStatus) {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -250,7 +250,7 @@ public class HelixServerStarter {
       }
 
       try {
-        // Sleep for 10 second.
+        // Sleep for 60 second.
         Thread.sleep(CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS);
       } catch (InterruptedException e) {
         LOGGER.error("Interrupted when waiting for Pinot server not to receive any queries.", e);
@@ -292,7 +292,7 @@ public class HelixServerStarter {
       }
 
       try {
-        // Sleep for 10 second.
+        // Sleep for 60 second.
         Thread.sleep(CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS);
       } catch (InterruptedException e) {
         LOGGER.error("Interrupted when waiting for no online resources.", e);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -32,8 +32,11 @@ import com.linkedin.pinot.server.realtime.ControllerLeaderLocator;
 import com.linkedin.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import com.linkedin.pinot.server.starter.ServerInstance;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationUtils;
@@ -43,8 +46,10 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
@@ -74,6 +79,7 @@ public class HelixServerStarter {
   private final HelixAdmin _helixAdmin;
   private final ServerInstance _serverInstance;
   private final AdminApiApplication _adminApiApplication;
+  private final String _zkServers;
 
   public HelixServerStarter(String helixClusterName, String zkServer, Configuration helixServerConfig)
       throws Exception {
@@ -96,27 +102,28 @@ public class HelixServerStarter {
 
     _maxQueryTimeMs = _helixServerConfig.getLong(CommonConstants.Server.CONFIG_OF_QUERY_EXECUTOR_TIMEOUT,
         CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
-    _maxShutdownWaitTimeMs = _helixServerConfig.getLong(CommonConstants.Server.CONFIG_OF_INSTANCE_MAX_SHUTDOWN_WAIT_TIME,
-        CommonConstants.Server.DEFAULT_MAX_SHUTDOWN_WAIT_TIME_MS);
+    _maxShutdownWaitTimeMs =
+        _helixServerConfig.getLong(CommonConstants.Server.CONFIG_OF_INSTANCE_MAX_SHUTDOWN_WAIT_TIME,
+            CommonConstants.Server.DEFAULT_MAX_SHUTDOWN_WAIT_TIME_MS);
 
     LOGGER.info("Connecting Helix components");
     setupHelixSystemProperties(_helixServerConfig);
     // Replace all white-spaces from list of zkServers.
-    String zkServers = zkServer.replaceAll("\\s+", "");
+    _zkServers = zkServer.replaceAll("\\s+", "");
     _helixManager =
-        HelixManagerFactory.getZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkServers);
+        HelixManagerFactory.getZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkServers);
     final StateMachineEngine stateMachineEngine = _helixManager.getStateMachineEngine();
     _helixManager.connect();
     _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded(helixClusterName, _instanceId);
     ZkHelixPropertyStore<ZNRecord> propertyStore = _helixManager.getHelixPropertyStore();
 
-
     LOGGER.info("Starting server instance");
     Utils.logVersions();
     ServerConf serverInstanceConfig = DefaultHelixStarterServerConfig.getDefaultHelixServerConfig(_helixServerConfig);
     // Need to do this before we start receiving state transitions.
-    ServerSegmentCompletionProtocolHandler.init(_helixServerConfig.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
+    ServerSegmentCompletionProtocolHandler.init(
+        _helixServerConfig.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
     _serverInstance = new ServerInstance();
     _serverInstance.init(serverInstanceConfig, propertyStore);
     _serverInstance.start();
@@ -226,6 +233,7 @@ public class HelixServerStarter {
     waitUntilNoIncomingQueries();
     _helixManager.disconnect();
     _serverInstance.shutDown();
+    waitUntilNoOnlineResources();
   }
 
   private void waitUntilNoIncomingQueries() {
@@ -235,9 +243,9 @@ public class HelixServerStarter {
     long endTime = _maxShutdownWaitTimeMs + System.currentTimeMillis();
 
     while (currentTime < endTime) {
-      if (currentTime > _serverInstance.getLatestQueryTime() + CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS) {
-        LOGGER.info("No incoming query within {}ms, safely shutdown Pinot server. Total waiting Time: {}ms", CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS,
-            (currentTime - startTime));
+      if (noIncomingQueries(currentTime)) {
+        LOGGER.info("No incoming query within {}ms. Total waiting Time: {}ms",
+            CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS, (currentTime - startTime));
         return;
       }
 
@@ -251,8 +259,100 @@ public class HelixServerStarter {
       }
       currentTime = System.currentTimeMillis();
     }
-    LOGGER.error("Reach timeout since Pinot server {} keeps receiving queries! Forcing Pinot server to shutdown. Max waiting time: {}",
-        _instanceId, _maxShutdownWaitTimeMs);
+    LOGGER.error("Reach timeout waiting for no incoming queries! Max waiting time: {}ms", _maxShutdownWaitTimeMs);
+  }
+
+  /**
+   * Init a helix spectator to watch the external view change.
+   */
+  private void waitUntilNoOnlineResources() {
+    LOGGER.info("Waiting upto {}ms until no online resources...", _maxShutdownWaitTimeMs);
+
+    // Initialize a helix spectator.
+    HelixManager spectatorManager =
+        HelixManagerFactory.getZKHelixManager(_helixClusterName, _instanceId, InstanceType.SPECTATOR, _zkServers);
+    try {
+      spectatorManager.connect();
+    } catch (Exception e) {
+      LOGGER.error("Exception connecting spectator helix manager to cluster. Skip checking external view.", e);
+      return;
+    }
+
+    Set<String> resources = fetchLatestTableResources(spectatorManager.getClusterManagmentTool());
+
+    long startTime = System.currentTimeMillis();
+    long currentTime = startTime;
+    long endTime = _maxShutdownWaitTimeMs + System.currentTimeMillis();
+
+    while (currentTime < endTime) {
+      if (noOnlineResource(spectatorManager, resources)) {
+        LOGGER.info("No online resource within {}ms. Total waiting Time: {}ms",
+            CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS, (currentTime - startTime));
+        return;
+      }
+
+      try {
+        // Sleep for 10 second.
+        Thread.sleep(CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS);
+      } catch (InterruptedException e) {
+        LOGGER.error("Interrupted when waiting for no online resources.", e);
+        Thread.currentThread().interrupt();
+        return;
+      }
+      currentTime = System.currentTimeMillis();
+    }
+    LOGGER.error(
+        "Reach timeout waiting for no online resources! Forcing Pinot server to shutdown. Max waiting time: {}ms",
+        _maxShutdownWaitTimeMs);
+    spectatorManager.disconnect();
+  }
+
+  private boolean noIncomingQueries(long currentTime) {
+    return currentTime > _serverInstance.getLatestQueryTime() + CommonConstants.Server.DEFAULT_CHECK_INTERVAL_TIME_MS;
+  }
+
+  private boolean noOnlineResource(HelixManager spectatorManager, Set<String> resources) {
+    Iterator<String> iterator = resources.iterator();
+    while (iterator.hasNext()) {
+      String resourceName = iterator.next();
+      ExternalView externalView =
+          spectatorManager.getClusterManagmentTool().getResourceExternalView(_helixClusterName, resourceName);
+      if (externalView == null) {
+        iterator.remove();
+        continue;
+      }
+      for (String partition : externalView.getPartitionSet()) {
+        Map<String, String> instanceStateMap = externalView.getStateMap(partition);
+        if (instanceStateMap.containsKey(_instanceId)) {
+          if ("ONLINE".equals(instanceStateMap.get(_instanceId))) {
+            return false;
+          }
+        }
+      }
+      iterator.remove();
+    }
+    return true;
+  }
+
+  private Set<String> fetchLatestTableResources(HelixAdmin helixAdmin) {
+    Set<String> resourcesToMonitor = new HashSet<>();
+    for (String resourceName : helixAdmin.getResourcesInCluster(_helixClusterName)) {
+      // Only monitor table resources
+      if (!TableNameBuilder.isTableResource(resourceName)) {
+        continue;
+      }
+      // Only monitor enabled resources
+      IdealState idealState = helixAdmin.getResourceIdealState(_helixClusterName, resourceName);
+      if (idealState.isEnabled()) {
+        for (String partitionName : idealState.getPartitionSet()) {
+          if (idealState.getInstanceSet(partitionName).contains(_instanceId)) {
+            resourcesToMonitor.add(resourceName);
+            break;
+          }
+        }
+      }
+    }
+    return resourcesToMonitor;
   }
 
   /**


### PR DESCRIPTION
This PR adds code to have pinot server wait until it doesn't get any incoming queries within 60 seconds during shutdown. The max waiting time is 10 mins. Add `_latestQueryTime` in ServerInstance to track the latest Query time.
This PR also adds code to wait for the EV update as well. A spectator helix manager is needed to keep track of the EV change.
Unit test added.