### PR TITLE
[TE] frontend - ommitting failed alerts from list

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
@@ -101,11 +101,11 @@
     {{#if paginatedSelectedAlerts}}
       <section class="te-search-header">
         <span class="te-search-title">
-          Alerts Found({{selectedAlerts.length}})
+          Alerts Found({{totalFilteredAlerts}})
         </span>
         <span class="pull-right">
           Showing {{paginatedSelectedAlerts.length}} of
-          {{selectedAlerts.length}} {{if (gt selectedAlerts.length 1) 'alerts' 'alert'}}
+          {{totalFilteredAlerts}} {{if (gt totalFilteredAlerts 1) 'alerts' 'alert'}}
         </span>
       </section>
     {{/if}}


### PR DESCRIPTION
In our Alerts index page, we want to ensure we do not include alerts that are somehow not associated with any metric - basically blank. These should be filtered/cleaned up on the backend, but doesn't hurt to have a clean list on the front in the meantime.

<img width="903" alt="screen shot 2018-10-15 at 1 31 58 pm" src="https://user-images.githubusercontent.com/11814420/46970456-bbcc8680-d07e-11e8-9fa2-be55296fc2eb.png">

(tests passing locally)