### PR TITLE
[TE] frontend - rootcause chart for daily metrics

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -239,10 +239,11 @@ export default Component.extend({
         return {};
       }
 
-      return filterPrefix(displayableUrns, 'frontend:metric:current:')
+      const charts = filterPrefix(displayableUrns, 'frontend:metric:current:')
         .map(urn => [toMetricLabel(toMetricUrn(urn), entities), urn])
-        .sort()
         .map(t => t[1]);
+
+      return charts;
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -239,11 +239,9 @@ export default Component.extend({
         return {};
       }
 
-      const charts = filterPrefix(displayableUrns, 'frontend:metric:current:')
+      return filterPrefix(displayableUrns, 'frontend:metric:current:')
         .map(urn => [toMetricLabel(toMetricUrn(urn), entities), urn])
         .map(t => t[1]);
-
-      return charts;
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -208,8 +208,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
   setupController(controller, model) {
     this._super(...arguments);
 
-    console.log('model : ', model);
-
     const {
       analysisRangeStart,
       analysisRangeEnd,

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
@@ -1,6 +1,5 @@
 .rootcause-chart {
   flex-grow: 1;
-  min-height: 400px;
 
   &__title {
     padding-left: 16px;


### PR DESCRIPTION
Changes to RCA graph:
- If metric is daily, back up the anomaly range inspector window by 1 day (current day usually will have no data)
- Dried up the duplicate analysis range prep code a bit in rootcause/route
- Removed white space under graph
- Gave more width to anomaly range selector for minute metrics
- Preserving order of user-added metrics (new graphs would occasionally appear at top of stack)

Before (daily metric)
<img width="1252" alt="screen shot 2018-10-09 at 3 05 47 pm" src="https://user-images.githubusercontent.com/11814420/46697969-8259ce00-cbdb-11e8-89fe-c98cb7f1eb47.png">

After (daily metric)
<img width="1195" alt="screen shot 2018-10-09 at 4 28 58 pm" src="https://user-images.githubusercontent.com/11814420/46699799-850af200-cbe0-11e8-8c4f-f9fb3f8fed1a.png">



In latest commit:
- removed anomalyRange adjustment logic (need a more wholistic approach)