### PR TITLE
[TE] frontend - fixing width of custom date range picker input

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -26,6 +26,7 @@
 
 import Component from '@ember/component';
 import moment from 'moment';
+import { get, set } from '@ember/object';
 import { buildDateEod } from 'thirdeye-frontend/utils/utils';
 
 const RANGE_FORMAT = 'YYYY-MM-DD HH:mm';
@@ -43,6 +44,7 @@ export default Component.extend({
   timePickerIncrement: 5,
   activeRangeStart: '',
   activeRangeEnd: '',
+  uiDateFormat: 'MMM D, YYYY',
   serverFormat: RANGE_FORMAT,
 
   /**
@@ -52,6 +54,19 @@ export default Component.extend({
     'Today': [DEFAULT_END_DATE],
     'Last 1 month': [moment().subtract(1, 'months').startOf('day'), DEFAULT_END_DATE],
     'Last 2 months': [moment().subtract(2, 'months').startOf('day'), DEFAULT_END_DATE]
+  },
+
+  /**
+   * Pick a custom date range input class (width) based on the incoming date format
+   */
+  didReceiveAttrs() {
+    this._super(...arguments);
+    const uiDateFormat = get(this, 'uiDateFormat');
+    const pickerClassName = 'range-pill-selectors__range-picker';
+    let dateMode = 'default';
+    if (uiDateFormat.includes('h a')) { dateMode = 'hours' }
+    if (uiDateFormat.includes('hh:mm a')) { dateMode = 'minutes' }
+    set(this, 'inputClassName', `${pickerClassName} ${pickerClassName}--${dateMode}`);
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
@@ -4,8 +4,9 @@
     <li class="range-pill-selectors__item {{if range.isActive "range-pill-selectors__item--active"}}" {{action "onRangeOptionClick" range}} data-value={{range.value}}>
       {{range.name}}
       {{#if (eq range.name "Custom")}}
+        {{log "uiDateFormat: " uiDateFormat}}
         : {{date-range-picker
-            class="range-pill-selectors__range-picker range-pill-selectors__range-picker--explore"
+            class=inputClassName
             timePicker=true
             timePicker24Hour=true
             timePickerIncrement=timePickerIncrement

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -213,7 +213,7 @@ export default Controller.extend({
    * @type {String}
    */
   uiDateFormat: computed('alertData.windowUnit', function() {
-    const rawGranularity = this.get('alertData.windowUnit');
+    const rawGranularity = this.get('alertData.bucketUnit');
     const granularity = rawGranularity ? rawGranularity.toLowerCase() : '';
 
     switch(granularity) {

--- a/thirdeye/thirdeye-frontend/app/styles/components/range-pill-selectors.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/range-pill-selectors.scss
@@ -32,8 +32,15 @@
   &__range-picker {
     display: inline-block;
     color: app-shade(black, 7);
-    min-width: 290px;
     margin: 0;
+
+    &--minutes {
+      min-width: 290px;
+    }
+
+    &--hours {
+      min-width: 250px;
+    }
 
     .daterangepicker-input {
       background: none;
@@ -41,6 +48,7 @@
       box-shadow: none;
       padding: 3px 5px;
       height: auto;
+      margin-right: 15px;
 
       &:hover {
         cursor: pointer;

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -592,7 +592,6 @@ body {
 
   &__value-solo {
     color: app-shade(black, 5);
-    word-wrap: break-word;
     max-width: 340px;
     max-height: 65px;
     overflow: hidden;


### PR DESCRIPTION
Our custom time range picker input has several format modes throughout the app. Some are fixed, some are granularity-based. We now assign smarter classes to the `range-pill-selector` component to allow for a better width fit.

<img width="462" alt="screen shot 2018-10-15 at 5 26 52 pm" src="https://user-images.githubusercontent.com/11814420/46981897-d19e7380-d09f-11e8-9fda-f6e0f30d3ffa.png">
<img width="564" alt="screen shot 2018-10-15 at 5 26 58 pm" src="https://user-images.githubusercontent.com/11814420/46981905-d6fbbe00-d09f-11e8-8811-636b8e4aeb54.png">
<img width="578" alt="screen shot 2018-10-15 at 5 27 05 pm" src="https://user-images.githubusercontent.com/11814420/46981912-dbc07200-d09f-11e8-8238-58a57012d83d.png">
