### PR TITLE
Adding backwards compatibility for segment upload

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -70,19 +70,10 @@ public class FileUploadDownloadClient implements Closeable {
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
-    public static final String UPLOAD_VERSION = "UPLOAD_VERSION";
   }
 
   public static class QueryParameters {
     public static final String ENABLE_PARALLEL_PUSH_PROTECTION = "enableParallelPushProtection";
-  }
-
-  public enum UploadVersion {
-    V1, V2;
-
-    public static UploadVersion getDefaultUploadVersion() {
-      return V2;
-    }
   }
 
   public enum FileUploadType {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -70,10 +70,19 @@ public class FileUploadDownloadClient implements Closeable {
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
+    public static final String UPLOAD_VERSION = "UPLOAD_VERSION";
   }
 
   public static class QueryParameters {
     public static final String ENABLE_PARALLEL_PUSH_PROTECTION = "enableParallelPushProtection";
+  }
+
+  public enum UploadVersion {
+    V1, V2;
+
+    public static UploadVersion getDefaultUploadVersion() {
+      return V2;
+    }
   }
 
   public enum FileUploadType {
@@ -90,7 +99,7 @@ public class FileUploadDownloadClient implements Closeable {
   private static final String HTTP = "http";
   private static final String HTTPS = "https";
   private static final String SCHEMA_PATH = "/schemas";
-  private static final String SEGMENT_PATH = "/segments";
+  private static final String SEGMENT_PATH = "/v2/segments";
   private static final String SEGMENT_METADATA_PATH = "/segmentmetadata";
   private static final String TABLES_PATH = "/tables";
   private static final String TYPE_DELIMITER = "?type=";

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadDownloadClientTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadDownloadClientTest.java
@@ -51,7 +51,7 @@ public class FileUploadDownloadClientTest {
   @BeforeClass
   public void setUp() throws Exception {
     TEST_SERVER = HttpServer.create(new InetSocketAddress(TEST_PORT), 0);
-    TEST_SERVER.createContext("/segments", new testSegmentUploadHandler());
+    TEST_SERVER.createContext("/v2/segments", new testSegmentUploadHandler());
     TEST_SERVER.setExecutor(null); // creates a default executor
     TEST_SERVER.start();
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -326,21 +326,14 @@ public class PinotSegmentUploadRestletResource {
     }
   }
 
-  private FileUploadDownloadClient.UploadVersion getUploadVersion(String uploadVersionString) {
-    if (uploadVersionString != null) {
-      return FileUploadDownloadClient.UploadVersion.valueOf(uploadVersionString);
-    } else {
-      return FileUploadDownloadClient.UploadVersion.getDefaultUploadVersion();
-    }
-  }
-
   private String getZkDownloadURIForURIUpload(String currentSegmentLocationURI, SegmentMetadata segmentMetadata,
       FileUploadPathProvider provider, boolean moveSegmentToFinalLocation) throws URISyntaxException, UnsupportedEncodingException {
     String zkDownloadUri;
     if (new URI(currentSegmentLocationURI).getScheme().equals(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
       zkDownloadUri = ControllerConf.constructDownloadUrl(segmentMetadata.getTableName(), segmentMetadata.getName(),
           provider.getVip());
-    } else if (moveSegmentToFinalLocation) {
+    } else if (!moveSegmentToFinalLocation) {
+      LOGGER.info("Setting zkDownloadUri to {}, skipping move", currentSegmentLocationURI);
       zkDownloadUri = currentSegmentLocationURI;
     } else {
       LOGGER.info("Using configured data dir {}", _controllerConf.getDataDir());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
@@ -65,14 +65,14 @@ public class ZKOperator {
 
     // Brand new segment, not refresh, directly add the segment
     if (znRecord == null) {
-      LOGGER.info("Adding new segment: {}", segmentName);
+      LOGGER.info("Adding new segment {} from table {}", segmentName, rawTableName);
       String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
       processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, crypter,
           rawTableName, segmentName, moveSegmentToFinalLocation);
       return;
     }
 
-    LOGGER.info("Segment {} already exists, refreshing if necessary", segmentName);
+    LOGGER.info("Segment {} from table {} already exists, refreshing if necessary", segmentName, rawTableName);
 
     processExistingSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation,
         enableParallelPushProtection, headers, zkDownloadURI, offlineTableName, segmentName, znRecord, moveSegmentToFinalLocation);
@@ -162,7 +162,7 @@ public class ZKOperator {
           moveSegmentToPermanentDirectory(currentSegmentLocation, finalSegmentLocationURI);
           LOGGER.info("Moved segment {} from temp location {} to {}", segmentName, currentSegmentLocation.getAbsolutePath(), finalSegmentLocationURI.getPath());
         } else {
-          LOGGER.info("Skipping segment move, keeping segment at {}", zkDownloadURI);
+          LOGGER.info("Skipping segment move, keeping segment {} from table {} at {}", segmentName, offlineTableName, zkDownloadURI);
         }
 
         _pinotHelixResourceManager.refreshSegment(segmentMetadata, existingSegmentZKMetadata);
@@ -207,6 +207,8 @@ public class ZKOperator {
         LOGGER.error("Could not move segment {} from table {} to permanent directory", segmentName, rawTableName, e);
         throw new RuntimeException(e);
       }
+    } else {
+      LOGGER.info("Skipping segment move, keeping segment {} from table {} at {}", segmentName, rawTableName, zkDownloadURI);
     }
     _pinotHelixResourceManager.addNewSegment(segmentMetadata, zkDownloadURI, crypter);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/upload/ZKOperator.java
@@ -79,14 +79,14 @@ public class ZKOperator {
   }
 
   private void processExistingSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
-      File currentSegmentLocation, boolean enableParallelPushProtection, HttpHeaders headers, String downloadURI,
+      File currentSegmentLocation, boolean enableParallelPushProtection, HttpHeaders headers, String zkDownloadURI,
       String offlineTableName, String segmentName, ZNRecord znRecord, boolean moveSegmentToFinalLocation) throws Exception {
 
     OfflineSegmentZKMetadata existingSegmentZKMetadata = new OfflineSegmentZKMetadata(znRecord);
     long existingCrc = existingSegmentZKMetadata.getCrc();
 
     // Set the download URL.
-    existingSegmentZKMetadata.setDownloadUrl(downloadURI);
+    existingSegmentZKMetadata.setDownloadUrl(zkDownloadURI);
 
     // Set the crypter name (even if null, so it can be removed from metadata).
     String crypter = headers.getHeaderString(FileUploadDownloadClient.CustomHeaders.CRYPTER);
@@ -161,6 +161,8 @@ public class ZKOperator {
         if (moveSegmentToFinalLocation) {
           moveSegmentToPermanentDirectory(currentSegmentLocation, finalSegmentLocationURI);
           LOGGER.info("Moved segment {} from temp location {} to {}", segmentName, currentSegmentLocation.getAbsolutePath(), finalSegmentLocationURI.getPath());
+        } else {
+          LOGGER.info("Skipping segment move, keeping segment at {}", zkDownloadURI);
         }
 
         _pinotHelixResourceManager.refreshSegment(segmentMetadata, existingSegmentZKMetadata);


### PR DESCRIPTION
* The new segment upload behavior is not backwards compatible with the old segment upload behavior in that the new one creates its own final location URI and will move the segment to this location while the old one took the header offered as the final location
* To remedy this, I am adding 2 endpoints, an old endpoint /segments and /v2/segments for the new segment upload (with the move) with an upload_version header.
* The old segment upload endpoint will still work if you call the old endpoint. I have also changed the default endpoints generated in our code to call the v2 endpoint.