### PR TITLE
Removing extra copy in default crypter during segment upload

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -36,7 +36,7 @@ import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
 import com.linkedin.pinot.controller.util.TableSizeReader;
 import com.linkedin.pinot.controller.validation.StorageQuotaChecker;
-import com.linkedin.pinot.core.crypt.DefaultPinotCrypter;
+import com.linkedin.pinot.core.crypt.NoOpPinotCrypter;
 import com.linkedin.pinot.core.crypt.PinotCrypter;
 import com.linkedin.pinot.core.crypt.PinotCrypterFactory;
 import com.linkedin.pinot.core.metadata.DefaultMetadataExtractor;
@@ -274,9 +274,11 @@ public class PinotSegmentUploadRestletResource {
       tempDecryptedFile = new File(provider.getFileUploadTmpDir(), tempFileName);
       tempSegmentDir = new File(provider.getTmpUntarredPath(), tempFileName);
 
-      // Set default crypter and encrypted file accordingly
+      // Set default crypter to the noop crypter when no crypter header is sent
+      // In this case, the noop crypter will not do any operations, so the encrypted and decrypted file will have the same
+      // file path.
       if (crypterClassHeader == null) {
-        crypterClassHeader = DefaultPinotCrypter.class.getName();
+        crypterClassHeader = NoOpPinotCrypter.class.getName();
         tempEncryptedFile = new File(provider.getFileUploadTmpDir(), tempFileName);
       } else {
         tempEncryptedFile = new File(provider.getFileUploadTmpDir(), tempFileName + ENCRYPTED_SUFFIX);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -314,13 +314,8 @@ public class PinotSegmentUploadRestletResource {
           .validateSegment(segmentMetadata, tempSegmentDir);
 
       // Zk operations
-      if (crypterClassHeader.equalsIgnoreCase(DefaultPinotCrypter.class.getName())) {
-        completeZkOperations(enableParallelPushProtection, headers, tempDecryptedFile, provider, segmentMetadata,
-            segmentName, zkDownloadUri);
-      } else {
-        completeZkOperations(enableParallelPushProtection, headers, tempEncryptedFile, provider, segmentMetadata,
-            segmentName, zkDownloadUri);
-      }
+      completeZkOperations(enableParallelPushProtection, headers, tempEncryptedFile, provider, segmentMetadata,
+          segmentName, zkDownloadUri);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentMetadata.getName() + " of table: " + segmentMetadata.getTableName());
     } catch (WebApplicationException e) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/DefaultPinotCrypter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/DefaultPinotCrypter.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * This class is the default implementation for the PinotCrypter. It simply copies the file to the given location.
+ * This class is the default implementation for the PinotCrypter. It is a noop crypter and will not do any operations.
  */
 public class DefaultPinotCrypter implements PinotCrypter {
   public static final Logger LOGGER = LoggerFactory.getLogger(DefaultPinotCrypter.class);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/DefaultPinotCrypter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/DefaultPinotCrypter.java
@@ -16,9 +16,7 @@
 package com.linkedin.pinot.core.crypt;
 
 import java.io.File;
-import java.io.IOException;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,21 +34,11 @@ public class DefaultPinotCrypter implements PinotCrypter {
 
   @Override
   public void encrypt(File decryptedFile, File encryptedFile) {
-    try {
-      FileUtils.copyFile(decryptedFile, encryptedFile);
-    } catch (IOException e) {
-      LOGGER.warn("Could not encrypt file");
-      FileUtils.deleteQuietly(encryptedFile);
-    }
+    return;
   }
 
   @Override
   public void decrypt(File encryptedFile, File decryptedFile) {
-    try {
-      FileUtils.copyFile(encryptedFile, decryptedFile);
-    } catch (IOException e) {
-      LOGGER.warn("Could not decrypt file");
-      FileUtils.deleteQuietly(decryptedFile);
-    }
+    return;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/NoOpPinotCrypter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/NoOpPinotCrypter.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
 /**
  * This class is the default implementation for the PinotCrypter. It is a noop crypter and will not do any operations.
  */
-public class DefaultPinotCrypter implements PinotCrypter {
-  public static final Logger LOGGER = LoggerFactory.getLogger(DefaultPinotCrypter.class);
+public class NoOpPinotCrypter implements PinotCrypter {
+  public static final Logger LOGGER = LoggerFactory.getLogger(NoOpPinotCrypter.class);
 
   @Override
   public void init(Configuration config) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/PinotCrypterFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/PinotCrypterFactory.java
@@ -36,8 +36,8 @@ public class PinotCrypterFactory {
       PinotCrypter pinotCrypter =  (PinotCrypter) Class.forName(crypterClassName).newInstance();
       return pinotCrypter;
     } catch (Exception e) {
-      LOGGER.warn("Unable to instantiate {}, creating default crypter {}", crypterClassName, DefaultPinotCrypter.class.getName(), e);
-      return new DefaultPinotCrypter();
+      LOGGER.warn("Unable to instantiate {}, creating default crypter {}", crypterClassName, NoOpPinotCrypter.class.getName(), e);
+      return new NoOpPinotCrypter();
     }
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/crypt/PinotCrypterFactoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/crypt/PinotCrypterFactoryTest.java
@@ -22,10 +22,10 @@ import org.testng.annotations.Test;
 public class PinotCrypterFactoryTest {
   @Test
   public void testDefaultPinotCrypter() {
-    Assert.assertTrue(PinotCrypterFactory.create(null) instanceof DefaultPinotCrypter);
+    Assert.assertTrue(PinotCrypterFactory.create(null) instanceof NoOpPinotCrypter);
   }
   @Test
   public void testConfiguredPinotCrypter() {
-    Assert.assertTrue(PinotCrypterFactory.create(DefaultPinotCrypter.class.getName()) instanceof DefaultPinotCrypter);
+    Assert.assertTrue(PinotCrypterFactory.create(NoOpPinotCrypter.class.getName()) instanceof NoOpPinotCrypter);
   }
 }


### PR DESCRIPTION
* Currently, we have two unnecessary copy calls during segment upload if we are using the default crypter. Essentially, "decrypting" the segment is not needed. Also, we do not need segment fetcher to do an extra copy; in the case of segment, we will simply start with the segment in its final location.