### PR TITLE
[TE] rootcause - unbreak rca coldstart page

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
@@ -41,6 +41,7 @@ export default Component.extend({
     function() {
       const { selectedUrns, entities } = this.getProperties('selectedUrns', 'entities');
       const result = filterPrefix(selectedUrns, 'thirdeye:metric:')
+        .filter(urn => urn in entities)
         .map((urn) => {
           const entity = entities[urn];
           const agg = entity ? { alias: entity.label, id: entity.urn.split(':')[2] } : {};
@@ -117,11 +118,10 @@ export default Component.extend({
      */
     onFocus(selectObj) {
       const {
-        onFocus,
         selectionEditable,
         searchInputSelector
       } = getProperties(this, 'onFocus', 'selectionEditable', 'searchInputSelector');
-      if (selectionEditable && selectObj.isActive) {
+      if (selectionEditable && selectObj.isActive && selectObj.selected) {
         const selectInputEl = document.querySelector(searchInputSelector);
         selectInputEl.value = selectObj.selected.alias;
       }

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -133,14 +133,12 @@
     <div class="card-container card-container--md card-container--space-around card-container--flush-top">
       <div class="card-container__row card-container__row--flex row">
         <div class="col-xs-10">
-          {{#if selectedUrns.size}}
-            {{rootcause-select-metric-dimension
-              selectedUrn=metricUrn
-              selectedUrns=selectedUrns
-              entities=entities
-              onSelection=(action "onPrimaryChange")
-            }}
-          {{/if}}
+          {{rootcause-select-metric-dimension
+            selectedUrn=metricUrn
+            selectedUrns=selectedUrns
+            entities=entities
+            onSelection=(action "onPrimaryChange")
+          }}
         </div>
         <div class="col-xs-2">
           {{#if context.urns.size}}


### PR DESCRIPTION
Recent changes in #3273 removed the metric selector from the blank RCA page. This PR re-creates the original state an fixes an error on empty selection introduced in #3277