### PR TITLE
In TableConfig, put initial value for TenantConfig and TableCustomConfig to follow the nonnull annotation

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
@@ -78,7 +78,11 @@ public class TableConfig {
   @NestedConfig
   private RoutingConfig _routingConfig;
 
-  public TableConfig() {}
+  public TableConfig() {
+    // TODO: currently these 2 fields are annotated as non-null. Revisit to see whether that's necessary
+    _tenantConfig = new TenantConfig();
+    _customConfig = new TableCustomConfig();
+  }
 
   private TableConfig(@Nonnull String tableName, @Nonnull TableType tableType,
       @Nonnull SegmentsValidationAndRetentionConfig validationConfig, @Nonnull TenantConfig tenantConfig,


### PR DESCRIPTION
Currently, if we deserialize TableConfig using the new config Deserializer, these 2 fields might be left null