### PR TITLE
Move StreamMessageDecoder into StreamConsumer

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -166,12 +166,12 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
     // create and init stream level consumer
     _streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
-    _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(
-        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName());
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig, schema);
+    String clientId = HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName();
+    _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(clientId, tableName);
     // TODO: define a contract for StreamLevelConsumer.init() or get rid of it completely
     // A future refactoring work of unifying StreamConfig and StreamProviderConfig should give some clarity into this
-    _streamLevelConsumer.init(kafkaStreamProviderConfig, tableName, serverMetrics);
+    _streamLevelConsumer.init(kafkaStreamProviderConfig, serverMetrics);
     _streamLevelConsumer.start();
 
     tableStreamName = tableName + "_" + kafkaStreamProviderConfig.getStreamName();
@@ -226,7 +226,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           GenericRow row = null;
           try {
             readRow = GenericRow.createOrReuseRow(readRow);
-            readRow = _streamLevelConsumer.next(readRow);
+            readRow = _streamLevelConsumer.nextDecoded(readRow);
             row = readRow;
 
             if (readRow != null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaPartitionLevelConsumer.java
@@ -94,6 +94,12 @@ public class KafkaPartitionLevelConsumer extends KafkaConnectionHandler implemen
     }
   }
 
+  /**
+   * Given the messages and offsets message batch from a kafka simple stream, decode the row at the given index
+   * @param messagesAndOffsets
+   * @param index
+   * @param decodedRow
+   */
   @Override
   public void decodeRow(MessageBatch messagesAndOffsets, int index, GenericRow decodedRow) {
     _messageDecoder.decode(messagesAndOffsets.getMessageAtIndex(index),

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -36,7 +36,7 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    */
   @Override
   public PartitionLevelConsumer createPartitionLevelConsumer(String clientId, int partition) {
-    return new KafkaPartitionLevelConsumer(clientId, _streamConfig, partition);
+    return new KafkaPartitionLevelConsumer(clientId, _streamConfig, partition, _schema);
   }
 
   /**
@@ -45,8 +45,8 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    * @return
    */
   @Override
-  public StreamLevelConsumer createStreamLevelConsumer(String clientId) {
-    return new KafkaStreamLevelConsumer();
+  public StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName) {
+    return new KafkaStreamLevelConsumer(clientId, tableName, _streamConfig, _schema);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
@@ -34,7 +34,7 @@ public class PartitionCountFetcher implements Callable<Boolean> {
 
   public PartitionCountFetcher(StreamConfig streamConfig) {
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig, null);
     _topicName = streamConfig.getKafkaTopicName();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
@@ -37,10 +37,10 @@ public interface PartitionLevelConsumer extends Closeable {
 
   /**
    * Decodes a message from the message batch into a generic row
-   * @param messageBatch
+   * @param messagesAndOffsets
    * @param index
    * @param destination
    * @return
    */
-  void decodeRow(MessageBatch messageBatch, int index, GenericRow destination);
+  void decodeRow(MessageBatch messagesAndOffsets, int index, GenericRow destination);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.stream;
 
+import com.linkedin.pinot.core.data.GenericRow;
 import java.io.Closeable;
 
 
@@ -33,4 +34,13 @@ public interface PartitionLevelConsumer extends Closeable {
    */
   MessageBatch fetchMessages(long startOffset, long endOffset, int timeoutMillis)
       throws java.util.concurrent.TimeoutException;
+
+  /**
+   * Decodes a message from the message batch into a generic row
+   * @param messageBatch
+   * @param index
+   * @param destination
+   * @return
+   */
+  void decodeRow(MessageBatch messageBatch, int index, GenericRow destination);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionLevelConsumer.java
@@ -36,7 +36,7 @@ public interface PartitionLevelConsumer extends Closeable {
       throws java.util.concurrent.TimeoutException;
 
   /**
-   * Decodes a message from the message batch into a generic row
+   * Decodes a message from the message batch into a generic row, given the message index
    * @param messagesAndOffsets
    * @param index
    * @param destination

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
@@ -41,7 +41,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     _offsetCriteria = offsetCriteria;
     _partitionId = partitionId;
     _streamConfig = streamConfig;
-    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
+    _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig, null);
     _topicName = streamConfig.getKafkaTopicName();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.stream;
 
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
+import com.linkedin.pinot.common.data.Schema;
 
 
 /**
@@ -23,13 +23,15 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderCo
  */
 public abstract class StreamConsumerFactory {
   protected StreamConfig _streamConfig;
+  protected Schema _schema;
 
   /**
    * Initializes the stream consumer factory with the stream metadata for the table
    * @param streamConfig
    */
-  void init(StreamConfig streamConfig) {
+  void init(StreamConfig streamConfig, Schema schema) {
     _streamConfig = streamConfig;
+    _schema = schema;
   }
 
   /**
@@ -45,7 +47,7 @@ public abstract class StreamConsumerFactory {
    * @param clientId
    * @return
    */
-  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId);
+  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, String tableName);
 
   /**
    * Creates a metadata provider which provides partition specific metadata
@@ -60,8 +62,4 @@ public abstract class StreamConsumerFactory {
    */
   public abstract StreamMetadataProvider createStreamMetadataProvider(String clientId);
 
-  // TODO First split KafkaLowLevelStreamProviderConfig to be kafka agnostic and kafka-specific and then rename.
-  public StreamMessageDecoder getDecoder(KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig) throws Exception {
-    return kafkaStreamProviderConfig.getDecoder();
-  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
@@ -17,27 +17,30 @@ package com.linkedin.pinot.core.realtime.stream;
 
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.data.Schema;
+import java.util.Map;
 
 
 /**
- * Provider class for {@link StreamConsumerFactory}
+ * Provider for {@link StreamMessageDecoder}
  */
-public abstract class StreamConsumerFactoryProvider {
+public abstract class StreamDecoderProvider {
 
   /**
-   * Constructs the {@link StreamConsumerFactory} using the {@link StreamConfig ::getConsumerFactoryName()} property and initializes it
+   * Constructs a {@link StreamMessageDecoder} using properties in {@link StreamConfig} and initializes it
    * @param streamConfig
+   * @param schema
    * @return
    */
-  public static StreamConsumerFactory create(StreamConfig streamConfig, Schema schema) {
-    StreamConsumerFactory factory = null;
+  public static StreamMessageDecoder create(StreamConfig streamConfig, Schema schema) {
+    StreamMessageDecoder decoder = null;
+    String decoderClass = streamConfig.getDecoderClass();
+    Map<String, String> decoderProperties = streamConfig.getDecoderProperties();
     try {
-      factory = (StreamConsumerFactory) Class.forName(streamConfig.getConsumerFactoryName()).newInstance();
+      decoder = (StreamMessageDecoder) Class.forName(decoderClass).newInstance();
+      decoder.init(decoderProperties, schema, streamConfig.getKafkaTopicName());
     } catch (Exception e) {
       Utils.rethrowException(e);
     }
-    factory.init(streamConfig, schema);
-    return factory;
+    return decoder;
   }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamLevelConsumer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamLevelConsumer.java
@@ -24,7 +24,7 @@ public interface StreamLevelConsumer {
   /**
    *
    */
-  void init(StreamProviderConfig streamProviderConfig, String tableName, ServerMetrics serverMetrics) throws Exception;
+  void init(StreamProviderConfig streamProviderConfig, ServerMetrics serverMetrics) throws Exception;
 
   /**
    *
@@ -40,14 +40,14 @@ public interface StreamLevelConsumer {
   /**
    * return GenericRow
    */
-  GenericRow next(GenericRow destination);
+  GenericRow nextDecoded(GenericRow destination);
 
   /**
    *
    * @param offset
    * @return
    */
-  GenericRow next(long offset);
+  GenericRow nextDecoded(long offset);
 
   /**
    *

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.config.TableTaskConfig;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.net.URL;
@@ -96,6 +97,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected boolean useLlc() {
     return false;
+  }
+
+  protected String getStreamConsumerFactoryClassName() {
+    return SimpleConsumerFactory.class.getName();
   }
 
   protected int getRealtimeSegmentFlushSize() {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -381,7 +381,6 @@ public abstract class ClusterTest extends ControllerTest {
       // LLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.simple.toString());
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, streamConsumerFactoryName);
     } else {
       // HLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.highLevel.toString());

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -374,20 +374,21 @@ public abstract class ClusterTest extends ControllerTest {
       String kafkaTopic, int realtimeSegmentFlushSize, File avroFile, String timeColumnName, String timeType,
       String schemaName, String brokerTenant, String serverTenant, String loadMode, String sortedColumn,
       List<String> invertedIndexColumns, List<String> noDictionaryColumns, TableTaskConfig taskConfig,
-      String kafkaConsumerFactoryName) throws Exception {
+      String streamConsumerFactoryName) throws Exception {
     Map<String, String> streamConfigs = new HashMap<>();
     streamConfigs.put("streamType", "kafka");
     if (useLlc) {
       // LLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.simple.toString());
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, kafkaConsumerFactoryName);
+      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, streamConsumerFactoryName);
     } else {
       // HLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.highLevel.toString());
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.ZK_BROKER_URL, kafkaZkUrl);
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, kafkaZkUrl);
     }
+    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, streamConsumerFactoryName);
     streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.TOPIC_NAME, kafkaTopic);
     AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;
     streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -95,7 +95,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
 
     addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
         getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, null, null,
-        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig(), null);
+        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig(), getStreamConsumerFactoryClassName());
 
     completeTableConfiguration();
   }


### PR DESCRIPTION
The data manager level doesn't need to manage the decoding of the messages. It can be handled by the stream consumer. The StreamLevelConsumer already has decoder inside the consumer. Adding a method in PartitionLevelConsumer to decode a message. This will allow us to remove decoders from LLRealtimeDataManager. The consumers are responsible for creating the decoder they need using the stream configs and StreamDecoderProvider.
The classes StreamConsumerFactory, StreamLevelConsumer and PartitionLevelConsumer show how the updated interfaces look like.