### PR TITLE
[ThirdEye][s] Fix StringUtils on empty property value

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFunctionDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFunctionDTO.java
@@ -17,14 +17,13 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFunctionBean;
-import java.io.ByteArrayInputStream;
+import com.linkedin.thirdeye.datalayer.util.StringUtils;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public class AnomalyFunctionDTO extends AnomalyFunctionBean {
    * true if this function should get total metric
    */
   public boolean isToCalculateGlobalMetric() {
-    return StringUtils.isNotEmpty(this.getGlobalMetric());
+    return org.apache.commons.lang3.StringUtils.isNotEmpty(this.getGlobalMetric());
   }
 
   /**
@@ -75,7 +74,6 @@ public class AnomalyFunctionDTO extends AnomalyFunctionBean {
       props = toProperties(getProperties());
     } catch (IOException e) {
       LOGGER.warn("Failed to parse property string ({}) for anomaly function: {}", getProperties(), getId());
-
     }
     return props;
   }
@@ -86,30 +84,10 @@ public class AnomalyFunctionDTO extends AnomalyFunctionBean {
    * @return a Properties object corresponds to the properties String of this anomaly function.
    */
   public static Properties toProperties(String properties) throws IOException {
-    Properties props = new Properties();
-
-    if (properties != null) {
-      String[] tokens = properties.split(";");
-      for (String token : tokens) {
-        try {
-          props.load(new ByteArrayInputStream(token.getBytes()));
-        } catch (IOException e) {
-        }
-      }
+    if (properties == null || properties.isEmpty()) {
+      return new Properties();
     }
-    return props;
-  }
-
-  /**
-   * Convert Properties to String following the format in TE
-   */
-  public String propertiesToString(Properties props){
-    StringBuilder stringBuilder = new StringBuilder();
-    for(Map.Entry entry : props.entrySet()){
-      stringBuilder.append(entry.getKey() + "=" + entry.getValue() + ";");
-    }
-    stringBuilder.deleteCharAt(stringBuilder.length() - 1);
-    return stringBuilder.toString();
+    return StringUtils.decodeCompactedProperties(properties);
   }
 
   /**
@@ -122,6 +100,6 @@ public class AnomalyFunctionDTO extends AnomalyFunctionBean {
     for (Map.Entry<String, String> entry : config.entrySet()) {
       properties.setProperty(entry.getKey(), entry.getValue());
     }
-    setProperties(propertiesToString(properties));
+    setProperties(StringUtils.encodeCompactedProperties(properties));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
@@ -18,6 +18,7 @@ package com.linkedin.thirdeye.datalayer.util;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,13 @@ public class StringUtils {
     Properties props = new Properties();
     for (String part : SEMICOLON_SPLITTER.split(propStr)) {
       List<String> kvPair = EQUALS_SPLITTER.splitToList(part);
-      props.setProperty(kvPair.get(0), kvPair.get(1));
+      if (kvPair.size() == 2) {
+        props.setProperty(kvPair.get(0).trim(), kvPair.get(1).trim());
+      } else if (kvPair.size() == 1) {
+        props.setProperty(kvPair.get(0).trim(), "");
+      } else {
+        throw new IllegalArgumentException(part + " is not a legal property string");
+      }
     }
     return props;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/util/StringUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/util/StringUtilsTest.java
@@ -1,0 +1,18 @@
+package com.linkedin.thirdeye.datalayer.util;
+
+import java.util.Properties;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StringUtilsTest {
+  @Test
+  public void testDecodeCompactedProperties(){
+    String propertiesString = "a=a;b=";
+    Properties props = StringUtils.decodeCompactedProperties(propertiesString);
+
+    Assert.assertEquals(2, props.size());
+    Assert.assertEquals("a", props.getProperty("a"));
+    Assert.assertEquals("", props.getProperty("b"));
+  }
+}


### PR DESCRIPTION
An exception is thrown when encountering empty property value. The pr is to fix the exception when input property has empty property value. For example, we may have a property string, a=a;b=. We expect to have {"a":"a","b":""}. Before the fix, the StringUtils will throw an exception because it gets nothing from b's value.