### PR TITLE
[TE] dataframe - prevent metric metadata load amplification in helpers

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
@@ -486,32 +486,17 @@ public class DataFrameUtils {
    * @throws ExecutionException
    */
   private static ThirdEyeRequest.ThirdEyeRequestBuilder makeThirdEyeRequestBuilder(MetricSlice slice, MetricConfigDTO metric, DatasetConfigDTO dataset, List<MetricExpression> expressions, MetricConfigManager metricDAO) throws ExecutionException {
-    List<MetricConfigDTO> datasetMetrics = metricDAO.findByDataset(dataset.getDataset());
-    Set<String> metricNames = new HashSet<>();
-    for (MetricConfigDTO metricDTO : datasetMetrics) {
-      metricNames.add(metricDTO.getName());
-    }
-
     List<MetricFunction> functions = new ArrayList<>();
     for(MetricExpression exp : expressions) {
       functions.addAll(exp.computeMetricFunctions());
     }
 
-    Multimap<String, String> effectiveFilters = ArrayListMultimap.create();
-    for (String dimName : slice.filters.keySet()) {
-      if (dataset.getDimensions().contains(dimName)
-          || metricNames.contains(dimName)) {
-        effectiveFilters.putAll(dimName, slice.filters.get(dimName));
-      }
-    }
-
     return ThirdEyeRequest.newBuilder()
         .setStartTimeInclusive(slice.start)
         .setEndTimeExclusive(slice.end)
-        .setFilterSet(effectiveFilters)
+        .setFilterSet(slice.filters)
         .setMetricFunctions(functions)
         .setDataSource(dataset.getDataSource());
-
   }
 
   /**


### PR DESCRIPTION
This PR removes a load amplification on metric metadata from a convenience function for loading time series and aggregates.