### PR TITLE
Always build shaded jar for pinot-common

### DIFF
--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -34,7 +34,7 @@ if [ $noThirdEyeChange -eq 0 ]; then
   fi
 fi
 
-mvn clean install -B -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true -Pbuild-shaded-jar
+mvn clean install -B -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true
 if [ $? -ne 0 ]; then
   exit 1
 fi

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -311,7 +311,7 @@
     <profile>
       <id>build-shaded-jar</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Because pinot-hadoop have dependency on pinot-common shaded jar, always build shaded jar for pinot-common