### PR TITLE
[TE] rootcause - fix unintended metric selection on tab change

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -190,7 +190,14 @@ export default Component.extend({
    * Keeps track of items that are selected in the table
    * @type {Array}
    */
-  preselectedItems: [], // FIXME: this is broken across all of RCA and works by accident only
+  preselectedItems: computed({
+    get () {
+      return [];
+    },
+    set () {
+      // ignore
+    }
+  }),
 
   actions: {
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-trend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-trend/component.js
@@ -340,7 +340,14 @@ export default Component.extend({
    * Keeps track of items that are selected in the table
    * @type {Array}
    */
-  preselectedItems: [], // FIXME: this is broken across all of RCA and works by accident only
+  preselectedItems: computed({
+    get () {
+      return [];
+    },
+    set () {
+      // ignore
+    }
+  }),
 
   /**
    * Helper to format time stamp specifically for trend table


### PR DESCRIPTION
This PR fixes the unintended toggling of selected metrics when changing tabs between "metrics" (or "trend") and other tabs