### PR TITLE
Create StreamDecoderProvider

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -167,8 +167,9 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // create and init stream level consumer
     _streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
-    _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(
-        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName());
+    String clientId =
+        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName();
+    _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(clientId, schema);
     // TODO: define a contract for StreamLevelConsumer.init() or get rid of it completely
     // A future refactoring work of unifying StreamConfig and StreamProviderConfig should give some clarity into this
     _streamLevelConsumer.init(kafkaStreamProviderConfig, tableName, serverMetrics);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -51,6 +51,7 @@ import com.linkedin.pinot.core.realtime.stream.PartitionLevelConsumer;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactoryProvider;
+import com.linkedin.pinot.core.realtime.stream.StreamDecoderProvider;
 import com.linkedin.pinot.core.realtime.stream.StreamMessageDecoder;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadataProvider;
 import com.linkedin.pinot.core.realtime.stream.TransientConsumerException;
@@ -1071,7 +1072,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setAggregateMetrics(indexingConfig.getAggregateMetrics());
 
     // Create message decoder
-    _messageDecoder = _streamConsumerFactory.getDecoder(kafkaStreamProviderConfig);
+    _messageDecoder = StreamDecoderProvider.create(_streamConfig, _schema);
     _clientId = _streamPartitionId + "-" + NetUtil.getHostnameOrAddress();
 
     // Create field extractor

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerFactory.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
+import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.realtime.stream.PartitionLevelConsumer;
 import com.linkedin.pinot.core.realtime.stream.StreamConsumerFactory;
 import com.linkedin.pinot.core.realtime.stream.StreamLevelConsumer;
@@ -45,8 +46,8 @@ public class SimpleConsumerFactory extends StreamConsumerFactory {
    * @return
    */
   @Override
-  public StreamLevelConsumer createStreamLevelConsumer(String clientId) {
-    return new KafkaStreamLevelConsumer();
+  public StreamLevelConsumer createStreamLevelConsumer(String clientId, Schema schema) {
+    return new KafkaStreamLevelConsumer(clientId, _streamConfig, schema);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConsumerFactory.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.stream;
 
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
+import com.linkedin.pinot.common.data.Schema;
 
 
 /**
@@ -45,7 +45,7 @@ public abstract class StreamConsumerFactory {
    * @param clientId
    * @return
    */
-  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId);
+  public abstract StreamLevelConsumer createStreamLevelConsumer(String clientId, Schema schema);
 
   /**
    * Creates a metadata provider which provides partition specific metadata
@@ -60,8 +60,4 @@ public abstract class StreamConsumerFactory {
    */
   public abstract StreamMetadataProvider createStreamMetadataProvider(String clientId);
 
-  // TODO First split KafkaLowLevelStreamProviderConfig to be kafka agnostic and kafka-specific and then rename.
-  public StreamMessageDecoder getDecoder(KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig) throws Exception {
-    return kafkaStreamProviderConfig.getDecoder();
-  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.stream;
+
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.data.Schema;
+import java.util.Map;
+
+
+/**
+ * Provider for {@link StreamMessageDecoder}
+ */
+public abstract class StreamDecoderProvider {
+
+  /**
+   * Constructs a {@link StreamMessageDecoder} using properties in {@link StreamConfig} and initializes it
+   * @param streamConfig
+   * @param schema
+   * @return
+   */
+  public static StreamMessageDecoder create(StreamConfig streamConfig, Schema schema) {
+    StreamMessageDecoder decoder = null;
+    String decoderClass = streamConfig.getDecoderClass();
+    Map<String, String> decoderProperties = streamConfig.getDecoderProperties();
+    try {
+      decoder = (StreamMessageDecoder) Class.forName(decoderClass).newInstance();
+      decoder.init(decoderProperties, schema, streamConfig.getKafkaTopicName());
+    } catch (Exception e) {
+      Utils.rethrowException(e);
+    }
+    return decoder;
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.config.TableTaskConfig;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.net.URL;
@@ -96,6 +97,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected boolean useLlc() {
     return false;
+  }
+
+  protected String getStreamConsumerFactoryClassName() {
+    return SimpleConsumerFactory.class.getName();
   }
 
   protected int getRealtimeSegmentFlushSize() {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -374,20 +374,20 @@ public abstract class ClusterTest extends ControllerTest {
       String kafkaTopic, int realtimeSegmentFlushSize, File avroFile, String timeColumnName, String timeType,
       String schemaName, String brokerTenant, String serverTenant, String loadMode, String sortedColumn,
       List<String> invertedIndexColumns, List<String> noDictionaryColumns, TableTaskConfig taskConfig,
-      String kafkaConsumerFactoryName) throws Exception {
+      String streamConsumerFactoryName) throws Exception {
     Map<String, String> streamConfigs = new HashMap<>();
     streamConfigs.put("streamType", "kafka");
     if (useLlc) {
       // LLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.simple.toString());
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, kafkaConsumerFactoryName);
     } else {
       // HLC
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.highLevel.toString());
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.ZK_BROKER_URL, kafkaZkUrl);
       streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, kafkaZkUrl);
     }
+    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, streamConsumerFactoryName);
     streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.TOPIC_NAME, kafkaTopic);
     AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;
     streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -95,7 +95,8 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
 
     addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
         getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, null, null,
-        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig(), null);
+        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig(),
+        getStreamConsumerFactoryClassName());
 
     completeTableConfiguration();
   }


### PR DESCRIPTION
Create a StreamDecoderProvider to provide the decoders for the stream. The StreamDecoderProvider uses only StreamConfig and Schema, eliminating the usages of KafkaStreamProviderConfig
Also fixing some integration tests which were not working as expected.

Linking to https://github.com/linkedin/pinot/issues/2583