### PR TITLE
Rename StreamMetadata to StreamConfig

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -28,7 +28,7 @@ import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -125,9 +125,9 @@ public class RoutingTableBuilderFactory {
         break;
       case PartitionAwareRealtime:
         // Check that the table uses LLC kafka consumer.
-        StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+        StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
 
-        if (streamMetadata.getConsumerTypes().size() == 1 && streamMetadata.getConsumerTypes().get(0)
+        if (streamConfig.getConsumerTypes().size() == 1 && streamConfig.getConsumerTypes().get(0)
             == CommonConstants.Helix.DataSource.Realtime.Kafka.ConsumerType.simple) {
           builder = new PartitionAwareRealtimeRoutingTableBuilder();
         } else {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -31,7 +31,7 @@ import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotResourceManagerResponse;
 import com.linkedin.pinot.controller.helix.core.rebalance.RebalanceUserConfigConstants;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -361,15 +361,15 @@ public class PinotTableRestletResource {
     boolean verifyReplication = true;
 
     if (config.getTableType() == CommonConstants.Helix.TableType.REALTIME) {
-      StreamMetadata streamMetadata;
+      StreamConfig streamConfig;
       try {
-        streamMetadata = new StreamMetadata(config.getIndexingConfig().getStreamConfigs());
+        streamConfig = new StreamConfig(config.getIndexingConfig().getStreamConfigs());
       } catch (Exception e) {
         String errorMsg = String.format("Invalid tableIndexConfig or streamConfig: %s", e.getMessage());
         throw new PinotHelixResourceManager.InvalidTableConfigException(errorMsg, e);
       }
-      verifyReplicasPerPartition = streamMetadata.hasSimpleKafkaConsumerType();
-      verifyReplication = streamMetadata.hasHighLevelKafkaConsumerType();
+      verifyReplicasPerPartition = streamConfig.hasSimpleKafkaConsumerType();
+      verifyReplication = streamConfig.hasHighLevelKafkaConsumerType();
     }
 
     if (verifyReplication) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -69,7 +69,7 @@ import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrate
 import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.controller.helix.starter.HelixConfig;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1205,11 +1205,11 @@ public class PinotHelixResourceManager {
 
   private void ensureRealtimeClusterIsSetUp(TableConfig config, String realtimeTableName,
       IndexingConfig indexingConfig) {
-    StreamMetadata streamMetadata = new StreamMetadata(indexingConfig.getStreamConfigs());
+    StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
     IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, realtimeTableName);
 
-    if (streamMetadata.hasHighLevelKafkaConsumerType()) {
-      if (streamMetadata.hasSimpleKafkaConsumerType()) {
+    if (streamConfig.hasHighLevelKafkaConsumerType()) {
+      if (streamConfig.hasSimpleKafkaConsumerType()) {
         // We may be adding on low-level, or creating both.
         if (idealState == null) {
           // Need to create both. Create high-level consumer first.
@@ -1227,7 +1227,7 @@ public class PinotHelixResourceManager {
     }
 
     // Either we have only low-level consumer, or both.
-    if (streamMetadata.hasSimpleKafkaConsumerType()) {
+    if (streamConfig.hasSimpleKafkaConsumerType()) {
       // Will either create idealstate entry, or update the IS entry with new segments
       // (unless there are low-level segments already present)
       final List<LLCRealtimeSegmentZKMetadata> llcSegmentMetadatas =

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -27,7 +27,7 @@ import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.core.realtime.stream.PartitionCountFetcher;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.List;
 import java.util.Map;
 import org.apache.helix.HelixAdmin;
@@ -139,14 +139,14 @@ public class PinotTableIdealStateBuilder {
     }
   }
 
-  public static int getPartitionCount(StreamMetadata streamMetadata) {
-    PartitionCountFetcher partitionCountFetcher = new PartitionCountFetcher(streamMetadata);
+  public static int getPartitionCount(StreamConfig streamConfig) {
+    PartitionCountFetcher partitionCountFetcher = new PartitionCountFetcher(streamConfig);
     try {
       RetryPolicies.noDelayRetryPolicy(3).attempt(partitionCountFetcher);
       return partitionCountFetcher.getPartitionCount();
     } catch (Exception e) {
       Exception fetcherException = partitionCountFetcher.getException();
-      LOGGER.error("Could not get partition count for {}", streamMetadata.getKafkaTopicName(), fetcherException);
+      LOGGER.error("Could not get partition count for {}", streamConfig.getKafkaTopicName(), fetcherException);
       throw new RuntimeException(fetcherException);
     }
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -23,7 +23,7 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.common.metrics.ControllerMeter;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
@@ -130,7 +130,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         continue;
       }
 
-      StreamMetadata metadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
       if (metadata.hasHighLevelKafkaConsumerType()) {
         idealStateMap.put(realtimeTableName, _pinotHelixResourceManager.getHelixAdmin()
             .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), realtimeTableName));
@@ -328,7 +328,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         String znRecordId = tableConfigZnRecord.getId();
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfig.fromZnRecord(tableConfigZnRecord);
-          StreamMetadata metadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+          StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
           if (metadata.hasHighLevelKafkaConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -28,7 +28,7 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix.StateModel.Realtime
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,8 +86,8 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
     PartitionAssignment newPartitionAssignment = new PartitionAssignment(tableNameWithType);
 
     if (tableConfig.getTableType().equals(CommonConstants.Helix.TableType.REALTIME)) {
-      StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
-      if (!streamMetadata.hasSimpleKafkaConsumerType()) {
+      StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+      if (!streamConfig.hasSimpleKafkaConsumerType()) {
         LOGGER.info("Table {} does not have LLC and will have no partition assignment", tableNameWithType);
         return newPartitionAssignment;
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.controller.validation;
 
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
@@ -29,7 +28,7 @@ import com.linkedin.pinot.common.utils.time.TimeUtils;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -157,8 +156,8 @@ public class ValidationManager {
     List<RealtimeSegmentZKMetadata> metadataList =
             ZKMetadataProvider.getRealtimeSegmentZKMetadataListForTable(propertystore, tableNameWithType);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
-    StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
-    if (streamMetadata.hasSimpleKafkaConsumerType() && !streamMetadata.hasHighLevelKafkaConsumerType()) {
+    StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    if (streamConfig.hasSimpleKafkaConsumerType() && !streamConfig.hasHighLevelKafkaConsumerType()) {
       countHLCSegments = false;
     }
     // Update the gauge to contain the total document count in the segments

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -40,7 +40,7 @@ import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
@@ -1410,7 +1410,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    protected long getKafkaPartitionOffset(StreamMetadata streamMetadata, final String offsetCriteria,
+    protected long getKafkaPartitionOffset(StreamConfig streamConfig, final String offsetCriteria,
         int partitionId) {
       if (offsetCriteria.equals(KAFKA_LARGEST_OFFSET)) {
         return _kafkaLargestOffsetToReturn;
@@ -1456,7 +1456,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    protected int getKafkaPartitionCount(StreamMetadata metadata) {
+    protected int getKafkaPartitionCount(StreamConfig metadata) {
       return _tableConfigStore.getNKafkaPartitions(_currentTable);
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -38,10 +38,10 @@ import com.linkedin.pinot.core.realtime.StreamProviderConfig;
 import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactoryProvider;
 import com.linkedin.pinot.core.realtime.stream.StreamLevelConsumer;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import java.io.File;
 import java.util.ArrayList;
@@ -76,7 +76,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final File resourceTmpDir;
   private final MutableSegmentImpl realtimeSegment;
   private final String tableStreamName;
-  private final StreamMetadata _streamMetadata;
+  private final StreamConfig _streamConfig;
 
   private final long start = System.currentTimeMillis();
   private long segmentEndTimeThreshold;
@@ -165,12 +165,12 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       resourceTmpDir.mkdirs();
     }
     // create and init stream level consumer
-    _streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamMetadata);
+    _streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(
-        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamMetadata.getKafkaTopicName());
+        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName());
     // TODO: define a contract for StreamLevelConsumer.init() or get rid of it completely
-    // A future refactoring work of unifying StreamMetadata and StreamProviderConfig into StreamConfigs should give some clarity into this
+    // A future refactoring work of unifying StreamConfig and StreamProviderConfig should give some clarity into this
     _streamLevelConsumer.init(kafkaStreamProviderConfig, tableName, serverMetrics);
     _streamLevelConsumer.start();
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -19,7 +19,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.core.realtime.stream.PermanentConsumerException;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -95,42 +95,42 @@ public class KafkaConnectionHandler {
 
   /**
    * Creates a kafka connection given the stream metadata
-   * @param streamMetadata
+   * @param streamConfig
    * @param simpleConsumerFactory
    */
-  public KafkaConnectionHandler(String clientId, StreamMetadata streamMetadata,
+  public KafkaConnectionHandler(String clientId, StreamConfig streamConfig,
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = streamMetadata.getKafkaTopicName();
-    _connectTimeoutMillis = streamMetadata.getKafkaConnectionTimeoutMillis();
+    _topic = streamConfig.getKafkaTopicName();
+    _connectTimeoutMillis = streamConfig.getKafkaConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = false;
     _partition = Integer.MIN_VALUE;
 
-    initializeBootstrapNodeList(streamMetadata.getBootstrapHosts());
+    initializeBootstrapNodeList(streamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
 
   /**
    * Creates a kafka connection given the stream metadata and partition
-   * @param streamMetadata
+   * @param streamConfig
    * @param partition
    * @param simpleConsumerFactory
    */
-  public KafkaConnectionHandler(String clientId, StreamMetadata streamMetadata, int partition,
+  public KafkaConnectionHandler(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = streamMetadata.getKafkaTopicName();
-    _connectTimeoutMillis = streamMetadata.getKafkaConnectionTimeoutMillis();
+    _topic = streamConfig.getKafkaTopicName();
+    _connectTimeoutMillis = streamConfig.getKafkaConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = true;
     _partition = partition;
 
-    initializeBootstrapNodeList(streamMetadata.getBootstrapHosts());
+    initializeBootstrapNodeList(streamConfig.getBootstrapHosts());
     setCurrentState(new ConnectingToBootstrapNode());
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -18,8 +18,8 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamMessageDecoder;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.core.realtime.StreamProviderConfig;
 import java.util.HashMap;
@@ -197,7 +197,7 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
       // For LL segments, instanceZkMetadata will be null
       this.groupId = instanceMetadata.getGroupId(tableConfig.getTableName());
     }
-    StreamMetadata kafkaMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    StreamConfig kafkaMetadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
     this.kafkaTopicName = kafkaMetadata.getKafkaTopicName();
     this.decodeKlass = kafkaMetadata.getDecoderClass();
     this.decoderProps = kafkaMetadata.getDecoderProperties();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
@@ -19,7 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.linkedin.pinot.core.realtime.stream.MessageBatch;
 import com.linkedin.pinot.core.realtime.stream.PartitionLevelConsumer;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.io.IOException;
 import kafka.api.FetchRequestBuilder;
 import kafka.javaapi.FetchResponse;
@@ -35,14 +35,14 @@ import org.slf4j.LoggerFactory;
 public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implements PartitionLevelConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaPartitionLevelConsumer.class);
 
-  public KafkaPartitionLevelConsumer(String clientId, StreamMetadata streamMetadata, int partition) {
-    super(clientId, streamMetadata, partition, new KafkaSimpleConsumerFactoryImpl());
+  public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
+    super(clientId, streamConfig, partition, new KafkaSimpleConsumerFactoryImpl());
   }
 
   @VisibleForTesting
-  public KafkaPartitionLevelConsumer(String clientId, StreamMetadata streamMetadata, int partition,
+  public KafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
-    super(clientId, streamMetadata, partition, kafkaSimpleConsumerFactory);
+    super(clientId, streamConfig, partition, kafkaSimpleConsumerFactory);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamMetadataProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamMetadataProvider.java
@@ -18,7 +18,7 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
 import java.io.IOException;
 import java.util.Collections;
@@ -44,31 +44,31 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
 
   /**
    * Create a partition specific metadata provider
-   * @param streamMetadata
+   * @param streamConfig
    * @param partition
    */
-  public KafkaStreamMetadataProvider(String clientId, StreamMetadata streamMetadata, int partition) {
-    super(clientId, streamMetadata, partition, new KafkaSimpleConsumerFactoryImpl());
+  public KafkaStreamMetadataProvider(String clientId, StreamConfig streamConfig, int partition) {
+    super(clientId, streamConfig, partition, new KafkaSimpleConsumerFactoryImpl());
   }
 
   /**
    * Create a stream specific metadata provider
-   * @param streamMetadata
+   * @param streamConfig
    */
-  public KafkaStreamMetadataProvider(String clientId, StreamMetadata streamMetadata) {
-    super(clientId, streamMetadata, new KafkaSimpleConsumerFactoryImpl());
+  public KafkaStreamMetadataProvider(String clientId, StreamConfig streamConfig) {
+    super(clientId, streamConfig, new KafkaSimpleConsumerFactoryImpl());
   }
 
   @VisibleForTesting
-  public KafkaStreamMetadataProvider(String clientId, StreamMetadata streamMetadata, int partition,
+  public KafkaStreamMetadataProvider(String clientId, StreamConfig streamConfig, int partition,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
-    super(clientId, streamMetadata, partition, kafkaSimpleConsumerFactory);
+    super(clientId, streamConfig, partition, kafkaSimpleConsumerFactory);
   }
 
   @VisibleForTesting
-  public KafkaStreamMetadataProvider(String clientId, StreamMetadata streamMetadata,
+  public KafkaStreamMetadataProvider(String clientId, StreamConfig streamConfig,
       KafkaSimpleConsumerFactory kafkaSimpleConsumerFactory) {
-    super(clientId, streamMetadata, kafkaSimpleConsumerFactory);
+    super(clientId, streamConfig, kafkaSimpleConsumerFactory);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -36,7 +36,7 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    */
   @Override
   public PartitionLevelConsumer createPartitionLevelConsumer(String clientId, int partition) {
-    return new KafkaPartitionLevelConsumer(clientId, _streamMetadata, partition);
+    return new KafkaPartitionLevelConsumer(clientId, _streamConfig, partition);
   }
 
   /**
@@ -57,7 +57,7 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    */
   @Override
   public StreamMetadataProvider createPartitionMetadataProvider(String clientId, int partition) {
-    return new KafkaStreamMetadataProvider(clientId, _streamMetadata, partition);
+    return new KafkaStreamMetadataProvider(clientId, _streamConfig, partition);
   }
 
   /**
@@ -67,6 +67,6 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    */
   @Override
   public StreamMetadataProvider createStreamMetadataProvider(String clientId) {
-    return new KafkaStreamMetadataProvider(clientId, _streamMetadata);
+    return new KafkaStreamMetadataProvider(clientId, _streamConfig);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
@@ -27,15 +27,15 @@ public class PartitionCountFetcher implements Callable<Boolean> {
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionCountFetcher.class);
 
   private int _partitionCount = -1;
-  private final StreamMetadata _streamMetadata;
+  private final StreamConfig _streamConfig;
   private StreamConsumerFactory _streamConsumerFactory;
   private Exception _exception;
   private final String _topicName;
 
-  public PartitionCountFetcher(StreamMetadata streamMetadata) {
-    _streamMetadata = streamMetadata;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamMetadata);
-    _topicName = streamMetadata.getKafkaTopicName();
+  public PartitionCountFetcher(StreamConfig streamConfig) {
+    _streamConfig = streamConfig;
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    _topicName = streamConfig.getKafkaTopicName();
   }
 
   public int getPartitionCount() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
@@ -35,14 +35,14 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
   private Exception _exception = null;
   private long _offset = -1;
   private StreamConsumerFactory _streamConsumerFactory;
-  StreamMetadata _streamMetadata;
+  StreamConfig _streamConfig;
 
-  public PartitionOffsetFetcher(final String offsetCriteria, int partitionId, StreamMetadata streamMetadata) {
+  public PartitionOffsetFetcher(final String offsetCriteria, int partitionId, StreamConfig streamConfig) {
     _offsetCriteria = offsetCriteria;
     _partitionId = partitionId;
-    _streamMetadata = streamMetadata;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamMetadata);
-    _topicName = streamMetadata.getKafkaTopicName();
+    _streamConfig = streamConfig;
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
+    _topicName = streamConfig.getKafkaTopicName();
   }
 
   public long getOffset() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
@@ -47,8 +47,8 @@ import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
  * - Decoder-specific properties
  * Add a derived class that is Kafka-specific that includes members like zk string and bootstrap hosts.
  */
-public class StreamMetadata {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StreamMetadata.class);
+public class StreamConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamConfig.class);
 
   private final String _kafkaTopicName;
   private final List<ConsumerType> _consumerTypes = new ArrayList<>(2);
@@ -65,7 +65,7 @@ public class StreamMetadata {
   private static final long DEFAULT_KAFKA_CONNECTION_TIMEOUT_MILLIS = 30000L;
   private static final int DEFAULT_KAFKA_FETCH_TIMEOUT_MILLIS = 5000;
 
-  public StreamMetadata(Map<String, String> streamConfigMap) {
+  public StreamConfig(Map<String, String> streamConfigMap) {
     _zkBrokerUrl =
         streamConfigMap.get(StringUtil.join(".", Helix.DataSource.STREAM_PREFIX,
             Helix.DataSource.Realtime.Kafka.HighLevelConsumer.ZK_CONNECTION_STRING));
@@ -234,7 +234,7 @@ public class StreamMetadata {
       return false;
     }
 
-    StreamMetadata that = (StreamMetadata) o;
+    StreamConfig that = (StreamConfig) o;
 
     return isEqual(_kafkaTopicName, that._kafkaTopicName) &&
         isEqual(_consumerTypes, that._consumerTypes) &&

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
@@ -22,14 +22,14 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderCo
  * Factory for a stream which provides a consumer and a metadata provider for the stream
  */
 public abstract class StreamConsumerFactory {
-  protected StreamMetadata _streamMetadata;
+  protected StreamConfig _streamConfig;
 
   /**
    * Initializes the stream consumer factory with the stream metadata for the table
-   * @param streamMetadata
+   * @param streamConfig
    */
-  void init(StreamMetadata streamMetadata) {
-    _streamMetadata = streamMetadata;
+  void init(StreamConfig streamConfig) {
+    _streamConfig = streamConfig;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactoryProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactoryProvider.java
@@ -24,18 +24,18 @@ import com.linkedin.pinot.common.Utils;
 public abstract class StreamConsumerFactoryProvider {
 
   /**
-   * Constructs the {@link StreamConsumerFactory} using the {@link StreamMetadata::getConsumerFactoryName()} property and initializes it
-   * @param streamMetadata
+   * Constructs the {@link StreamConsumerFactory} using the {@link StreamConfig ::getConsumerFactoryName()} property and initializes it
+   * @param streamConfig
    * @return
    */
-  public static StreamConsumerFactory create(StreamMetadata streamMetadata) {
+  public static StreamConsumerFactory create(StreamConfig streamConfig) {
     StreamConsumerFactory factory = null;
     try {
-      factory = (StreamConsumerFactory) Class.forName(streamMetadata.getConsumerFactoryName()).newInstance();
+      factory = (StreamConsumerFactory) Class.forName(streamConfig.getConsumerFactoryName()).newInstance();
     } catch (Exception e) {
       Utils.rethrowException(e);
     }
-    factory.init(streamMetadata);
+    factory.init(streamConfig);
     return factory;
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/kafka/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/kafka/KafkaPartitionLevelConsumerTest.java
@@ -19,7 +19,7 @@ import com.google.common.base.Preconditions;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaPartitionLevelConsumer;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactory;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamMetadataProvider;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -220,7 +220,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.topic.name", streamKafkaTopicName);
     streamConfigMap.put("stream.kafka.broker.list", streamKafkaBrokerList);
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
-    StreamMetadata streamMetadata = new StreamMetadata(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory = new MockKafkaSimpleConsumerFactory(
         new String[] { "abcd", "bcde" },
@@ -232,7 +232,7 @@ public class KafkaPartitionLevelConsumerTest {
     );
 
     KafkaStreamMetadataProvider streamMetadataProvider =
-        new KafkaStreamMetadataProvider(clientId, streamMetadata, mockKafkaSimpleConsumerFactory);
+        new KafkaStreamMetadataProvider(clientId, streamConfig, mockKafkaSimpleConsumerFactory);
     Assert.assertEquals(streamMetadataProvider.fetchPartitionCount(10000L), 2);
   }
 
@@ -249,7 +249,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.topic.name", streamKafkaTopicName);
     streamConfigMap.put("stream.kafka.broker.list", streamKafkaBrokerList);
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
-    StreamMetadata streamMetadata = new StreamMetadata(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory = new MockKafkaSimpleConsumerFactory(
         new String[] { "abcd", "bcde" },
@@ -262,7 +262,7 @@ public class KafkaPartitionLevelConsumerTest {
 
     int partition = 0;
     KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
-        new KafkaPartitionLevelConsumer(clientId, streamMetadata, partition, mockKafkaSimpleConsumerFactory);
+        new KafkaPartitionLevelConsumer(clientId, streamConfig, partition, mockKafkaSimpleConsumerFactory);
     kafkaSimpleStreamConsumer.fetchMessages(12345L, 23456L, 10000);
   }
 
@@ -279,7 +279,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.topic.name", streamKafkaTopicName);
     streamConfigMap.put("stream.kafka.broker.list", streamKafkaBrokerList);
     streamConfigMap.put("stream.kafka.consumer.type", streamKafkaConsumerType);
-    StreamMetadata streamMetadata = new StreamMetadata(streamConfigMap);
+    StreamConfig streamConfig = new StreamConfig(streamConfigMap);
 
     MockKafkaSimpleConsumerFactory mockKafkaSimpleConsumerFactory = new MockKafkaSimpleConsumerFactory(
         new String[] { "abcd", "bcde" },
@@ -291,7 +291,7 @@ public class KafkaPartitionLevelConsumerTest {
 
     int partition = 0;
     KafkaStreamMetadataProvider kafkaStreamMetadataProvider =
-        new KafkaStreamMetadataProvider(clientId, streamMetadata, partition, mockKafkaSimpleConsumerFactory);
+        new KafkaStreamMetadataProvider(clientId, streamConfig, partition, mockKafkaSimpleConsumerFactory);
     kafkaStreamMetadataProvider.fetchPartitionOffset("smallest", 10000);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/stream/MetadataEqualsHashCodeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/stream/MetadataEqualsHashCodeTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 public class MetadataEqualsHashCodeTest {
   @Test
   public void testEqualsAndHashCode() {
-    EqualsVerifier.forClass(StreamMetadata.class).suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS).
+    EqualsVerifier.forClass(StreamConfig.class).suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS).
         usingGetClass().verify();
   }
 }


### PR DESCRIPTION
StreamConfig object is the wrapper around the TableConfig.indexingConfig.streamConfig map. The next step will be to introduce stream specific stream configs eg. kafkaStreamConfig and also to unify StreamProviderConfig and StreamConfig. This renaming also ensures that we do not confuse StreamConfig with the StreamMetadataProviders