### PR TITLE
[TE] Auto create alert groups with dataset owners as recipients during bulk onboard

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardUtility.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.auto.onboard;
 
+import com.google.common.base.CaseFormat;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
 import com.linkedin.thirdeye.datasource.DataSources;
 import com.linkedin.thirdeye.datasource.DataSourcesLoader;
@@ -17,6 +18,9 @@ import org.slf4j.LoggerFactory;
 
 public class AutoOnboardUtility {
   private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardUtility.class);
+
+  private static final String DEFAULT_ALERT_GROUP_PREFIX = "auto_onboard_dataset_";
+  private static final String DEFAULT_ALERT_GROUP_SUFFIX = "_alert";
 
   public static Map<String, List<AutoOnboard>> getDataSourceToAutoOnboardMap(URL dataSourcesUrl) {
     Map<String, List<AutoOnboard>> dataSourceToOnboardMap = new HashMap<>();
@@ -56,5 +60,10 @@ public class AutoOnboardUtility {
     }
 
     return dataSourceToOnboardMap;
+  }
+
+  public static String getAutoAlertGroupName(String dataset) {
+    return DEFAULT_ALERT_GROUP_PREFIX
+        + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, dataset) + DEFAULT_ALERT_GROUP_SUFFIX;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -169,7 +169,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new DetectionMigrationResource(
         DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getAnomalyFunctionDAO(),
         DAO_REGISTRY.getDetectionConfigManager(), anomalyFunctionFactory, alertFilterFactory));
-    env.jersey().register(new OnboardResource());
+    env.jersey().register(new OnboardResource(config));
     env.jersey().register(new EntityMappingResource());
     env.jersey().register(new OnboardDatasetMetricResource());
     env.jersey().register(new AutoOnboardResource(config));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.BaseAlertFilterAutoTune;
 import com.linkedin.thirdeye.api.Constants;
