### PR TITLE
[TE] frontend - bug fix for edit alerts modal

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/modals/manage-groups-modal/component.js
@@ -250,7 +250,11 @@ export default Component.extend({
     const { preselectedFunctionId, groupOptionsRaw } =
       getProperties(this, 'preselectedFunctionId', 'groupOptionsRaw');
 
-    return groupOptionsRaw.filter(group => group.emailConfig.functionIds.includes(preselectedFunctionId));
+    return groupOptionsRaw.filter((group) => {
+      if (group.emailConfig && group.emailConfig.functionIds) {
+        return group.emailConfig.functionIds.includes(preselectedFunctionId);
+      }
+    });
   }),
 
   /**


### PR DESCRIPTION
Needed a less rigid approach to a subscription groups filter in the edit alerts modal (avoid filtering on missing properties).

<img width="1305" alt="screen shot 2018-10-17 at 3 55 11 pm" src="https://user-images.githubusercontent.com/11814420/47120920-7ac2a680-d225-11e8-8493-acd35f5ebb75.png">
