### PR TITLE
[TE] frontend - isolate anomalyResponseObject modification to home controller

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
 import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
-import { computed, set, get } from '@ember/object';
+import { computed, set, get, setProperties } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import moment from 'moment';
+import _ from 'lodash';
 import { setUpTimeRangeOptions } from 'thirdeye-frontend/utils/manage-alert-utils';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
 
@@ -13,7 +14,6 @@ const DISPLAY_DATE_FORMAT = 'YYYY-MM-DD HH:mm'; // format used consistently acro
 const TIME_RANGE_OPTIONS = ['today', '1d', '2d', '1w'];
 
 export default Controller.extend({
-  anomalyResponseObj: anomalyUtil.anomalyResponseObj,
   toggleCollapsed: false, /* hide/show accordians */
   isReportAnomalyEnabled: false,
 
@@ -26,19 +26,18 @@ export default Controller.extend({
 
   init() {
     this._super(...arguments);
-    get(this, 'anomalyResponseObj').push({
+    // Add ALL option to copy of global anomaly response object
+    const anomalyResponseObj = _.cloneDeep(anomalyUtil.anomalyResponseObj);
+    anomalyResponseObj.push({
       name: 'All Resolutions',
       value: 'ALL',
       status: 'All Resolutions'
     });
+    setProperties(this, {
+      anomalyResponseObj,
+      anomalyResponseNames: anomalyResponseObj.mapBy('name')
+    });
   },
-
-  anomalyResponseNames: computed(
-    'anomalyResponseObj',
-    function() {
-      return anomalyUtil.anomalyResponseObj.mapBy('name');
-    }
-  ),
 
   filteredAnomalyMapping: computed(
     'model.{anomalyMapping,feedbackType}',

--- a/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/index/controller.js
@@ -27,15 +27,15 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     // Add ALL option to copy of global anomaly response object
-    const anomalyResponseObj = _.cloneDeep(anomalyUtil.anomalyResponseObj);
-    anomalyResponseObj.push({
+    const anomalyResponseFilterTypes = _.cloneDeep(anomalyUtil.anomalyResponseObj);
+    anomalyResponseFilterTypes.push({
       name: 'All Resolutions',
       value: 'ALL',
       status: 'All Resolutions'
     });
     setProperties(this, {
-      anomalyResponseObj,
-      anomalyResponseNames: anomalyResponseObj.mapBy('name')
+      anomalyResponseFilterTypes,
+      anomalyResponseNames: anomalyResponseFilterTypes.mapBy('name')
     });
   },
 
@@ -154,7 +154,7 @@ export default Controller.extend({
    * @return {string}
    */
   _checkFeedback: function(selected) {
-    return get(this, 'anomalyResponseObj').find((type) => {
+    return get(this, 'anomalyResponseFilterTypes').find((type) => {
       return type.name === selected;
     });
   },

--- a/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/controller.js
@@ -7,6 +7,7 @@
  */
 import Controller from '@ember/controller';
 import $ from 'jquery';
+import _ from 'lodash';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
 import { isBlank } from '@ember/utils';
 import { task } from 'ember-concurrency';
@@ -40,7 +41,7 @@ const CUSTOMIZE_OPTIONS = [{
 
 export default Controller.extend({
   shareDashboardApiService: service('services/api/share-dashboard'),
-  anomalyResponseObj: anomalyUtil.anomalyResponseObj,
+  anomalyResponseObj: _.cloneDeep(anomalyUtil.anomalyResponseObj),
   showCopyTooltip: false,
   showSharedTooltip: false,
   shareUrl: null,

--- a/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/share-dashboard/controller.js
@@ -41,7 +41,7 @@ const CUSTOMIZE_OPTIONS = [{
 
 export default Controller.extend({
   shareDashboardApiService: service('services/api/share-dashboard'),
-  anomalyResponseObj: _.cloneDeep(anomalyUtil.anomalyResponseObj),
+  anomalyResponseFilterTypes: _.cloneDeep(anomalyUtil.anomalyResponseObj),
   showCopyTooltip: false,
   showSharedTooltip: false,
   shareUrl: null,
@@ -57,7 +57,7 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     //Add one more option
-    get(this, 'anomalyResponseObj').push({
+    get(this, 'anomalyResponseFilterTypes').push({
       name: 'All Resolutions',
       value: 'ALL',
       status: 'All Resolutions'
@@ -240,7 +240,7 @@ export default Controller.extend({
    * @return {string}
    */
   _checkFeedback: function(selected) {
-    return get(this, 'anomalyResponseObj').find((type) => {
+    return get(this, 'anomalyResponseFilterTypes').find((type) => {
       return type.name === selected;
     });
   },

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -5,7 +5,7 @@
   border: 1px solid app-shade(black, 1);
 
   &__comment {
-    margin-top: 10px;
+    margin-left: 10px;
     float: left;
   }
 


### PR DESCRIPTION
The home and index share controllers add an "All Resolutions" option to the globally defined anomalyResponseObj in anomaly utils. Here we are cloning that object to ensure the modified options are not used in the anomaly "labeling" options component, which needs to use the original array.

Also a tiny css tweak for the anomaly comments icon.

<img width="264" alt="screen shot 2018-10-14 at 7 32 54 pm" src="https://user-images.githubusercontent.com/11814420/46924221-02bb6d00-cfe8-11e8-9235-282cc6d6caa4.png">
<img width="570" alt="screen shot 2018-10-14 at 7 33 04 pm" src="https://user-images.githubusercontent.com/11814420/46924224-06e78a80-cfe8-11e8-8b29-c6324d931e31.png">