+import com.linkedin.thirdeye.dashboard.ThirdEyeDashboardConfiguration;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.ApplicationDTO;
@@ -367,7 +368,7 @@ public class DetectionJobResource {
       }
       // if isRemoveAnomaliesInWindow is true, remove existing anomalies within same replay window
       if (isRemoveAnomaliesInWindow) {
-        OnboardResource onboardResource = new OnboardResource();
+        OnboardResource onboardResource = new OnboardResource(new ThirdEyeDashboardConfiguration());
         onboardResource.deleteExistingAnomalies(functionId, startTime.getMillis(), endTime.getMillis());
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardResource.java
@@ -16,21 +16,28 @@
 
 package com.linkedin.thirdeye.dashboard.resources;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.CaseFormat;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardResource;
 import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
+import com.linkedin.thirdeye.auto.onboard.AutoOnboardUtility;
+import com.linkedin.thirdeye.dashboard.ThirdEyeDashboardConfiguration;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.detection.alert.DetectionAlertFilterRecipients;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
+import java.util.Collections;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.format.ISODateTimeFormat;
 import org.joda.time.DateTime;
+import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,13 +68,17 @@ public class OnboardResource {
   private MetricConfigManager metricConfigDAO;
   private AlertConfigManager emailConfigurationDAO;
   private TaskManager taskDAO;
+  private ThirdEyeDashboardConfiguration config;
 
   private static final String DEFAULT_FUNCTION_PREFIX = "thirdEyeAutoOnboard_";
   private static final String DEFAULT_ALERT_GROUP = "te_bulk_onboard_alerts";
+  private static final String DEFAULT_ALERT_GROUP_APPLICATION = "others";
+  private static final String DEFAULT_ALERT_GROUP_CRON = "0 0 12 ? * FRI *"; // Weekly - Friday Noon
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
   private static final Logger LOG = LoggerFactory.getLogger(OnboardResource.class);
 
-  public OnboardResource() {
+  public OnboardResource(ThirdEyeDashboardConfiguration config) {
+    this.config = config;
     this.anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
     this.mergedAnomalyResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.metricConfigDAO = DAO_REGISTRY.getMetricConfigDAO();
@@ -81,18 +92,40 @@ public class OnboardResource {
     this.mergedAnomalyResultDAO = mergedAnomalyResultManager;
   }
 
+  /**
+   * Endpoint for bulk onboarding of metrics
+   *
+   * This endpoint will create anomaly functions for all the metrics under the given tag
+   * and also has the ability to auto create alert config groups with dataset owners as
+   * recipients and send out email alerts.
+   *
+   * @param tag the tag belonging to the metrics which you would like to onboard
+   * @param functionPrefix (optional, DEFAULT_FUNCTION_PREFIX) a custom anomaly function prefix
+   * @param forceSyncAlertGroup (optional, true) force create alert groups based on dataset owners
+   * @param alertGroupName (optional) subscribe to a custom subscription alert group
+   * @param application (optional) the application to which this alert belongs to.
+   * @return HTTP response containing onboard statistics and warnings
+   */
   @POST
   @Path("/bulk-onboard")
   @ApiOperation("Endpoint used for bulk on-boarding alerts leveraging the create-job endpoint.")
   public Response bulkOnboardAlert(
       @NotNull @QueryParam("tag") String tag,
       @DefaultValue(DEFAULT_FUNCTION_PREFIX) @QueryParam("functionPrefix") String functionPrefix,
-      @DefaultValue(DEFAULT_ALERT_GROUP) @QueryParam("alertGroupName") String alertGroupName) throws Exception {
+      @DefaultValue("true") @QueryParam("forceSyncAlertGroup") boolean forceSyncAlertGroup,
+      @QueryParam("alertGroupName") String alertGroupName, @QueryParam("alertGroupCron") String alertGroupCron,
+      @QueryParam("application") String application)
+      throws Exception {
     Map<String, String> responseMessage = new HashMap<>();
-    AlertConfigDTO alertConfigDTO = emailConfigurationDAO.findWhereNameEquals(alertGroupName);
-    if (alertConfigDTO == null) {
-      responseMessage.put("message", "cannot find the alert group with name " + alertGroupName + ".");
-      return Response.status(Response.Status.BAD_REQUEST).entity(responseMessage).build();
+    Counter counter = new Counter();
+
+    AlertConfigDTO alertConfigDTO = null;
+    if (StringUtils.isNotEmpty(alertGroupName)) {
+      alertConfigDTO = emailConfigurationDAO.findWhereNameEquals(alertGroupName);
+      if (alertConfigDTO == null) {
+        responseMessage.put("message", "cannot find an alert group with name " + alertGroupName + ".");
+        return Response.status(Response.Status.BAD_REQUEST).entity(responseMessage).build();
+      }
     }
 
     List<MetricConfigDTO> metrics = fetchMetrics(tag);
@@ -101,13 +134,23 @@ public class OnboardResource {
     // For each metric create a new anomaly function & replay it
     List<Long> ids = new ArrayList<>();
     for (MetricConfigDTO metric : metrics) {
-      String functionName = functionPrefix + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, metric.getName())
-          + "_" + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, metric.getDataset());
+      String functionName = functionPrefix
+          + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, metric.getName()) + "_"
+          + CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, metric.getDataset());
+
+      if (alertConfigDTO == null) {
+        alertConfigDTO = getAlertConfigGroupForMetric(metric, forceSyncAlertGroup, application, alertGroupCron);
+        if (alertConfigDTO == null) {
+          responseMessage.put("message", "cannot find an alert group for metric " + metric.getName() + ".");
+          return Response.status(Response.Status.BAD_REQUEST).entity(responseMessage).build();
+        }
+      }
 
       AnomalyFunctionDTO anomalyFunctionDTO = anomalyFunctionDAO.findWhereNameEquals(functionName);
       if (anomalyFunctionDTO != null) {
         LOG.error("[bulk-onboard] Anomaly function {} already exists.", anomalyFunctionDTO.getFunctionName());
-        responseMessage.put("skipped " + metric.getName(), "Anomaly function already exists.");
+        responseMessage.put("metric " + metric.getName(), "skipped! Anomaly function "
+            + anomalyFunctionDTO.getFunctionName() + " already exists.");
         continue;
       }
 
@@ -120,16 +163,77 @@ public class OnboardResource {
         String propertiesJson = OBJECT_MAPPER.writeValueAsString(properties);
         DetectionOnboardResource detectionOnboardResource = new DetectionOnboardResource(taskDAO, anomalyFunctionDAO);
         detectionOnboardResource.createDetectionOnboardingJob(functionName, propertiesJson);
-        anomalyFunctionDTO = anomalyFunctionDAO.findWhereNameEquals(functionName);
-        ids.add(anomalyFunctionDTO.getId());
+        ids.add(anomalyFunctionDAO.findWhereNameEquals(functionName).getId());
+        responseMessage.put("metric " + metric.getName(), "success! onboarded and added to subscription alertGroup = "
+            + alertConfigDTO.getName());
+        counter.inc();
       } catch (Exception e) {
         LOG.error("[bulk-onboard] There was an exception onboarding metric {} function {}.", metric, functionName, e);
         responseMessage.put("skipped " + metric.getName(), "Exception onboarding metric : " + e);
       }
     }
 
-    responseMessage.put("message", "successfully on-boarded the following function ids: " + ids);
+    responseMessage.put("message", "successfully onboarded " + counter.getCount() + " metrics with function ids " + ids);
     return Response.ok(responseMessage).build();
+  }
+
+  private AlertConfigDTO getAlertConfigGroupForMetric(MetricConfigDTO metric, boolean forceSyncAlertGroup,
+      String application, String cron) {
+    String alertGroupName = AutoOnboardUtility.getAutoAlertGroupName(metric.getDataset());
+    AlertConfigDTO alertConfigDTO = emailConfigurationDAO.findWhereNameEquals(alertGroupName);
+
+    if (forceSyncAlertGroup) {
+      syncAlertConfig(alertConfigDTO, alertGroupName, metric, application, cron);
+      alertConfigDTO = emailConfigurationDAO.findWhereNameEquals(alertGroupName);
+    } else {
+      if (alertConfigDTO == null) {
+        LOG.warn("Cannot find alert group {} corresponding to dataset {} for metric {}. Loading default alert group {}",
+            alertGroupName, metric.getDataset(), metric.getName(), DEFAULT_ALERT_GROUP);
+        alertConfigDTO = emailConfigurationDAO.findWhereNameEquals(DEFAULT_ALERT_GROUP);
+      }
+    }
+
+    return alertConfigDTO;
+  }
+
+  private void syncAlertConfig(AlertConfigDTO alertConfigDTO, String alertGroupName, MetricConfigDTO metric,
+      String application, String cron) {
+
+    if (alertConfigDTO == null) {
+      Set<String> recipients = metric.getDatasetConfig() != null ? metric.getDatasetConfig().getOwners() : Collections.<String>emptySet();
+      createAlertConfig(alertGroupName, application, cron, recipients);
+    } else {
+      // Note: Since we support only one subscription group per function in the legacy code, we append
+      // dataset owners and interested stakeholders to the same auto created subscription group.
+      // Side effect:
+      // If a dataset owner is removed at source, which rarely is the case, then we will continue to
+      // retain the owner in our subscription group and send him alerts unless manually removed.
+      alertConfigDTO.getReceiverAddresses().getTo().addAll(metric.getDatasetConfig().getOwners());
+      this.emailConfigurationDAO.update(alertConfigDTO);
+    }
+  }
+
+  private Long createAlertConfig(String alertGroupName, String application, String cron, Set<String> recipients) {
+    if (StringUtils.isEmpty(cron)) {
+      cron = DEFAULT_ALERT_GROUP_CRON;
+    } else {
+      if (!CronExpression.isValidExpression(cron)) {
+        throw new IllegalArgumentException("Invalid cron expression : " + cron);
+      }
+    }
+
+    if (StringUtils.isEmpty(application)) {
+      application = DEFAULT_ALERT_GROUP_APPLICATION;
+    }
+
+    AlertConfigDTO alertConfigDTO = new AlertConfigDTO();
+    alertConfigDTO.setName(alertGroupName);
+    alertConfigDTO.setApplication(application);
+    alertConfigDTO.setActive(true);
+    alertConfigDTO.setFromAddress(config.getFailureFromAddress());
+    alertConfigDTO.setCronExpression(cron);
+    alertConfigDTO.setReceiverAddresses(new DetectionAlertFilterRecipients(recipients));
+    return this.emailConfigurationDAO.save(alertConfigDTO);
   }
 
   private List<MetricConfigDTO> fetchMetrics(String tag) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/OnboardResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/OnboardResourceTest.java
@@ -1,0 +1,95 @@
+package com.linkedin.thirdeye.dashboard.resource;
+
+import com.linkedin.thirdeye.dashboard.ThirdEyeDashboardConfiguration;
+import com.linkedin.thirdeye.dashboard.resources.OnboardResource;
+import com.linkedin.thirdeye.datalayer.bao.DAOTestBase;
+import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class OnboardResourceTest {
+
+  private DAOTestBase testDAOProvider;
+  private DAORegistry daoRegistry;
+
+  @BeforeMethod
+  public void beforeClass() {
+    // Prepare database
+    testDAOProvider = DAOTestBase.getInstance();
+    daoRegistry = DAORegistry.getInstance();
+
+    DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
+    datasetConfigDTO.setDataset("test_dataset");
+    datasetConfigDTO.setOwners(new HashSet<String>(Arrays.asList("user_1", "user_2")));
+    daoRegistry.getDatasetConfigDAO().save(datasetConfigDTO);
+
+    MetricConfigDTO metricConfigDTO = new MetricConfigDTO();
+    metricConfigDTO.setName("test_metric");
+    metricConfigDTO.setDataset("test_dataset");
+    metricConfigDTO.setAlias("test_alias");
+    metricConfigDTO.setTags(new HashSet<String>(Arrays.asList("test_tag", "random_tag")));
+    daoRegistry.getMetricConfigDAO().save(metricConfigDTO);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  void afterClass() {
+    testDAOProvider.cleanup();
+  }
+
+  @Test
+  public void testBulkOnboard() throws Exception {
+    ThirdEyeDashboardConfiguration config = new ThirdEyeDashboardConfiguration();
+    config.setFailureFromAddress("thirdeye@test");
+    OnboardResource onboardResource = new OnboardResource(config);
+    Response response = onboardResource.bulkOnboardAlert("test_tag", "test_prefix_", true, null, null, null);
+
+    // Check if the alert group is automatically created
+    List<AlertConfigDTO> alertConfigDTOList = this.daoRegistry.getAlertConfigDAO().findAll();
+    Assert.assertEquals(alertConfigDTOList.size(), 1);
+    Assert.assertEquals(alertConfigDTOList.get(0).getName(), "auto_onboard_dataset_testDataset_alert");
+    Assert.assertEquals(alertConfigDTOList.get(0).getApplication(), "others");
+    Assert.assertEquals(alertConfigDTOList.get(0).getCronExpression(), "0 0 12 ? * FRI *");
+
+    // Check if anomaly function is created
+    List<AnomalyFunctionDTO> anomalyFunctionDTOList = this.daoRegistry.getAnomalyFunctionDAO().findAll();
+    Assert.assertEquals(anomalyFunctionDTOList.size(), 1);
+    Assert.assertEquals(anomalyFunctionDTOList.get(0).getFunctionName(), "test_prefix_testMetric_testDataset");
+
+    // Verify response
+    Assert.assertEquals(response.getStatus(), 200);
+    Assert.assertEquals(((Map<String, String>)response.getEntity()).get("metric test_metric"),
+        "success! onboarded and added to subscription alertGroup = auto_onboard_dataset_testDataset_alert");
+    Assert.assertEquals(((Map<String, String>)response.getEntity()).get("message"),
+        "successfully onboarded 1 metrics with function ids [" + anomalyFunctionDTOList.get(0).getId() + "]");
+  }
+
+  @Test
+  public void testBulkOnboardWithInvalidAlertGroup() throws Exception {
+    OnboardResource onboardResource = new OnboardResource(null);
+    Response response = onboardResource.bulkOnboardAlert("test_tag", null, true, "group_name", null, null);
+    Assert.assertEquals(response.getStatus(), 400);
+    Map<String, String> responseMap = (Map<String, String>) response.getEntity();
+    Assert.assertEquals(responseMap.get("message"), "cannot find an alert group with name group_name.");
+  }
+
+  @Test
+  public void testSoftBulkOnboardWithNoAlertGroup() throws Exception {
+    OnboardResource onboardResource = new OnboardResource(null);
+    Response response = onboardResource.bulkOnboardAlert("test_tag", null, false, null, null, null);
+    Assert.assertEquals(response.getStatus(), 400);
+    Map<String, String> responseMap = (Map<String, String>) response.getEntity();
+    Assert.assertEquals(responseMap.get("message"), "cannot find an alert group for metric test_metric.");
+  }
+}


### PR DESCRIPTION
Changes:
* Updated bulk onboarding endpoint to auto create and sync alert config groups with the dataset owners as recipients.
* Added a cleanup function which removes the auto created alert config groups when a dataset is deleted at source.

Testing:
* Added unit tests