### PR TITLE
Add method nonLeaderCleanUp() in PinotTaskManager and PinotTaskGenerator for necessary clean up after leadership change

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -96,6 +96,7 @@ public class PinotTaskManager {
       // Only schedule new tasks from leader controller
       if (!_helixResourceManager.isLeader()) {
         LOGGER.info("Skip scheduling new tasks on non-leader controller");
+        nonLeaderCleanUp();
         return;
       }
       scheduleTasks();
@@ -163,5 +164,14 @@ public class PinotTaskManager {
     }
 
     return tasksScheduled;
+  }
+
+  /**
+   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
+   */
+  private void nonLeaderCleanUp() {
+    for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
+      _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
+    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
@@ -129,4 +129,8 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
   public int getNumConcurrentTasksPerInstance() {
     return DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
   }
+
+  @Override
+  public void nonLeaderCleanUp() {
+  }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -50,4 +50,9 @@ public interface PinotTaskGenerator {
    * @return Maximum number of concurrent tasks allowed per instance
    */
   int getNumConcurrentTasksPerInstance();
+
+  /**
+   * Performs necessary cleanups (e.g. remove metrics) when the controller leadership changes.
+   */
+  void nonLeaderCleanUp();
 }


### PR DESCRIPTION
When controller leadership changes, we might want to perform some clean up job such as removing metrics.
This PR adds the methods to perform the clean up.