### PR TITLE
[TE] rootcause - avoid setup mode sticking around after first load

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -863,7 +863,12 @@ export default Controller.extend({
         newSelectedUrns.add(toBaselineUrn(urn));
       });
 
-    if (_.isEqual(selectedUrns, newSelectedUrns)) { return; }
+    if (_.isEqual(selectedUrns, newSelectedUrns)) {
+      if (loadingFrameworks.size <= 0) {
+        this.set('setupMode', ROOTCAUSE_SETUP_MODE_NONE);
+      }
+      return;
+    }
 
     this.setProperties({
       selectedUrns: newSelectedUrns,


### PR DESCRIPTION
Avoids a condition where the RCA UI remains in setup mode after initial data has been loaded completely. This prevents metrics from popping up randomly in the time series selection when changing filters