### PR TITLE
Fix a breaking change that download uri in zk is not the same as upload uri

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -373,6 +373,8 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.controller.crypter";
     public static final String LOCAL_SEGMENT_SCHEME = "file";
 
+    public static final String PERSIST_TO_PINOT_MANAGED_FILESYSTEM = "persistToPinotManagedFilesystem";
+
     public enum SegmentType {
       OFFLINE,
       REALTIME

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -68,6 +68,8 @@ public class FileUploadDownloadClient implements Closeable {
   public static class CustomHeaders {
     public static final String UPLOAD_TYPE = "UPLOAD_TYPE";
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
+    public static final String SEGMENT_PERSISTENCE_STRATEGY = "SEGMENT_PERSISTENCE_STRATEGY";
+
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
   }


### PR DESCRIPTION
Hi @jenniferdai,

Our offline pipeline are all based on URI upload type. And we expected downloadUri in SegmentMetadata in Zookeeper is the same as the upload uri we set in the request header.

Currently we have segments serving by two hdfs clusters: unsecure hdfs(Example URI: _hdfs://path/to/unsecure/segment_) and secure hdfs(Example URI:  _viewfs://path/to/secure/segment_).

I put a quick fix here, but maybe you have more thoughts on the "FileUploadPathProvider", please advise.
