### PR TITLE
[TE] frontend - Alert page bug fixes

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -192,7 +192,7 @@ export default Controller.extend({
     'selectedResolution',
     function() {
       let anomalies = this.get('filteredAnomalies');
-      const { pageSize, currentPage, selectedSortMode } = this.getProperties('pageSize', 'currentPage', 'selectedSortMode');
+      const { pageSize, currentPage, selectedSortMode } = getProperties(this, 'pageSize', 'currentPage', 'selectedSortMode');
 
       if (selectedSortMode) {
         let [ sortKey, sortDir ] = selectedSortMode.split(':');
@@ -356,7 +356,7 @@ export default Controller.extend({
         set(this, 'isAnomalyListFiltered', anomalyData.length !== newAnomalies.length);
         // Add an index number to each row
         newAnomalies.forEach((anomaly, index) => {
-          set(anomaly, 'index', index + 1);
+          set(anomaly, 'index', ++index);
         });
       }
       return newAnomalies;

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -47,6 +47,7 @@ export default Controller.extend({
    * Mapping anomaly table column names to corresponding prop keys
    */
   sortMap: {
+    number: 'index',
     start: 'anomalyStart',
     score: 'severityScore',
     change: 'changeRate',
@@ -96,6 +97,8 @@ export default Controller.extend({
       sortColumnStartUp: false,
       sortColumnScoreUp: false,
       sortColumnChangeUp: false,
+      sortColumnNumberUp: true,
+      isAnomalyListFiltered: false,
       isDimensionFetchDone: false,
       sortColumnResolutionUp: false,
       checkReplayInterval: 2000, // 2 seconds
@@ -186,6 +189,7 @@ export default Controller.extend({
     'currentPage',
     'loadedWoWData',
     'selectedSortMode',
+    'selectedResolution',
     function() {
       let anomalies = this.get('filteredAnomalies');
       const { pageSize, currentPage, selectedSortMode } = this.getProperties('pageSize', 'currentPage', 'selectedSortMode');
@@ -247,10 +251,11 @@ export default Controller.extend({
    */
   isAnomalyLoadError: computed(
     'totalAnomalies',
-    'filteredAnomalies.length',
+    'anomalyData.length',
     function() {
-      const { totalAnomalies, filteredAnomalies } = getProperties(this, 'totalAnomalies', 'filteredAnomalies');
-      return totalAnomalies !== filteredAnomalies.length;
+      const { totalAnomalies, anomalyData } = getProperties(this, 'totalAnomalies', 'anomalyData');
+      const totalsMatching = anomalyData ? (totalAnomalies !== anomalyData.length) : true;
+      return totalsMatching;
     }
   ),
 
@@ -330,28 +335,31 @@ export default Controller.extend({
     'anomaliesLoaded',
     function() {
       const {
+        anomalyData,
         anomaliesLoaded,
         selectedDimension: targetDimension,
         selectedResolution: targetResolution
-      } = this.getProperties('selectedDimension', 'selectedResolution', 'anomaliesLoaded');
-      let anomalies = [];
+      } = this.getProperties('anomalyData', 'selectedDimension', 'selectedResolution', 'anomaliesLoaded');
+      let newAnomalies = [];
 
-      if (anomaliesLoaded) {
-        anomalies = this.get('anomalyData');
+      if (anomaliesLoaded  && anomalyData) {
+        newAnomalies = this.get('anomalyData');
         if (targetDimension !== 'All Dimensions') {
           // Filter for selected dimension
-          anomalies = anomalies.filter(data => targetDimension === data.dimensionString);
+          newAnomalies = newAnomalies.filter(data => targetDimension === data.dimensionString);
         }
         if (targetResolution !== 'All Resolutions') {
           // Filter for selected resolution
-          anomalies = anomalies.filter(data => targetResolution === data.anomalyFeedback);
+          newAnomalies = newAnomalies.filter(data => targetResolution === data.anomalyFeedback);
         }
+        // Let page know whether anomalies viewed are filtered or not
+        set(this, 'isAnomalyListFiltered', anomalyData.length !== newAnomalies.length);
         // Add an index number to each row
-        anomalies.forEach((anomaly, index) => {
-          anomaly.index = index + 1;
+        newAnomalies.forEach((anomaly, index) => {
+          set(anomaly, 'index', index + 1);
         });
       }
-      return anomalies;
+      return newAnomalies;
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -496,8 +496,9 @@ export default Route.extend({
     this.controller.setProperties({
       anomalyData,
       dimensionOptions,
-      resolutionOptions,
+      resolutionOptions: [ ...new Set(resolutionOptions) ],
       anomaliesLoaded: true,
+      totalLoadedAnomalies: anomalyData.length,
       baselineOptionsLoading: false
     });
     // Fetch and append extra WoW data for each anomaly record

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -57,7 +57,16 @@
     {{/if}}
 
     <div class="te-content-block">
-      <h4 class="te-self-serve__block-title">Anomalies over time ({{#if anomaliesLoaded}}{{filteredAnomalies.length}}{{else}}...loading anomalies{{/if}})</h4>
+      <h4 class="te-self-serve__block-title">Anomalies over time (
+        {{#if anomaliesLoaded}}
+          {{filteredAnomalies.length}}
+          {{#if isAnomalyListFiltered}}
+            of {{totalLoadedAnomalies}}
+          {{/if}}
+        {{else}}
+          ...loading anomalies
+        {{/if}})
+      </h4>
       <a class="te-self-serve__side-link te-self-serve__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
       {{#if filteredAnomalies}}
@@ -68,7 +77,8 @@
               triggerId="select-dimension"
               triggerClass="te-form__select"
               options=dimensionOptions
-              searchEnabled=false
+              searchEnabled=true
+              searchPlaceholder="Type to filter..."
               matchTriggerWidth=true
               matchContentWidth=true
               selected=selectedDimension
@@ -80,6 +90,7 @@
           </div>
         {{/if}}
         {{!-- Resolution selector --}}
+        {{log "resolutionOptions: " resolutionOptions}}
         <div class="col-md-3">
           {{#power-select
             triggerId="select-resolution"
@@ -165,7 +176,13 @@
           {{#if filteredAnomalies}}
             <thead>
               <tr class="te-anomaly-table__row te-anomaly-table__head">
-                <th class="te-anomaly-table__cell-head">
+                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--lefter">
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "number"}}>
+                    #
+                    <i class="te-anomaly-table__icon glyphicon {{if sortColumnNumberUp "glyphicon-menu-down" "glyphicon-menu-up"}}"></i>
+                  </a>
+                </th>
+                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--lefter">
                   <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
                     Start/Duration (PDT)
                     <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
@@ -199,9 +216,11 @@
           <tbody>
             {{#each paginatedFilteredAnomalies as |anomaly|}}
               <tr class="te-anomaly-table__row">
+                 <td class="te-anomaly-table__cell te-anomaly-table__cell--index">
+                  <span>{{anomaly.index}}</span>
+                 </td>
                  <td class="te-anomaly-table__cell">
-                  <ul class="te-anomaly-table__list">
-                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--shadow">{{anomaly.index}}</li>
+                  <ul class="te-anomaly-table__list te-anomaly-table__list--lefter">
                     <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">
                       <a target="_blank" class="te-anomaly-table__link" href="/app/#/rootcause?anomalyId={{anomaly.anomalyId}}">
                         {{anomaly.startDateStr}}
@@ -256,7 +275,7 @@
                     {{else}}
                       {{#power-select
                         triggerId=anomaly.anomalyId
-                        triggerClass="te-anomaly-table__select te-anomaly-table__select--margin-right"
+                        triggerClass="te-anomaly-table__select"
                         options=responseOptions
                         searchEnabled=false
                         selected=anomaly.anomalyFeedback

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -90,7 +90,6 @@
           </div>
         {{/if}}
         {{!-- Resolution selector --}}
-        {{log "resolutionOptions: " resolutionOptions}}
         <div class="col-md-3">
           {{#power-select
             triggerId="select-resolution"
@@ -177,8 +176,7 @@
             <thead>
               <tr class="te-anomaly-table__row te-anomaly-table__head">
                 <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--lefter">
-                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "number"}}>
-                    #
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "number"}}>#
                     <i class="te-anomaly-table__icon glyphicon {{if sortColumnNumberUp "glyphicon-menu-down" "glyphicon-menu-up"}}"></i>
                   </a>
                 </th>
@@ -216,9 +214,7 @@
           <tbody>
             {{#each paginatedFilteredAnomalies as |anomaly|}}
               <tr class="te-anomaly-table__row">
-                 <td class="te-anomaly-table__cell te-anomaly-table__cell--index">
-                  <span>{{anomaly.index}}</span>
-                 </td>
+                 <td class="te-anomaly-table__cell te-anomaly-table__cell--index">{{anomaly.index}}</td>
                  <td class="te-anomaly-table__cell">
                   <ul class="te-anomaly-table__list te-anomaly-table__list--lefter">
                     <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -175,12 +175,12 @@
           {{#if filteredAnomalies}}
             <thead>
               <tr class="te-anomaly-table__row te-anomaly-table__head">
-                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--lefter">
+                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--left">
                   <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "number"}}>#
                     <i class="te-anomaly-table__icon glyphicon {{if sortColumnNumberUp "glyphicon-menu-down" "glyphicon-menu-up"}}"></i>
                   </a>
                 </th>
-                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--lefter">
+                <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--left">
                   <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
                     Start/Duration (PDT)
                     <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
@@ -216,7 +216,7 @@
               <tr class="te-anomaly-table__row">
                  <td class="te-anomaly-table__cell te-anomaly-table__cell--index">{{anomaly.index}}</td>
                  <td class="te-anomaly-table__cell">
-                  <ul class="te-anomaly-table__list te-anomaly-table__list--lefter">
+                  <ul class="te-anomaly-table__list te-anomaly-table__list--left">
                     <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">
                       <a target="_blank" class="te-anomaly-table__link" href="/app/#/rootcause?anomalyId={{anomaly.anomalyId}}">
                         {{anomaly.startDateStr}}

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -1,6 +1,7 @@
 .te-anomaly-table {
   width: 100%;
   margin-top: 12px;
+  background-color: white;
   border: 1px solid app-shade(black, 1);
 
   &__comment {
@@ -27,11 +28,18 @@
   }
 
   &__cell {
-    padding: 5px 20px;
+    padding: 5px 15px;
     font-size: 15px;
     font-weight: 500;
     color: app-shade(black, 8);
     position: relative;
+
+    &--index {
+      font-size: 14px;
+      padding: 7px 0 0 11px;
+      vertical-align: top;
+      color: app-shade(black, 4);
+    }
 
     &:last-child {
       max-width: 90px;
@@ -45,11 +53,15 @@
     font-size: 15px;
     font-weight: bold;
     color: app-shade(black, 6);
-    padding-left: 20px;
+    padding-left: 15px;
     line-height: 45px;
 
     &--fixed {
       width: 215px;
+    }
+
+    &--lefter {
+      padding-left: 10px;
     }
   }
 
@@ -71,9 +83,13 @@
 
   &__list {
     list-style: none;
-    margin-left: -39px;
+    margin-left: -37px;
     margin-bottom: 0;
     max-width: 280px;
+
+    &--lefter {
+      margin-left: -45px;
+    }
   }
 
   &__list-item {

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -60,7 +60,7 @@
       width: 215px;
     }
 
-    &--lefter {
+    &--left {
       padding-left: 10px;
     }
   }
@@ -87,7 +87,7 @@
     margin-bottom: 0;
     max-width: 280px;
 
-    &--lefter {
+    &--left {
       margin-left: -45px;
     }
   }


### PR DESCRIPTION
Handling 3 fixes for Alert Page:
- adding typeahead search in "Dimensions" filter (sometimes we have 200+ options to scroll)
- anomaly table filter by resolution now working properly + added clarity on number of anomalies being displayed, both in section title and index row
- handled case of anomaly index in each row being un-readable (spacing issues)

Also:
- Alert page "resolution options" was displaying duplicates - deduped the array
- Correction to the error state for "we were not able to load all anomalies"

<img width="1151" alt="screen shot 2018-10-12 at 5 28 29 pm" src="https://user-images.githubusercontent.com/11814420/46896727-4d9c7f80-ce44-11e8-9f83-e3694fd8d3a7.png">
