### PR TITLE
[TE] Customize offset in baseline rule detection & filter 

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleDetectionStage.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleDetectionStage.java
@@ -17,6 +17,7 @@
 package com.linkedin.thirdeye.detection.algorithm.stage;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.dashboard.resources.v2.BaselineParsingUtils;
 import com.linkedin.thirdeye.dataframe.BooleanSeries;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
@@ -48,14 +49,10 @@ public class BaselineRuleDetectionStage extends StaticAnomalyDetectionStage {
   private static final String COL_CHANGE = "change";
   private static final String COL_CHANGE_VIOLATION = "change_violation";
   private static final String COL_ANOMALY = "anomaly";
+  private static final String PROP_OFFSET = "offset";
+  private static final String PROP_OFFSET_DEFAULT = "median1w";
 
   private static final String PROP_METRIC_URN = "metricUrn";
-
-  private static final String PROP_AGGREGATION = "aggregation";
-  private static final String PROP_AGGREGATION_DEFAULT = "MEDIAN";
-
-  private static final String PROP_WEEKS = "weeks";
-  private static final int PROP_WEEKS_DEFAULT = 1;
 
   private static final String PROP_CHANGE = "change";
   private static final double PROP_CHANGE_DEFAULT = Double.NaN;
@@ -80,12 +77,10 @@ public class BaselineRuleDetectionStage extends StaticAnomalyDetectionStage {
     MetricEntity me = MetricEntity.fromURN(metricUrn);
     this.slice = MetricSlice.from(me.getId(), startTime, endTime, me.getFilters());
 
-    int weeks = MapUtils.getIntValue(specs, PROP_WEEKS, PROP_WEEKS_DEFAULT);
-    BaselineAggregateType
-        aggregation = BaselineAggregateType.valueOf(MapUtils.getString(specs, PROP_AGGREGATION, PROP_AGGREGATION_DEFAULT));
-    DateTimeZone timezone = DateTimeZone.forID(MapUtils.getString(specs, PROP_TIMEZONE, PROP_TIMEZONE_DEFAULT));
-    this.baseline = BaselineAggregate.fromWeekOverWeek(aggregation, weeks, 1, timezone);
+    String timezone = MapUtils.getString(specs, PROP_TIMEZONE, PROP_TIMEZONE_DEFAULT);
+    String offset = MapUtils.getString(specs, PROP_OFFSET, PROP_OFFSET_DEFAULT);
 
+    this.baseline = BaselineParsingUtils.parseOffset(offset, timezone);
     this.change = MapUtils.getDoubleValue(specs, PROP_CHANGE, PROP_CHANGE_DEFAULT);
     this.difference = MapUtils.getDoubleValue(specs, PROP_DIFFERENCE, PROP_DIFFERENCE_DEFAULT);
     this.configId = configId;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleFilterStage.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleFilterStage.java
@@ -18,6 +18,7 @@ package com.linkedin.thirdeye.detection.algorithm.stage;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
+import com.linkedin.thirdeye.dashboard.resources.v2.BaselineParsingUtils;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -39,11 +40,11 @@ import static com.linkedin.thirdeye.dataframe.util.DataFrameUtils.*;
  * This filter stage filters the anomalies if either the absolute changeThreshold, percentage changeThreshold or site wide impact does not pass the threshold.
  */
 public class BaselineRuleFilterStage implements AnomalyFilterStage {
-  private static final String PROP_WEEKS = "weeks";
-  private static final int PROP_WEEKS_DEFAULT = 1;
-
   private static final String PROP_CHANGE = "changeThreshold";
   private static final double PROP_CHANGE_DEFAULT = Double.NaN;
+
+  private static final String PROP_OFFSET = "offset";
+  private static final String PROP_OFFSET_DEFAULT = "median1w";
 
   private static final String PROP_DIFFERENCE = "differenceThreshold";
   private static final double PROP_DIFFERENCE_DEFAULT = Double.NaN;
@@ -93,10 +94,9 @@ public class BaselineRuleFilterStage implements AnomalyFilterStage {
 
   @Override
   public void init(Map<String, Object> properties, Long configId, long startTime, long endTime) {
-    int weeks = MapUtils.getIntValue(properties, PROP_WEEKS, PROP_WEEKS_DEFAULT);
-    DateTimeZone timezone =
-        DateTimeZone.forID(MapUtils.getString(properties, PROP_TIMEZONE, PROP_TIMEZONE_DEFAULT));
-    this.baseline = BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEDIAN, weeks, 1, timezone);
+    String offset = MapUtils.getString(properties, PROP_OFFSET, PROP_OFFSET_DEFAULT);
+    String timezone = MapUtils.getString(properties, PROP_TIMEZONE, PROP_TIMEZONE_DEFAULT);
+    this.baseline = BaselineParsingUtils.parseOffset(offset, timezone);
     // percentage changeThreshold
     this.changeThreshold = MapUtils.getDoubleValue(properties, PROP_CHANGE, PROP_CHANGE_DEFAULT);
     // absolute changeThreshold

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleDetectionStageTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleDetectionStageTest.java
@@ -42,11 +42,9 @@ import static com.linkedin.thirdeye.dataframe.util.DataFrameUtils.*;
 
 public class BaselineRuleDetectionStageTest {
   private static final String PROP_METRIC_URN = "metricUrn";
-  private static final String PROP_AGGREGATION = "aggregation";
-  private static final String PROP_WEEKS = "weeks";
+  private static final String PROP_OFFSET = "offset";
   private static final String PROP_CHANGE = "change";
   private static final String PROP_DIFFERENCE = "difference";
-  private static final String PROP_TIMEZONE = "timezone";
 
   private DataProvider provider;
   private DetectionPipeline detectionPipeline;
@@ -120,8 +118,7 @@ public class BaselineRuleDetectionStageTest {
 
   @Test
   public void testThreeWeekMedianChange() throws Exception {
-    this.stageSpecs.put(PROP_WEEKS, 3);
-    this.stageSpecs.put(PROP_AGGREGATION, BaselineAggregateType.MEDIAN.toString());
+    this.stageSpecs.put(PROP_OFFSET, "median3w");
     this.stageSpecs.put(PROP_CHANGE, 0.3);
     this.detectionPipeline = new AnomalyDetectionStageWrapper(this.provider, this.config, 1814400000L, 2419200000L);
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/algorithm/stage/BaselineRuleFilterTest.java
@@ -16,8 +16,6 @@
 
 package com.linkedin.thirdeye.detection.algorithm.stage;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -98,6 +96,7 @@ public class BaselineRuleFilterTest {
     this.properties = new HashMap<>();
     this.properties.put("nested", Collections.singletonList(Collections.singletonMap("className", "dummy")));
     this.properties.put("stageClassName", BaselineRuleFilterStage.class.getName());
+    this.properties.put("offset", "median1w");
     this.specs = new HashMap<>();
 
     this.properties.put("specs", specs);


### PR DESCRIPTION
Add the capability of configuring baseline detection and filter stage in a readable way, e.x. WoW, meadian4w, etc.