### PR TITLE
[TE] frontend - setting limits on custom MTTD in alert tuning

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
@@ -216,9 +216,6 @@ export default Controller.extend({
         }
       ];
 
-      const x = isPerfDataReady ? buildAnomalyStats(metrics, statsCards, false) : [];
-      console.log('x : ', metrics);
-
       return isPerfDataReady ? buildAnomalyStats(metrics, statsCards, false) : [];
     }
   ),

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -65,7 +65,8 @@ const sensitivityDefaults = {
   defaultPercentChange: '0.3',
   mttdGranularityMinimums: {
     days: 24,
-    hours: 1
+    hours: 1,
+    minutes: 0.25
   }
 };
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -117,8 +117,6 @@ const processDefaultTuningParams = (alertData) => {
     mttdGranularityMinimums
   } = sensitivityDefaults;
 
-  console.log('alertData : ', alertData);
-
   // Cautiously derive tuning data from alert filter properties
   const featureString = 'window_size_in_hour';
   const alertFilterObj = alertData.alertFilter || null;
@@ -130,10 +128,6 @@ const processDefaultTuningParams = (alertData) => {
   const granularityBucket = alertData.bucketUnit ? alertData.bucketUnit.toLowerCase() : null;
   const isBucketDefaultPresent = granularityBucket && mttdGranularityMinimums.hasOwnProperty(granularityBucket);
   const defaultMttdChange = isBucketDefaultPresent ? mttdGranularityMinimums[granularityBucket] : defaultMttdVal;
-
-  console.log('bucket: ', granularityBucket, ' isBucketDefaultPresent: ', isBucketDefaultPresent, ' defaultMttdChange: ', defaultMttdChange);
-
-
 
   // Load saved pattern into pattern options
   const savedTunePattern = alertPattern ? alertPattern : 'UP,DOWN';
@@ -154,7 +148,6 @@ const processDefaultTuningParams = (alertData) => {
 
   // Load saved mttd
   const mttdValue = alertMttd ? alertMttd[0].split('=')[1] : 'N/A';
-  console.log('num mttd val : ', alertMttd);
   //const customMttdChange = !isNaN(mttdValue) ? Number(mttdValue).toFixed(2) : defaultMttdChange;
   const customMttdChange = !isNaN(mttdValue) ? Math.round(Number(mttdValue)) : defaultMttdChange;
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -148,7 +148,6 @@ const processDefaultTuningParams = (alertData) => {
 
   // Load saved mttd
   const mttdValue = alertMttd ? alertMttd[0].split('=')[1] : 'N/A';
-  //const customMttdChange = !isNaN(mttdValue) ? Number(mttdValue).toFixed(2) : defaultMttdChange;
   const customMttdChange = !isNaN(mttdValue) ? Math.round(Number(mttdValue)) : defaultMttdChange;
 
   // Load saved severity value

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -63,6 +63,7 @@ const sensitivityDefaults = {
   selectedSeverityOption: 'Percentage of Change',
   selectedTunePattern: 'Up and Down',
   defaultPercentChange: '0.3',
+  // Set granularity minimums in number of hours
   mttdGranularityMinimums: {
     days: 24,
     hours: 1,

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
@@ -90,7 +90,7 @@
           {{input
             type="text"
             id="custom-tune-mttd"
-            class="form-control te-input"
+            class=customMttdClasses
             value=customMttdChange
             focus-out="onChangeMttdValue"
             disabled=isCustomFieldsDisabled

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -242,6 +242,10 @@ body {
   &--number {
     width: 50px;
   }
+
+  &--error {
+    border-color: red;
+  }
 }
 
 .te-page {


### PR DESCRIPTION
MTTD custom settings in alert tuning flow that are less than the metric's granularity will result in no effective alert filtering. Therefore, we're setting a constraint on the minimum MTTD (Minimum Time to Detect) setting.

<img width="729" alt="screen shot 2018-10-05 at 7 55 58 pm" src="https://user-images.githubusercontent.com/11814420/46565746-bc278d80-c8d8-11e8-9856-7e5791233527.png">
