### PR TITLE
[TE] detection - merger filling current & baseline value and child keeping merger

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
@@ -22,6 +22,7 @@ import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 
@@ -85,5 +86,26 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements A
 
   public void setChildren(Set<MergedAnomalyResultDTO> children) {
     this.children = children;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MergedAnomalyResultDTO)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    MergedAnomalyResultDTO that = (MergedAnomalyResultDTO) o;
+    return Objects.equals(feedback, that.feedback) && Objects.equals(function, that.function) && Objects.equals(
+        children, that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), feedback, function, children);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.detection.algorithm;
+
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.detection.DataProvider;
+import com.linkedin.thirdeye.detection.baseline.BaselineProvider;
+import com.linkedin.thirdeye.detection.baseline.BaselineProviderLoader;
+import com.linkedin.thirdeye.detection.baseline.RuleBaselineProvider;
+import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class BaselineFillingMergeWrapper extends MergeWrapper {
+  private static final Logger LOG = LoggerFactory.getLogger(MergeWrapper.class);
+
+  private static final String PROP_BASELINE_PROVIDER = "baselineValueProvider";
+  private static final String PROP_CURRENT_PROVIDER = "currentValueProvider";
+
+  protected BaselineProvider baselineValueProvider; // optionally configure a baseline value loader
+  protected BaselineProvider currentValueProvider;
+
+  public BaselineFillingMergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
+      throws Exception {
+    super(provider, config, startTime, endTime);
+    if (config.getProperties().containsKey(PROP_BASELINE_PROVIDER)) {
+      this.baselineValueProvider = BaselineProviderLoader.from(
+          MapUtils.getMap(config.getProperties(), PROP_BASELINE_PROVIDER));
+    }
+    if (config.getProperties().containsKey(PROP_CURRENT_PROVIDER)) {
+      this.currentValueProvider = BaselineProviderLoader.from(MapUtils.getMap(config.getProperties(), PROP_CURRENT_PROVIDER));
+    } else {
+      // default current provider
+      this.currentValueProvider = new RuleBaselineProvider();
+      this.currentValueProvider.init(Collections.<String, Object>singletonMap("offset", "current"));
+    }
+  }
+
+  @Override
+  protected List<MergedAnomalyResultDTO> merge(Collection<MergedAnomalyResultDTO> anomalies) {
+    return this.fillCurrentAndBaselineValue(super.merge(anomalies));
+  }
+
+  /**
+   * Fill in current and baseline value for the anomalies
+   * @param mergedAnomalies anomalies
+   * @return anomalies with current and baseline value filled
+   */
+  private List<MergedAnomalyResultDTO> fillCurrentAndBaselineValue(List<MergedAnomalyResultDTO> mergedAnomalies) {
+    Map<MetricSlice, MergedAnomalyResultDTO> metricSlicesToAnomaly = new HashMap<>();
+
+    for (MergedAnomalyResultDTO anomaly : mergedAnomalies) {
+      try {
+        String metricUrn = anomaly.getMetricUrn();
+        final MetricSlice slice = MetricSlice.from(MetricEntity.fromURN(metricUrn).getId(), anomaly.getStartTime(), anomaly.getEndTime(),
+            MetricEntity.fromURN(metricUrn).getFilters());
+        metricSlicesToAnomaly.put(slice, anomaly);
+      } catch (Exception e) {
+        // ignore
+        LOG.warn("cannot get metric slice for anomaly {}", anomaly);
+      }
+    }
+
+    Map<MetricSlice, Double> currentValues = this.currentValueProvider.computeBaselineAggregates(metricSlicesToAnomaly.keySet(), this.provider);
+    Map<MetricSlice, Double> baselineValues = new HashMap<>();
+    if (this.baselineValueProvider != null) {
+      baselineValues = this.baselineValueProvider.computeBaselineAggregates(metricSlicesToAnomaly.keySet(), this.provider);
+    }
+    for (Map.Entry<MetricSlice, MergedAnomalyResultDTO> entry : metricSlicesToAnomaly.entrySet()) {
+      MergedAnomalyResultDTO anomaly = entry.getValue();
+      MetricSlice slice = entry.getKey();
+      if (currentValues.containsKey(slice)){
+        anomaly.setAvgCurrentVal(currentValues.get(slice));
+      }
+      if (baselineValues.containsKey(slice)){
+        anomaly.setAvgBaselineVal(baselineValues.get(slice));
+      }
+    }
+    return mergedAnomalies;
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapper.java
@@ -40,8 +40,8 @@ public class BaselineFillingMergeWrapper extends MergeWrapper {
   private static final String PROP_BASELINE_PROVIDER = "baselineValueProvider";
   private static final String PROP_CURRENT_PROVIDER = "currentValueProvider";
 
-  protected BaselineProvider baselineValueProvider; // optionally configure a baseline value loader
-  protected BaselineProvider currentValueProvider;
+  private BaselineProvider baselineValueProvider; // optionally configure a baseline value loader
+  private BaselineProvider currentValueProvider;
 
   public BaselineFillingMergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
       throws Exception {
@@ -69,7 +69,7 @@ public class BaselineFillingMergeWrapper extends MergeWrapper {
    * @param mergedAnomalies anomalies
    * @return anomalies with current and baseline value filled
    */
-  private List<MergedAnomalyResultDTO> fillCurrentAndBaselineValue(List<MergedAnomalyResultDTO> mergedAnomalies) {
+  List<MergedAnomalyResultDTO> fillCurrentAndBaselineValue(List<MergedAnomalyResultDTO> mergedAnomalies) {
     Map<MetricSlice, MergedAnomalyResultDTO> metricSlicesToAnomaly = new HashMap<>();
 
     for (MergedAnomalyResultDTO anomaly : mergedAnomalies) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -96,7 +96,6 @@ public class ChildKeepingMergeWrapper extends MergeWrapper {
     newAnomaly.setFeedback(anomaly.getFeedback());
     newAnomaly.setAnomalyFeedbackId(anomaly.getAnomalyFeedbackId());
     newAnomaly.setScore(anomaly.getScore());
-    newAnomaly.setWeight(anomaly.getWeight());
     return newAnomaly;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.detection.algorithm;
+
+import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.detection.DataProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * The Child keeping Merge Wrapper. Merge anomalies and the anomalies before merging in the merged anomaly children set.
+ * Useful when merging anomalies from different source, e.g, different algorithms/rules, this merger allows tracing back to anomalies before merging.
+ * Will not merge anomalies if potential merged anomaly is beyond max duration.
+ */
+public class ChildKeepingMergeWrapper extends MergeWrapper {
+  public ChildKeepingMergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
+      throws Exception {
+    super(provider, config, startTime, endTime);
+  }
+
+  @Override
+  protected List<MergedAnomalyResultDTO> merge(Collection<MergedAnomalyResultDTO> anomalies) {
+    List<MergedAnomalyResultDTO> input = new ArrayList<>(anomalies);
+    Collections.sort(input, COMPARATOR);
+
+    List<MergedAnomalyResultDTO> output = new ArrayList<>();
+
+    Map<AnomalyKey, MergedAnomalyResultDTO> parents = new HashMap<>();
+    for (MergedAnomalyResultDTO anomaly : input) {
+      if (anomaly.isChild()) {
+        continue;
+      }
+
+      AnomalyKey key = AnomalyKey.from(anomaly);
+      MergedAnomalyResultDTO parent = parents.get(key);
+
+      if (parent == null || anomaly.getStartTime() - parent.getEndTime() > this.maxGap) {
+        // no parent, too far away
+        parents.put(key, anomaly);
+        output.add(anomaly);
+      } else if (anomaly.getEndTime() <= parent.getEndTime()
+          || anomaly.getEndTime() - parent.getStartTime() <= this.maxDuration) {
+        // fully merge into existing
+        if (parent.getChildren().isEmpty()){
+          parent.getChildren().add(copyAnomaly(parent));
+        }
+        parent.setEndTime(Math.max(parent.getEndTime(), anomaly.getEndTime()));
+
+        if (anomaly.getChildren().isEmpty()) {
+          parent.getChildren().add(anomaly);
+        } else {
+          parent.getChildren().addAll(anomaly.getChildren());
+        }
+      } else {
+        // partially overlap but potential merged anomaly is beyond max duration or merge not possible, do not merge
+        parents.put(key, anomaly);
+        output.add(anomaly);
+      }
+    }
+
+    return output;
+  }
+
+  MergedAnomalyResultDTO copyAnomaly(MergedAnomalyResultDTO anomaly) {
+    MergedAnomalyResultDTO newAnomaly = new MergedAnomalyResultDTO();
+    newAnomaly.setStartTime(anomaly.getStartTime());
+    newAnomaly.setEndTime(anomaly.getEndTime());
+    newAnomaly.setMetric(anomaly.getMetric());
+    newAnomaly.setMetricUrn(anomaly.getMetricUrn());
+    newAnomaly.setCollection(anomaly.getCollection());
+    newAnomaly.setDimensions(anomaly.getDimensions());
+    newAnomaly.setDetectionConfigId(anomaly.getDetectionConfigId());
+    newAnomaly.setAnomalyResultSource(anomaly.getAnomalyResultSource());
+    return newAnomaly;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -62,8 +62,7 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
           || anomaly.getEndTime() - parent.getStartTime() <= this.maxDuration) {
         // fully merge into existing
         if (parent.getChildren().isEmpty()){
-          MergedAnomalyResultDTO newAnomaly = new MergedAnomalyResultDTO();
-          parent.getChildren().add(copyAnomalyInfo(parent, newAnomaly));
+          parent.getChildren().add(copyAnomalyInfo(parent, new MergedAnomalyResultDTO()));
         }
         parent.setEndTime(Math.max(parent.getEndTime(), anomaly.getEndTime()));
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Useful when merging anomalies from different source, e.g, different algorithms/rules, this merger allows tracing back to anomalies before merging.
  * Will not merge anomalies if potential merged anomaly is beyond max duration.
  */
-public class ChildKeepingMergeWrapper extends MergeWrapper {
+public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
   public ChildKeepingMergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
       throws Exception {
     super(provider, config, startTime, endTime);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * The Child keeping Merge Wrapper. Merge anomalies and the anomalies before merging in the merged anomaly children set.
  * Useful when merging anomalies from different source, e.g, different algorithms/rules, this merger allows tracing back to anomalies before merging.
- * Will not merge anomalies if potential merged anomaly is beyond max duration.
+ * Will not merge anomalies if potential merged anomaly is beyond max duration. Will be able to fill in current and baseline value if configured.
  */
 public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
   public ChildKeepingMergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime)
@@ -78,10 +78,10 @@ public class ChildKeepingMergeWrapper extends BaselineFillingMergeWrapper {
       }
     }
 
-    return output;
+    return super.fillCurrentAndBaselineValue(output);
   }
 
-  MergedAnomalyResultDTO copyAnomalyInfo(MergedAnomalyResultDTO anomaly, MergedAnomalyResultDTO newAnomaly) {
+  private MergedAnomalyResultDTO copyAnomalyInfo(MergedAnomalyResultDTO anomaly, MergedAnomalyResultDTO newAnomaly) {
     newAnomaly.setStartTime(anomaly.getStartTime());
     newAnomaly.setEndTime(anomaly.getEndTime());
     newAnomaly.setMetric(anomaly.getMetric());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/ChildKeepingMergeWrapper.java
@@ -62,7 +62,8 @@ public class ChildKeepingMergeWrapper extends MergeWrapper {
           || anomaly.getEndTime() - parent.getStartTime() <= this.maxDuration) {
         // fully merge into existing
         if (parent.getChildren().isEmpty()){
-          parent.getChildren().add(copyAnomaly(parent));
+          MergedAnomalyResultDTO newAnomaly = new MergedAnomalyResultDTO();
+          parent.getChildren().add(copyAnomalyInfo(parent, newAnomaly));
         }
         parent.setEndTime(Math.max(parent.getEndTime(), anomaly.getEndTime()));
 
@@ -81,8 +82,7 @@ public class ChildKeepingMergeWrapper extends MergeWrapper {
     return output;
   }
 
-  MergedAnomalyResultDTO copyAnomaly(MergedAnomalyResultDTO anomaly) {
-    MergedAnomalyResultDTO newAnomaly = new MergedAnomalyResultDTO();
+  MergedAnomalyResultDTO copyAnomalyInfo(MergedAnomalyResultDTO anomaly, MergedAnomalyResultDTO newAnomaly) {
     newAnomaly.setStartTime(anomaly.getStartTime());
     newAnomaly.setEndTime(anomaly.getEndTime());
     newAnomaly.setMetric(anomaly.getMetric());
@@ -91,6 +91,12 @@ public class ChildKeepingMergeWrapper extends MergeWrapper {
     newAnomaly.setDimensions(anomaly.getDimensions());
     newAnomaly.setDetectionConfigId(anomaly.getDetectionConfigId());
     newAnomaly.setAnomalyResultSource(anomaly.getAnomalyResultSource());
+    newAnomaly.setAvgBaselineVal(anomaly.getAvgBaselineVal());
+    newAnomaly.setAvgCurrentVal(anomaly.getAvgCurrentVal());
+    newAnomaly.setFeedback(anomaly.getFeedback());
+    newAnomaly.setAnomalyFeedbackId(anomaly.getAnomalyFeedbackId());
+    newAnomaly.setScore(anomaly.getScore());
+    newAnomaly.setWeight(anomaly.getWeight());
     return newAnomaly;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/MergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/MergeWrapper.java
@@ -73,7 +73,7 @@ public class MergeWrapper extends DetectionPipeline {
    * @param startTime the start time
    * @param endTime the end time
    */
-  public MergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) throws Exception {
+  public MergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) {
     super(provider, config, startTime, endTime);
 
     this.maxGap = MapUtils.getLongValue(config.getProperties(), "maxGap", 0);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/MergeWrapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/MergeWrapper.java
@@ -18,6 +18,7 @@ package com.linkedin.thirdeye.detection.algorithm;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.detection.AnomalySlice;
@@ -25,6 +26,10 @@ import com.linkedin.thirdeye.detection.ConfigUtils;
 import com.linkedin.thirdeye.detection.DataProvider;
 import com.linkedin.thirdeye.detection.DetectionPipeline;
 import com.linkedin.thirdeye.detection.DetectionPipelineResult;
+import com.linkedin.thirdeye.detection.baseline.BaselineProvider;
+import com.linkedin.thirdeye.detection.baseline.BaselineProviderLoader;
+import com.linkedin.thirdeye.detection.baseline.RuleBaselineProvider;
+import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.collections.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -41,10 +48,14 @@ import org.apache.commons.collections.MapUtils;
  * Forward scan only, greedy clustering. Does not merge clusters that converge.
  */
 public class MergeWrapper extends DetectionPipeline {
+  private static final Logger LOG = LoggerFactory.getLogger(MergeWrapper.class);
+
   private static final String PROP_NESTED = "nested";
   private static final String PROP_CLASS_NAME = "className";
+  private static final String PROP_BASELINE_PROVIDER = "baselineValueProvider";
+  private static final String PROP_CURRENT_PROVIDER = "currentValueProvider";
 
-  private static final Comparator<MergedAnomalyResultDTO> COMPARATOR = new Comparator<MergedAnomalyResultDTO>() {
+  protected static final Comparator<MergedAnomalyResultDTO> COMPARATOR = new Comparator<MergedAnomalyResultDTO>() {
     @Override
     public int compare(MergedAnomalyResultDTO o1, MergedAnomalyResultDTO o2) {
       // earlier
@@ -61,9 +72,11 @@ public class MergeWrapper extends DetectionPipeline {
   };
 
   private final List<Map<String, Object>> nestedProperties;
-  private final long maxGap; // max time gap for merge
-  private final long maxDuration; // max overall duration of merged anomaly
+  protected final long maxGap; // max time gap for merge
+  protected final long maxDuration; // max overall duration of merged anomaly
   private final AnomalySlice slice;
+  protected BaselineProvider baselineValueProvider; // optionally configure a baseline value loader
+  protected BaselineProvider currentValueProvider;
 
   /**
    * Instantiates a new merge wrapper.
@@ -73,13 +86,24 @@ public class MergeWrapper extends DetectionPipeline {
    * @param startTime the start time
    * @param endTime the end time
    */
-  public MergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) {
+  public MergeWrapper(DataProvider provider, DetectionConfigDTO config, long startTime, long endTime) throws Exception {
     super(provider, config, startTime, endTime);
 
     this.maxGap = MapUtils.getLongValue(config.getProperties(), "maxGap", 0);
     this.maxDuration = MapUtils.getLongValue(config.getProperties(), "maxDuration", Long.MAX_VALUE);
     this.slice = new AnomalySlice().withStart(startTime).withEnd(endTime).withConfigId(config.getId());
     this.nestedProperties = ConfigUtils.getList(config.getProperties().get(PROP_NESTED));
+
+    if (config.getProperties().containsKey(PROP_BASELINE_PROVIDER)) {
+      this.baselineValueProvider = BaselineProviderLoader.from(MapUtils.getMap(config.getProperties(), PROP_BASELINE_PROVIDER));
+    }
+    if (config.getProperties().containsKey(PROP_CURRENT_PROVIDER)) {
+      this.currentValueProvider = BaselineProviderLoader.from(MapUtils.getMap(config.getProperties(), PROP_CURRENT_PROVIDER));
+    } else {
+      // default current provider
+      this.currentValueProvider = new RuleBaselineProvider();
+      this.currentValueProvider.init(Collections.<String, Object>singletonMap("offset", "current"));
+    }
   }
 
   @Override
@@ -122,8 +146,45 @@ public class MergeWrapper extends DetectionPipeline {
     all.addAll(retrieved);
     all.addAll(generated);
 
-    return new DetectionPipelineResult(this.merge(all))
-        .setDiagnostics(diagnostics);
+    return new DetectionPipelineResult(this.fillCurrentAndBaselineValue(this.merge(all))).setDiagnostics(diagnostics);
+  }
+
+  /**
+   * Fill in current and baseline value for the anomalies
+   * @param mergedAnomalies anomalies
+   * @return anomalies with current and baseline value filled
+   */
+  private List<MergedAnomalyResultDTO> fillCurrentAndBaselineValue(List<MergedAnomalyResultDTO> mergedAnomalies) {
+    Map<MetricSlice, MergedAnomalyResultDTO> metricSlicesToAnomaly = new HashMap<>();
+
+    for (MergedAnomalyResultDTO anomaly : mergedAnomalies) {
+      try {
+        String metricUrn = anomaly.getMetricUrn();
+        final MetricSlice slice = MetricSlice.from(MetricEntity.fromURN(metricUrn).getId(), anomaly.getStartTime(), anomaly.getEndTime(),
+            MetricEntity.fromURN(metricUrn).getFilters());
+        metricSlicesToAnomaly.put(slice, anomaly);
+      } catch (Exception e) {
+        // ignore
+        LOG.warn("cannot get metric slice for anomaly {}", anomaly);
+      }
+    }
+
+    Map<MetricSlice, Double> currentValues = this.currentValueProvider.computeBaselineAggregates(metricSlicesToAnomaly.keySet(), this.provider);
+    Map<MetricSlice, Double> baselineValues = new HashMap<>();
+    if (this.baselineValueProvider != null) {
+      baselineValues = this.baselineValueProvider.computeBaselineAggregates(metricSlicesToAnomaly.keySet(), this.provider);
+    }
+    for (Map.Entry<MetricSlice, MergedAnomalyResultDTO> entry : metricSlicesToAnomaly.entrySet()) {
+      MergedAnomalyResultDTO anomaly = entry.getValue();
+      MetricSlice slice = entry.getKey();
+      if (currentValues.containsKey(slice)){
+        anomaly.setAvgCurrentVal(currentValues.get(slice));
+      }
+      if (baselineValues.containsKey(slice)){
+        anomaly.setAvgBaselineVal(baselineValues.get(slice));
+      }
+    }
+    return mergedAnomalies;
   }
 
   protected List<MergedAnomalyResultDTO> merge(Collection<MergedAnomalyResultDTO> anomalies) {
@@ -188,7 +249,7 @@ public class MergeWrapper extends DetectionPipeline {
     return time;
   }
 
-  private static class AnomalyKey {
+  protected static class AnomalyKey {
     final String metric;
     final String collection;
     final DimensionMap dimensions;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/DetectionTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/DetectionTestUtils.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 
 public class DetectionTestUtils {
@@ -54,5 +55,25 @@ public class DetectionTestUtils {
 
   public static MergedAnomalyResultDTO makeAnomaly(Long configId, long start, long end, Map<String, String> dimensions) {
     return DetectionTestUtils.makeAnomaly(configId, start, end, null, null, dimensions);
+  }
+
+  public static MergedAnomalyResultDTO makeAnomaly(long start, long end, Set<MergedAnomalyResultDTO> children) {
+    MergedAnomalyResultDTO result = makeAnomaly(start, end);
+    result.setChildren(children);
+    return result;
+  }
+
+  public static MergedAnomalyResultDTO makeAnomaly(long start, long end, Map<String, String> dimensions, Set<MergedAnomalyResultDTO> children) {
+    MergedAnomalyResultDTO result = makeAnomaly(start, end, dimensions);
+    result.setChildren(children);
+    return result;
+  }
+
+  public static MergedAnomalyResultDTO makeAnomaly(long start, long end, String metricUrn, long currentValue, long baselineValue) {
+    MergedAnomalyResultDTO result = makeAnomaly(start, end);
+    result.setMetricUrn(metricUrn);
+    result.setAvgCurrentVal(currentValue);
+    result.setAvgBaselineVal(baselineValue);
+    return result;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/BaselineFillingMergeWrapperTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.detection.algorithm;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.datalayer.dto.DetectionConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.detection.DataProvider;
+import com.linkedin.thirdeye.detection.DetectionPipelineResult;
+import com.linkedin.thirdeye.detection.MockDataProvider;
+import com.linkedin.thirdeye.detection.MockPipeline;
+import com.linkedin.thirdeye.detection.MockPipelineLoader;
+import com.linkedin.thirdeye.detection.MockPipelineOutput;
+import com.linkedin.thirdeye.detection.baseline.MockBaselineProvider;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.linkedin.thirdeye.dataframe.util.DataFrameUtils.*;
+import static com.linkedin.thirdeye.detection.DetectionTestUtils.*;
+
+
+public class BaselineFillingMergeWrapperTest {
+  private static final String PROP_BASELINE_PROVIDER = "baselineValueProvider";
+  private static final String PROP_CURRENT_PROVIDER = "currentValueProvider";
+
+  private DetectionConfigDTO config;
+  private MergeWrapper wrapper;
+  private Map<String, Object> properties;
+  private List<Map<String, Object>> nestedProperties;
+  private List<MockPipeline> runs;
+
+  private static final Long PROP_ID_VALUE = 1000L;
+  private static final String PROP_NAME_VALUE = "myName";
+
+  private static final String PROP_CLASS_NAME = "className";
+  private static final String PROP_METRIC_URN = "metricUrn";
+  private static final String PROP_PROPERTIES = "properties";
+  private static final String PROP_NESTED = "nested";
+  private static final String PROP_MAX_GAP = "maxGap";
+
+  @BeforeMethod
+  public void beforeMethod() {
+    this.runs = new ArrayList<>();
+
+    this.properties = new HashMap<>();
+    this.properties.put(PROP_METRIC_URN, "thirdeye:metric:1");
+    this.properties.put(PROP_PROPERTIES, Collections.singletonMap("key", "value"));
+
+    Map<String, Object> nestedPropertiesOne = new HashMap<>();
+    nestedPropertiesOne.put(PROP_CLASS_NAME, "none");
+    nestedPropertiesOne.put(PROP_METRIC_URN, "thirdeye:metric:1");
+
+    Map<String, Object> nestedPropertiesTwo = new HashMap<>();
+    nestedPropertiesTwo.put(PROP_CLASS_NAME, "none");
+    nestedPropertiesTwo.put(PROP_METRIC_URN, "thirdeye:metric:2");
+
+    this.nestedProperties = new ArrayList<>();
+    this.nestedProperties.add(nestedPropertiesOne);
+    this.nestedProperties.add(nestedPropertiesTwo);
+
+    this.properties.put(PROP_NESTED, this.nestedProperties);
+
+    this.config = new DetectionConfigDTO();
+    this.config.setId(PROP_ID_VALUE);
+    this.config.setName(PROP_NAME_VALUE);
+    this.config.setProperties(this.properties);
+  }
+
+  @Test
+  public void testMergerCurrentAndBaselineLoading() throws Exception {
+    MergedAnomalyResultDTO anomaly = makeAnomaly(3000, 3600);
+    anomaly.setMetricUrn("thirdeye:metric:1");
+
+    Map<MetricSlice, DataFrame> aggregates = new HashMap<>();
+    aggregates.put(MetricSlice.from(1, 3000, 3600), DataFrame.builder(COL_TIME + ":LONG", COL_VALUE + ":DOUBLE").append(-1, 100).build());
+
+    DataProvider
+        provider = new MockDataProvider().setLoader(new MockPipelineLoader(this.runs, Collections.<MockPipelineOutput>emptyList())).setAnomalies(Collections.singletonList(anomaly)).setAggregates(aggregates);
+
+    this.config.getProperties().put(PROP_MAX_GAP, 100);
+    this.config.getProperties().put(PROP_CURRENT_PROVIDER, ImmutableMap.of("className", MockBaselineProvider.class.getName()));
+    this.config.getProperties().put(PROP_BASELINE_PROVIDER, ImmutableMap.of("className", MockBaselineProvider.class.getName()));
+
+    this.wrapper = new BaselineFillingMergeWrapper(provider, this.config, 2900, 3600);
+    DetectionPipelineResult output = this.wrapper.run();
+
+    List<MergedAnomalyResultDTO> anomalyResults = output.getAnomalies();
+    Assert.assertEquals(anomalyResults.size(), 1);
+    Assert.assertTrue(anomalyResults.contains(anomaly));
+    Assert.assertEquals(anomalyResults.get(0).getAvgBaselineVal(), 100.0);
+    Assert.assertEquals(anomalyResults.get(0).getAvgCurrentVal(), 100.0);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/baseline/MockBaselineProvider.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/baseline/MockBaselineProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.thirdeye.detection.baseline;
+
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.detection.DataProvider;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.linkedin.thirdeye.dataframe.util.DataFrameUtils.*;
+
+
+public class MockBaselineProvider implements BaselineProvider {
+  @Override
+  public void init(Map<String, Object> properties) {
+
+  }
+
+  @Override
+  public Map<MetricSlice, DataFrame> computeBaselineTimeSeries(Collection<MetricSlice> slices, DataProvider provider) {
+    return provider.fetchTimeseries(slices);
+  }
+
+  @Override
+  public Map<MetricSlice, Double> computeBaselineAggregates(Collection<MetricSlice> slices, DataProvider provider) {
+    Map<MetricSlice, DataFrame> data = provider.fetchAggregates(slices, Collections.EMPTY_LIST);
+    Map<MetricSlice, Double> result = new HashMap<>();
+    for (MetricSlice slice : slices) {
+      result.put(slice, data.get(slice).getDouble(COL_VALUE, 0));
+    }
+    return result;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
@@ -149,7 +149,6 @@ public class MergeDimensionThresholdIntegrationTest {
 
     MergedAnomalyResultDTO anomaly = DetectionTestUtils.makeAnomaly(null, start, end, METRIC, DATASET, dimensions);
     anomaly.setMetricUrn(metricUrn);
-    anomaly.setAvgCurrentVal(Double.NaN);
     return anomaly;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/integration/MergeDimensionThresholdIntegrationTest.java
@@ -149,6 +149,7 @@ public class MergeDimensionThresholdIntegrationTest {
 
     MergedAnomalyResultDTO anomaly = DetectionTestUtils.makeAnomaly(null, start, end, METRIC, DATASET, dimensions);
     anomaly.setMetricUrn(metricUrn);
+    anomaly.setAvgCurrentVal(Double.NaN);
     return anomaly;
   }
 }


### PR DESCRIPTION
- Add a merger which can configure the current & baseline value provider in the merger.
- Add a meger which can keep the child anomalies.
- Unit tests