### PR TITLE
Add a config to enable/disable segment level validation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -27,6 +27,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 
+
 public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   private static final String CONTROLLER_VIP_PORT = "controller.vip.port";
@@ -61,6 +62,8 @@ public class ControllerConf extends PropertiesConfiguration {
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
   private static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = "controller.realtime.segment.metadata.commit.numLocks";
+  private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
+  private static final String ENABLE_SEGMENT_LEVEL_VALIDATION = "controller.enable.segment.level.validation";
 
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_PREFIX = "controller.storage.factory.class";
@@ -82,9 +85,8 @@ public class ControllerConf extends PropertiesConfiguration {
       "com.linkedin.pinot.controller.api.access.AllowAllAccessFactory";
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
   private static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
-
-  private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
-  private static final boolean DEFAULT_STORAGE_QUOTA_CHECK = true;
+  private static final boolean DEFAULT_ENABLE_STORAGE_QUOTA_CHECK = true;
+  private static final boolean DEFAULT_ENABLE_SEGMENT_LEVEL_VALIDATION = true;
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
@@ -117,7 +119,8 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(PINOT_FS_FACTORY_CLASS_LOCAL, DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL);
 
     if (pinotFSFactoryClasses != null) {
-      pinotFSFactoryClasses.getKeys().forEachRemaining(key -> setProperty((String) key, pinotFSFactoryClasses.getProperty((String) key)));
+      pinotFSFactoryClasses.getKeys()
+          .forEachRemaining(key -> setProperty((String) key, pinotFSFactoryClasses.getProperty((String) key)));
     }
   }
 
@@ -136,7 +139,7 @@ public class ControllerConf extends PropertiesConfiguration {
     return ControllerConf.class.getClassLoader().getResource("webapp").toExternalForm();
   }
 
-  public void setQueryConsoleUseHttps(boolean useHttps){
+  public void setQueryConsoleUseHttps(boolean useHttps) {
     setProperty(CONSOLE_WEBAPP_USE_HTTPS, useHttps);
   }
 
@@ -212,7 +215,7 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public int getSegmentCommitTimeoutSeconds() {
     if (containsKey(SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
-      return Integer.parseInt((String)getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
+      return Integer.parseInt((String) getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
     }
     return SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds();
   }
@@ -234,13 +237,13 @@ public class ControllerConf extends PropertiesConfiguration {
     // The set method converted comma separated string into ArrayList, so need to convert back to String here.
     if (zkAddressObj instanceof ArrayList) {
       List<String> zkAddressList = (ArrayList<String>) zkAddressObj;
-      String[] zkAddress =  zkAddressList.toArray(new String[0]);
+      String[] zkAddress = zkAddressList.toArray(new String[0]);
       return StringUtil.join(",", zkAddress);
     } else if (zkAddressObj instanceof String) {
       return (String) zkAddressObj;
     } else {
       throw new RuntimeException("Unexpected data type for zkAddress PropertiesConfiguration, expecting String but got "
-              + zkAddressObj.getClass().getName());
+          + zkAddressObj.getClass().getName());
     }
   }
 
@@ -272,7 +275,7 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public String getControllerVipProtocol() {
-    if (containsKey(CONTROLLER_VIP_PROTOCOL) && ((String) getProperty(CONTROLLER_VIP_PROTOCOL)).equals("https")) {
+    if (containsKey(CONTROLLER_VIP_PROTOCOL) && getProperty(CONTROLLER_VIP_PROTOCOL).equals("https")) {
       return "https";
     }
     return "http";
@@ -332,7 +335,6 @@ public class ControllerConf extends PropertiesConfiguration {
   public void setStatusCheckerWaitForPushTimeInSeconds(int statusCheckerWaitForPushTimeInSeconds) {
     setProperty(STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS, Integer.toString(statusCheckerWaitForPushTimeInSeconds));
   }
-
 
   public long getExternalViewOnlineToOfflineTimeout() {
     if (containsKey(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT)) {
@@ -417,6 +419,10 @@ public class ControllerConf extends PropertiesConfiguration {
   }
 
   public boolean getEnableStorageQuotaCheck() {
-    return getBoolean(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_STORAGE_QUOTA_CHECK);
+    return getBoolean(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_ENABLE_STORAGE_QUOTA_CHECK);
+  }
+
+  public boolean getEnableSegmentLevelValidation() {
+    return getBoolean(ENABLE_SEGMENT_LEVEL_VALIDATION, DEFAULT_ENABLE_SEGMENT_LEVEL_VALIDATION);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -163,9 +163,9 @@ public class ControllerStarter {
     LOGGER.info("Starting validation manager");
     // Helix resource manager must be started in order to create PinotLLCRealtimeSegmentManager
     PinotLLCRealtimeSegmentManager.create(_helixResourceManager, _config, _controllerMetrics);
-    ValidationMetrics validationMetrics = new ValidationMetrics(_metricsRegistry);
-    _validationManager = new ValidationManager(validationMetrics, _helixResourceManager, _config,
-        PinotLLCRealtimeSegmentManager.getInstance());
+    _validationManager =
+        new ValidationManager(_config, _helixResourceManager, PinotLLCRealtimeSegmentManager.getInstance(),
+            new ValidationMetrics(_metricsRegistry));
     _validationManager.start();
 
     LOGGER.info("Starting realtime segment manager");


### PR DESCRIPTION
Currently in ValidationManager, we always fetch all segment ZK metadata and do validation on top of them
This could be a very costly operation for big cluster with huge number of segments
Provide an option to disable this validation