### PR TITLE
Changing segment fetcher init to use correct constant in controller

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -294,6 +294,7 @@ public class CommonConstants {
   }
 
   public static class Controller {
+    public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.controller.segment.fetcher";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.controller.storage.factory";
     public static final String HOST_HTTP_HEADER = "Pinot-Controller-Host";
     public static final String VERSION_HTTP_HEADER = "Pinot-Controller-Version";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -124,7 +124,7 @@ public class ControllerStarter {
 
     Configuration pinotFSConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     Configuration segmentFetcherFactoryConfig =
-        _config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
+        _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
 
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");


### PR DESCRIPTION
* Currently, we use the server constant to initialize Segment Fetcher, changing it to use the controller prefix inside ControllerStarter