### PR TITLE
[Clean up] Enhance TableSizeReader to reduce the logs

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -473,8 +473,8 @@ public class PinotSegmentRestletResource {
       try {
         resultForTable.put(FileUploadPathProvider.TABLE_NAME, tableNameWithType);
         // TODO: maybe better to put as json instead of json string
-        resultForTable.put("segments", objectMapper.writeValueAsString(
-            _pinotHelixResourceManager.getInstanceToSegmentsInATableMap(tableNameWithType)));
+        resultForTable.put("segments",
+            objectMapper.writeValueAsString(_pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType)));
       } catch (JSONException | JsonProcessingException e) {
         throw new ControllerApplicationException(LOGGER,
             "Caught JSON exception while getting instance to segments map for table: " + tableNameWithType,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -15,21 +15,16 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
 import com.linkedin.pinot.common.http.MultiGetRequest;
 import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
 import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
-import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import org.apache.commons.httpclient.ConnectTimeoutException;
-import org.apache.commons.httpclient.ConnectionPoolTimeoutException;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -43,34 +38,36 @@ import org.slf4j.LoggerFactory;
  * For servers returning errors (http error or otherwise), no entry is created in the return map
  */
 public class ServerTableSizeReader {
-  private static final Logger LOGGER = LoggerFactory.getLogger(
-      ServerTableSizeReader.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private final Executor executor;
-  private final HttpConnectionManager connectionManager;
+  private final Executor _executor;
+  private final HttpConnectionManager _connectionManager;
 
   public ServerTableSizeReader(Executor executor, HttpConnectionManager connectionManager) {
-    this.executor = executor;
-    this.connectionManager = connectionManager;
+    _executor = executor;
+    _connectionManager = connectionManager;
   }
 
-  public Map<String, List<SegmentSizeInfo>> getSizeDetailsFromServers(BiMap<String, String> serverEndPoints,
-      String table, int timeoutMsec) {
+  public Map<String, List<SegmentSizeInfo>> getSegmentSizeInfoFromServers(BiMap<String, String> serverEndPoints,
+      String tableNameWithType, int timeoutMs) {
+    int numServers = serverEndPoints.size();
+    LOGGER.info("Reading segment sizes from {} servers for table: {} with timeout: {}ms", numServers, tableNameWithType,
+        timeoutMs);
 
-    List<String> serverUrls = new ArrayList<>(serverEndPoints.size());
+    List<String> serverUrls = new ArrayList<>(numServers);
     BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
     for (String endpoint : endpointsToServers.keySet()) {
-      String tableSizeUri = "http://" + endpoint + "/table/" + table + "/size";
+      String tableSizeUri = "http://" + endpoint + "/table/" + tableNameWithType + "/size";
       serverUrls.add(tableSizeUri);
     }
 
-    MultiGetRequest mget = new MultiGetRequest(executor, connectionManager);
-    LOGGER.info("Reading segment sizes from {} servers for table: {}, timeoutMsec: {}", serverUrls.size(), table, timeoutMsec);
-    CompletionService<GetMethod> completionService = mget.execute(serverUrls, timeoutMsec);
+    // TODO: use some service other than completion service so that we know which server encounters the error
+    CompletionService<GetMethod> completionService =
+        new MultiGetRequest(_executor, _connectionManager).execute(serverUrls, timeoutMs);
+    Map<String, List<SegmentSizeInfo>> serverToSegmentSizeInfoListMap = new HashMap<>();
 
-    Map<String, List<SegmentSizeInfo>> serverSegmentSizes = new HashMap<>(serverEndPoints.size());
-
-    for (int i = 0; i < serverUrls.size(); i++) {
+    for (int i = 0; i < numServers; i++) {
       GetMethod getMethod = null;
       try {
         getMethod = completionService.take().get();
@@ -80,29 +77,25 @@ public class ServerTableSizeReader {
           LOGGER.error("Server: {} returned error: {}", instance, getMethod.getStatusCode());
           continue;
         }
-        TableSizeInfo tableSizeInfo = new ObjectMapper().readValue(getMethod.getResponseBodyAsString(), TableSizeInfo.class);
-        serverSegmentSizes.put(instance, tableSizeInfo.segments);
-      } catch (InterruptedException e) {
-        LOGGER.warn("Interrupted exception while reading segment size for table: {}", table, e);
-      } catch (ExecutionException e) {
-        if (Throwables.getRootCause(e) instanceof SocketTimeoutException) {
-          LOGGER.warn("Server request to read table size was timed out for table: {}.", table, e);
-        } else if (Throwables.getRootCause(e) instanceof ConnectTimeoutException) {
-          LOGGER.warn("Server request to read table size timed out waiting for connection. table: {}.", table, e);
-        } else if (Throwables.getRootCause(e) instanceof ConnectionPoolTimeoutException) {
-          LOGGER.warn("Server request to read table size timed out on getting a connection from pool, table: {}.", table, e);
-        } else {
-          LOGGER.warn("Execution exception while reading segment sizes for table: {}.", table, e);
-        }
-      } catch(Exception e) {
-        LOGGER.warn("Error while reading segment sizes for table: {}", table);
+        TableSizeInfo tableSizeInfo = OBJECT_MAPPER.readValue(getMethod.getResponseBodyAsStream(), TableSizeInfo.class);
+        serverToSegmentSizeInfoListMap.put(instance, tableSizeInfo.segments);
+      } catch (Exception e) {
+        // Ignore individual exceptions because the exception has been logged in MultiGetRequest
+        // Log the number of failed servers after gathering all responses
       } finally {
         if (getMethod != null) {
           getMethod.releaseConnection();
         }
       }
     }
-    LOGGER.info("Finished reading segment sizes for table: {}", table);
-    return serverSegmentSizes;
+
+    int numServersResponded = serverToSegmentSizeInfoListMap.size();
+    if (numServersResponded != numServers) {
+      LOGGER.warn("Finish reading segment sizes for table: {} with {}/{} servers responded", tableNameWithType,
+          numServersResponded, numServers);
+    } else {
+      LOGGER.info("Finish reading segment sizes for table: {}", tableNameWithType);
+    }
+    return serverToSegmentSizeInfoListMap;
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/ServerTableSizeReaderTest.java
@@ -150,7 +150,7 @@ public class ServerTableSizeReaderTest {
       endpoints.put(serverList.get(i), endpointList.get(i));
     }
     endpoints.put(serverList.get(5), endpointList.get(5));
-    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSizeDetailsFromServers(endpoints, "foo", timeoutMsec);
+    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSegmentSizeInfoFromServers(endpoints, "foo", timeoutMsec);
     Assert.assertEquals(serverSizes.size(), 3);
     Assert.assertTrue(serverSizes.containsKey(serverList.get(0)));
     Assert.assertTrue(serverSizes.containsKey(serverList.get(1)));
@@ -168,7 +168,7 @@ public class ServerTableSizeReaderTest {
     for (int i = 0; i < serverCount; i++) {
       endpoints.put(serverList.get(i), endpointList.get(i));
     }
-    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSizeDetailsFromServers(endpoints, "foo", timeoutMsec);
+    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSegmentSizeInfoFromServers(endpoints, "foo", timeoutMsec);
     Assert.assertEquals(serverSizes.size(), 3);
     Assert.assertTrue(serverSizes.containsKey(serverList.get(0)));
     Assert.assertTrue(serverSizes.containsKey(serverList.get(1)));

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -230,7 +230,7 @@ public class TableSizeReaderTest {
 
   private TableSizeReader.TableSizeDetails testRunner(final String[] servers, String table)
       throws InvalidConfigException {
-    when(helix.getInstanceToSegmentsInATableMap(anyString()))
+    when(helix.getServerToSegmentsMap(anyString()))
         .thenAnswer(new Answer<Object>() {
           @Override
           public Object answer(InvocationOnMock invocationOnMock)


### PR DESCRIPTION
1. In MultiGetRequest, log a warning for failed GET request (there is no way to get the failed url info from the caller side because we don't keep the order of URLS in CompletionService)
2. In TableSizeReader, if there are missing segments from all servers, log only one lines with all missing segments
3. Also fixed the issue where getResponseBodyAsStream should be used instead of getResponseBodyAsString for large size response