### PR TITLE
Refactor stream config properties related constants

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -127,8 +127,7 @@ public class RoutingTableBuilderFactory {
         // Check that the table uses LLC kafka consumer.
         StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
 
-        if (streamConfig.getConsumerTypes().size() == 1 && streamConfig.getConsumerTypes().get(0)
-            == CommonConstants.Helix.DataSource.Realtime.Kafka.ConsumerType.simple) {
+        if (streamConfig.getConsumerTypes().size() == 1 && streamConfig.hasLowLevelConsumerType()) {
           builder = new PartitionAwareRealtimeRoutingTableBuilder();
         } else {
           builder = new DefaultRealtimeRoutingTableBuilder();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.common.utils;
 
 import com.linkedin.pinot.common.response.BrokerResponseFactory;
 import java.io.File;
-import org.apache.commons.lang.StringUtils;
 
 
 public class CommonConstants {
@@ -64,9 +63,6 @@ public class CommonConstants {
     }
 
     public static class DataSource {
-      public static final String SCHEMA = "schema";
-      public static final String KAFKA = "kafka";
-      public static final String STREAM_PREFIX = "stream";
       public enum SegmentAssignmentStrategyType {
         RandomAssignmentStrategy,
         BalanceNumSegmentAssignmentStrategy,
@@ -84,117 +80,9 @@ public class CommonConstants {
         PartitionAwareRealtime
       }
 
-      public static class Schema {
-        public static final String COLUMN_NAME = "columnName";
-        public static final String DATA_TYPE = "dataType";
-        public static final String DELIMETER = "delimeter";
-        public static final String IS_SINGLE_VALUE = "isSingleValue";
-        public static final String FIELD_TYPE = "fieldType";
-        public static final String TIME_UNIT = "timeUnit";
-      }
-
-      public static class Realtime {
-        public static final String STREAM_TYPE = "streamType";
-        // Time threshold that will keep the realtime segment open for before we convert it into an offline segment
-        public static final String REALTIME_SEGMENT_FLUSH_TIME = "realtime.segment.flush.threshold.time";
-        // Time threshold that controller will wait for the segment to be built by the server
-        public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
-        /**
-         * Row count flush threshold for realtime segments. This behaves in a similar way for HLC and LLC. For HLC,
-         * since there is only one consumer per server, this size is used as the size of the consumption buffer and
-         * determines after how many rows we flush to disk. For example, if this threshold is set to two million rows,
-         * then a high level consumer would have a buffer size of two million.
-         *
-         * For LLC, this size is divided across all the segments assigned to a given server and is set on a per segment
-         * basis. Assuming a low level consumer server is assigned four Kafka partitions to consume from and a flush
-         * size of two million, then each consuming segment would have a flush size of five hundred thousand rows, for a
-         * total of two million rows in memory.
-         *
-         * Keep in mind that this NOT a hard threshold, as other tables can also be assigned to this server, and that in
-         * certain conditions (eg. if the number of servers, replicas of Kafka partitions changes) where Kafka partition
-         * to server assignment changes, it's possible to end up with more (or less) than this number of rows in memory.
-         *
-         * If this value is set to 0, then the consumers adjust the number of rows consumed by a partition such that
-         * the size of the completed segment is the desired size (see REALTIME_DESIRED_SEGMENT_SIZE), unless
-         * REALTIME_SEGMENT_FLUSH_TIME is reached first)
-         */
-        public static final String REALTIME_SEGMENT_FLUSH_SIZE = "realtime.segment.flush.threshold.size";
-        /*
-         * The desired size of a completed realtime segment.
-         * This config is used only if REALTIME_SEGMENT_FLUSH_SIZE (or REALTIME_SEGMENT_FLUSH_SIZE  + ".llc") is set
-         * to 0. Default value of REALTIME_SEGMENT_FLUSH_SIZE is "200M". Values are parsed using DataSize class.
-         *
-         * The value for this configuration should be chosen based on the amount of memory available on consuming
-         * machines, the number of completed segments that are expected to be resident on the machine and the amount
-         * of memory used by consuming machines. In other words:
-         *
-         *    numPartitionsInMachine * (consumingPartitionMemory + numPartitionsRetained * REALTIME_DESIRED_SEGMENT_SIZE)
-         *
-         * must be less than or equal to the total memory available to store pinot data.
-         *
-         * Note that consumingPartitionMemory will vary depending on the rows that are consumed.
-         *
-         * Not included here is any heap memory used (currently inverted index uses heap memory for consuming partitions).
-         */
-        public static final String REALTIME_DESIRED_SEGMENT_SIZE = "realtime.segment.flush.desired.size";
-        public static final String LLC_PROPERTY_SUFFIX = ".llc";
-        public static final String LLC_REALTIME_SEGMENT_FLUSH_SIZE = REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX;
-        public static final String LLC_REALTIME_SEGMENT_FLUSH_TIME = REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX;
-
-        public static enum StreamType {
-          kafka
-        }
-
-        public static class Kafka {
-
-          public static enum ConsumerType {
-            simple,
-            highLevel
-          }
-
-          public static final String TOPIC_NAME = "kafka.topic.name";
-          public static final String CONSUMER_TYPE = "kafka.consumer.type";
-          public static final String DECODER_CLASS = "kafka.decoder.class.name";
-          public static final String DECODER_PROPS_PREFIX = "kafka.decoder.prop";
-          public static final String KAFKA_CONSUMER_PROPS_PREFIX = "kafka.consumer.prop";
-          public static final String KAFKA_CONNECTION_TIMEOUT_MILLIS = "kafka.connection.timeout.ms";
-          public static final String KAFKA_FETCH_TIMEOUT_MILLIS = "kafka.fetch.timeout.ms";
-          public static final String ZK_BROKER_URL = "kafka.zk.broker.url";
-          public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
-          public static final String CONSUMER_FACTORY = "kafka.consumer.factory.class.name";
-
-          // Consumer properties
-          public static final String AUTO_OFFSET_RESET = "auto.offset.reset";
-
-          public static String getDecoderPropertyKeyFor(String key) {
-            return StringUtils.join(new String[] { DECODER_PROPS_PREFIX, key }, ".");
-          }
-
-          public static String getDecoderPropertyKey(String incoming) {
-            return incoming.split(DECODER_PROPS_PREFIX + ".")[1];
-          }
-
-          public static String getConsumerPropertyKey(String incoming) {
-            return incoming.split(KAFKA_CONSUMER_PROPS_PREFIX + ".")[1];
-          }
-
-          public static class HighLevelConsumer {
-            public static final String ZK_CONNECTION_STRING = "kafka.hlc.zk.connect.string";
-            public static final String GROUP_ID = "kafka.hlc.group.id";
-          }
-
-          public static class ConsumerFactory {
-            public static final String SIMPLE_CONSUMER_FACTORY_STRING = "com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory";
-          }
-        }
-      }
-
     }
 
     public static class Instance {
-      public static final String INSTANCE_NAME = "instance.name";
-      public static final String GROUP_ID_SUFFIX = "kafka.hlc.groupId";
-      public static final String PARTITION_SUFFIX = "kafka.hlc.partition";
       public static final String INSTANCE_ID_KEY = "instanceId";
       public static final String DATA_DIR_KEY = "dataDir";
       public static final String ADMIN_PORT_KEY = "adminPort";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -368,8 +368,8 @@ public class PinotTableRestletResource {
         String errorMsg = String.format("Invalid tableIndexConfig or streamConfig: %s", e.getMessage());
         throw new PinotHelixResourceManager.InvalidTableConfigException(errorMsg, e);
       }
-      verifyReplicasPerPartition = streamConfig.hasSimpleKafkaConsumerType();
-      verifyReplication = streamConfig.hasHighLevelKafkaConsumerType();
+      verifyReplicasPerPartition = streamConfig.hasLowLevelConsumerType();
+      verifyReplication = streamConfig.hasHighLevelConsumerType();
     }
 
     if (verifyReplication) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1206,8 +1206,8 @@ public class PinotHelixResourceManager {
     StreamConfig streamConfig = new StreamConfig(indexingConfig.getStreamConfigs());
     IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, realtimeTableName);
 
-    if (streamConfig.hasHighLevelKafkaConsumerType()) {
-      if (streamConfig.hasSimpleKafkaConsumerType()) {
+    if (streamConfig.hasHighLevelConsumerType()) {
+      if (streamConfig.hasLowLevelConsumerType()) {
         // We may be adding on low-level, or creating both.
         if (idealState == null) {
           // Need to create both. Create high-level consumer first.
@@ -1225,7 +1225,7 @@ public class PinotHelixResourceManager {
     }
 
     // Either we have only low-level consumer, or both.
-    if (streamConfig.hasSimpleKafkaConsumerType()) {
+    if (streamConfig.hasLowLevelConsumerType()) {
       // Will either create idealstate entry, or update the IS entry with new segments
       // (unless there are low-level segments already present)
       final List<LLCRealtimeSegmentZKMetadata> llcSegmentMetadatas =

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -21,11 +21,11 @@ import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
 import com.linkedin.pinot.core.realtime.stream.PartitionCountFetcher;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.List;
@@ -146,7 +146,7 @@ public class PinotTableIdealStateBuilder {
       return partitionCountFetcher.getPartitionCount();
     } catch (Exception e) {
       Exception fetcherException = partitionCountFetcher.getException();
-      LOGGER.error("Could not get partition count for {}", streamConfig.getKafkaTopicName(), fetcherException);
+      LOGGER.error("Could not get partition count for {}", streamConfig.getTopicName(), fetcherException);
       throw new RuntimeException(fetcherException);
     }
   }
@@ -193,9 +193,8 @@ public class PinotTableIdealStateBuilder {
 
   private static String getGroupIdFromRealtimeDataTable(String realtimeTableName,
       Map<String, String> streamProviderConfig) {
-    String keyOfGroupId =
-        StringUtil
-            .join(".", Helix.DataSource.STREAM_PREFIX, Helix.DataSource.Realtime.Kafka.HighLevelConsumer.GROUP_ID);
+    String keyOfGroupId = KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_GROUP_ID);
     String groupId = StringUtil.join("_", realtimeTableName, System.currentTimeMillis() + "");
     if (streamProviderConfig.containsKey(keyOfGroupId) && !streamProviderConfig.get(keyOfGroupId).isEmpty()) {
       groupId = streamProviderConfig.get(keyOfGroupId);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -55,6 +55,7 @@ import com.linkedin.pinot.core.realtime.segment.ConsumingSegmentAssignmentStrate
 import com.linkedin.pinot.core.realtime.segment.RealtimeSegmentAssignmentStrategy;
 import com.linkedin.pinot.core.realtime.stream.PartitionOffsetFetcher;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
@@ -619,10 +620,8 @@ public class PinotLLCRealtimeSegmentManager {
     }
     TableConfig tableConfig = getRealtimeTableConfig(tableName);
     final Map<String, String> streamConfigs = tableConfig.getIndexingConfig().getStreamConfigs();
-    if (streamConfigs != null && streamConfigs.containsKey(
-        CommonConstants.Helix.DataSource.Realtime.SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
-      final String commitTimeoutSecondsStr =
-          streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.SEGMENT_COMMIT_TIMEOUT_SECONDS);
+    if (streamConfigs != null && streamConfigs.containsKey(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
+      final String commitTimeoutSecondsStr = streamConfigs.get(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS);
       try {
         return TimeUnit.MILLISECONDS.convert(Integer.parseInt(commitTimeoutSecondsStr), TimeUnit.SECONDS);
       } catch (Exception e) {
@@ -702,7 +701,7 @@ public class PinotLLCRealtimeSegmentManager {
       return partitionOffsetFetcher.getOffset();
     } catch (Exception e) {
       Exception fetcherException = partitionOffsetFetcher.getException();
-      LOGGER.error("Could not get offset for topic {} partition {}, criteria {}", streamConfig.getKafkaTopicName(),
+      LOGGER.error("Could not get offset for topic {} partition {}, criteria {}", streamConfig.getTopicName(),
           partitionId, offsetCriteria, fetcherException);
       throw new RuntimeException(fetcherException);
     }
@@ -941,8 +940,7 @@ public class PinotLLCRealtimeSegmentManager {
       newPartitions.add(partition);
     }
 
-    String offsetCriteria = streamConfig.getKafkaConsumerProperties()
-        .get(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET);
+    String offsetCriteria = streamConfig.getOffsetCriteria();
     Set<String> consumingSegments =
         setupNewPartitions(tableConfig, streamConfig, offsetCriteria, partitionAssignment, newPartitions, now);
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -131,7 +131,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
       }
 
       StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
-      if (metadata.hasHighLevelKafkaConsumerType()) {
+      if (metadata.hasHighLevelConsumerType()) {
         idealStateMap.put(realtimeTableName, _pinotHelixResourceManager.getHelixAdmin()
             .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), realtimeTableName));
       } else {
@@ -329,7 +329,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfig.fromZnRecord(tableConfigZnRecord);
           StreamConfig metadata = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
-          if (metadata.hasHighLevelKafkaConsumerType()) {
+          if (metadata.hasHighLevelConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -87,7 +87,7 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
 
     if (tableConfig.getTableType().equals(CommonConstants.Helix.TableType.REALTIME)) {
       StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
-      if (!streamConfig.hasSimpleKafkaConsumerType()) {
+      if (!streamConfig.hasLowLevelConsumerType()) {
         LOGGER.info("Table {} does not have LLC and will have no partition assignment", tableNameWithType);
         return newPartitionAssignment;
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -277,7 +277,7 @@ public class ValidationManager {
         _pinotHelixResourceManager.getRealtimeSegmentMetadata(realtimeTableName);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
     StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
-    if (streamConfig.hasSimpleKafkaConsumerType() && !streamConfig.hasHighLevelKafkaConsumerType()) {
+    if (streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType()) {
       countHLCSegments = false;
     }
     // Update the gauge to contain the total document count in the segments

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -17,13 +17,14 @@ package com.linkedin.pinot.controller.api.resources;
 
 import com.linkedin.pinot.common.config.QuotaConfig;
 import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.Realtime.Kafka;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
 import com.linkedin.pinot.controller.helix.ControllerTest;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
@@ -73,14 +74,18 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     addDummySchema(REALTIME_TABLE_NAME);
 
     Map<String, String> streamConfigs = new HashMap<>();
-    streamConfigs.put("streamType", "kafka");
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.highLevel.toString());
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.TOPIC_NAME, "fakeTopic");
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS, "fakeClass");
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, "fakeUrl");
-    streamConfigs.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1234));
+    String streamType = "kafka";
+    streamConfigs.put(StreamConfigProperties.STREAM_TYPE, streamType);
     streamConfigs.put(
-        DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET, "smallest");
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        StreamConfig.ConsumerType.HIGHLEVEL.toString());
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), "fakeTopic");
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS), "fakeClass");
+    streamConfigs.put(KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_ZK_CONNECTION_STRING), "fakeUrl");
+    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, Integer.toString(1234));
+    streamConfigs.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), "smallest");
     _realtimeBuilder.setTableName(REALTIME_TABLE_NAME)
         .setTimeColumnName("timeColumn")
         .setTimeType("DAYS")

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableViewsTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableViewsTest.java
@@ -19,11 +19,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
 import com.linkedin.pinot.controller.helix.ControllerTest;
 import com.linkedin.pinot.controller.utils.SegmentMetadataMockUtils;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
@@ -71,8 +72,14 @@ public class TableViewsTest extends ControllerTest {
     // add schema for realtime table
     addDummySchema(HYBRID_TABLE_NAME);
     Map<String, String> streamConfigs = new HashMap<>();
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + DataSource.Realtime.Kafka.CONSUMER_TYPE,
-        DataSource.Realtime.Kafka.ConsumerType.highLevel.toString());
+    String streamType = "kafka";
+    String topic = "aTopic";
+    streamConfigs.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    streamConfigs.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigs.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        StreamConfig.ConsumerType.HIGHLEVEL.toString());
     tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME).setTableName(HYBRID_TABLE_NAME)
         .setNumReplicas(2)
         .setStreamConfigs(streamConfigs)

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -33,14 +33,15 @@ import com.linkedin.pinot.common.partition.StreamPartitionAssignmentGenerator;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
-import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.api.resources.LLCSegmentCompletionHandlers;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
@@ -145,7 +146,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     invalidConfig = true;
     testSetupNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, invalidConfig, badStream);
 
-    // bad stream configs
+    /*// bad stream configs
     badStream = true;
     tableConfig =
         makeTableConfig(tableName, nReplicas, null, null, DEFAULT_SERVER_TENANT);
@@ -153,7 +154,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     nPartitions = 4;
     instances = getInstanceList(3);
     testSetupNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, invalidConfig, badStream);
-
+*/
     // noop path - 0 partitions
     badStream = false;
     tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_LARGEST_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT);
@@ -1170,16 +1171,20 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(mockValidationConfig.getReplicasPerPartitionNumber()).thenReturn(nReplicas);
     when(mockTableConfig.getValidationConfig()).thenReturn(mockValidationConfig);
     Map<String, String> streamConfigMap = new HashMap<>(1);
-    streamConfigMap.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE,
-        "100000");
-    streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "simple");
-    streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), autoOffsetReset);
+    String streamType = "kafka";
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    String topic = "aTopic";
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigMap.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "100000");
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        "simple");
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), autoOffsetReset);
 
-    final String bootstrapHostConfigKey = CommonConstants.Helix.DataSource.STREAM_PREFIX + "."
-        + CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST;
+    final String bootstrapHostConfigKey = KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST);
     streamConfigMap.put(bootstrapHostConfigKey, bootstrapHosts);
 
     IndexingConfig mockIndexConfig = mock(IndexingConfig.class);
@@ -1195,13 +1200,18 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
   private static Map<String, String> getStreamConfigs() {
     Map<String, String> streamPropMap = new HashMap<>(1);
-    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "simple");
-    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), "smallest");
-    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST), "host:1234");
+    String streamType = "kafka";
+    streamPropMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    String topic = "aTopic";
+    streamPropMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamPropMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        "simple");
+    streamPropMap.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), "smallest");
+    streamPropMap.put(KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST), "host:1234");
     return streamPropMap;
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -146,21 +146,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
     invalidConfig = true;
     testSetupNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, invalidConfig, badStream);
 
-    /*// bad stream configs
-    badStream = true;
-    tableConfig =
-        makeTableConfig(tableName, nReplicas, null, null, DEFAULT_SERVER_TENANT);
-    idealState = idealStateBuilder.build();
-    nPartitions = 4;
-    instances = getInstanceList(3);
-    testSetupNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, invalidConfig, badStream);
-*/
     // noop path - 0 partitions
     badStream = false;
     tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_LARGEST_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT);
     idealState = idealStateBuilder.build();
     nPartitions = 0;
     invalidConfig = false;
+    instances = getInstanceList(3);
     testSetupNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, invalidConfig, badStream);
 
     // noop path - ideal state disabled - this can happen in the code path only if there is already an idealstate with HLC segments in it, and it has been disabled.

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceStrategyTest.java
@@ -26,8 +26,8 @@ import com.linkedin.pinot.common.partition.IdealStateBuilderUtil;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.partition.StreamPartitionAssignmentGenerator;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -593,8 +593,14 @@ public class DefaultRebalanceStrategyTest {
     when(mockTableConfig.getTableType()).thenReturn(tableTypeFromTableName);
 
     Map<String, String> streamConfigMap = new HashMap<>(1);
-    streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), consumerTypesCSV);
+    String streamType = "kafka";
+    String topic = "aTopic";
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        consumerTypesCSV);
     IndexingConfig mockIndexConfig = mock(IndexingConfig.class);
     when(mockIndexConfig.getStreamConfigs()).thenReturn(streamConfigMap);
     when(mockTableConfig.getIndexingConfig()).thenReturn(mockIndexConfig);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -168,7 +168,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     String clientId =
-        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getKafkaTopicName();
+        HLRealtimeSegmentDataManager.class.getSimpleName() + "-" + _streamConfig.getTopicName();
     _streamLevelConsumer = _streamConsumerFactory.createStreamLevelConsumer(clientId, schema);
     // TODO: define a contract for StreamLevelConsumer.init() or get rid of it completely
     // A future refactoring work of unifying StreamConfig and StreamProviderConfig should give some clarity into this

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/StreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/StreamProviderConfig.java
@@ -18,16 +18,11 @@ package com.linkedin.pinot.core.realtime;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
-import java.util.Map;
 
 
 public interface StreamProviderConfig {
 
-  void init(Map<String, String> properties, Schema schema);
-
   void init(TableConfig tableConfig, InstanceZKMetadata instanceMetadata, Schema schema);
-
-  String getStreamProviderClass();
 
   Schema getSchema();
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaConnectionHandler.java
@@ -102,8 +102,8 @@ public class KafkaConnectionHandler {
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = streamConfig.getKafkaTopicName();
-    _connectTimeoutMillis = streamConfig.getKafkaConnectionTimeoutMillis();
+    _topic = streamConfig.getTopicName();
+    _connectTimeoutMillis = streamConfig.getConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = false;
@@ -123,8 +123,8 @@ public class KafkaConnectionHandler {
       KafkaSimpleConsumerFactory simpleConsumerFactory) {
     _simpleConsumerFactory = simpleConsumerFactory;
     _clientId = clientId;
-    _topic = streamConfig.getKafkaTopicName();
-    _connectTimeoutMillis = streamConfig.getKafkaConnectionTimeoutMillis();
+    _topic = streamConfig.getTopicName();
+    _connectTimeoutMillis = streamConfig.getConnectionTimeoutMillis();
     _simpleConsumer = null;
 
     isPartitionProvided = true;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -140,13 +140,13 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
     this.kafkaConsumerProps = kafkaMetadata.getKafkaConsumerProperties();
     this.zkString = kafkaMetadata.getZkBrokerUrl();
 
-    String flushThresholdRowsProperty = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS;
+    final String flushThresholdRowsProperty = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS;
     if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(flushThresholdRowsProperty)) {
       realtimeRecordsThreshold =
           Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(flushThresholdRowsProperty));
     }
 
-    String flushThresholdTimeProperty = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME;
+    final String flushThresholdTimeProperty = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME;
     if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(flushThresholdTimeProperty)) {
       segmentTimeInMillis =
           convertToMs(tableConfig.getIndexingConfig().getStreamConfigs().get(flushThresholdTimeProperty));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
@@ -19,9 +19,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.DataSize;
-import java.util.Map;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,39 +41,31 @@ public class KafkaLowLevelStreamProviderConfig extends KafkaHighLevelStreamProvi
   public void init(TableConfig tableConfig, InstanceZKMetadata instanceMetadata, Schema schema) {
     super.init(tableConfig, instanceMetadata, schema);
 
-    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
+    String flushThresholdRowsProperty =
+        StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS + StreamConfigProperties.LLC_SUFFIX;
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(flushThresholdRowsProperty)) {
       llcRealtimeRecordsThreshold =
-          Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE));
+          Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(flushThresholdRowsProperty));
     }
 
-    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME)) {
+    String flushThresholdTimeProperty =
+        StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME + StreamConfigProperties.LLC_SUFFIX;
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(flushThresholdTimeProperty)) {
       llcSegmentTimeInMillis =
-          Long.parseLong(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME));
+          Long.parseLong(tableConfig.getIndexingConfig().getStreamConfigs().get(flushThresholdTimeProperty));
     }
 
-    String desiredSegmentSizeStr = tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_DESIRED_SEGMENT_SIZE);
+    String desiredSegmentSizeStr =
+        tableConfig.getIndexingConfig().getStreamConfigs().get(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE);
     if (desiredSegmentSizeStr != null) {
-      long longVal = DataSize.toBytes(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_DESIRED_SEGMENT_SIZE));
+      long longVal = DataSize.toBytes(
+          tableConfig.getIndexingConfig().getStreamConfigs().get(StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE));
       if (longVal > 0) {
         desiredSegmentSizeBytes = longVal;
       } else {
-        LOGGER.warn("Invalid value '{}' for {}. Ignored", desiredSegmentSizeStr, CommonConstants.Helix.DataSource.Realtime.REALTIME_DESIRED_SEGMENT_SIZE);
+        LOGGER.warn("Invalid value '{}' for {}. Ignored", desiredSegmentSizeStr,
+            StreamConfigProperties.SEGMENT_FLUSH_DESIRED_SIZE);
       }
-    }
-  }
-
-  @Override
-  public void init(Map<String, String> properties, Schema schema) {
-    super.init(properties, schema);
-
-    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
-      llcRealtimeRecordsThreshold =
-          Integer.parseInt(properties.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE));
-    }
-
-    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME)) {
-      llcSegmentTimeInMillis =
-          convertToMs(properties.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME));
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
 import com.google.common.base.Joiner;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaStreamConfigProperties.java
@@ -1,0 +1,41 @@
+package com.linkedin.pinot.core.realtime.impl.kafka;
+
+import com.google.common.base.Joiner;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
+
+
+/**
+ * Property key definitions for all kafka stream related properties
+ */
+public class KafkaStreamConfigProperties {
+  public static final String DOT_SEPARATOR = ".";
+  public static final String STREAM_TYPE = "kafka";
+
+  public static class HighLevelConsumer {
+    public static final String KAFKA_HLC_ZK_CONNECTION_STRING = "kafka.hlc.zk.connect.string";
+    public static final String KAFKA_HLC_GROUP_ID = "kafka.hlc.group.id";
+    public static final String ZK_SESSION_TIMEOUT_MS = "zookeeper.session.timeout.ms";
+    public static final String ZK_CONNECTION_TIMEOUT_MS = "zookeeper.connection.timeout.ms";
+    public static final String ZK_SYNC_TIME_MS = "zookeeper.sync.time.ms";
+    public static final String REBALANCE_MAX_RETRIES = "rebalance.max.retries";
+    public static final String REBALANCE_BACKOFF_MS = "rebalance.backoff.ms";
+    public static final String AUTO_COMMIT_ENABLE = "auto.commit.enable";
+    public static final String AUTO_OFFSET_RESET = "auto.offset.reset";
+  }
+
+  public static class LowLevelConsumer {
+    public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
+  }
+
+  public static final String KAFKA_CONSUMER_PROP_PREFIX = "kafka.consumer.prop";
+
+  /**
+   * Helper method to create a property string for kafka stream
+   * @param property
+   * @return
+   */
+  public static String constructStreamProperty(String property) {
+    return Joiner.on(DOT_SEPARATOR).join(StreamConfigProperties.STREAM_PREFIX, property);
+  }
+}
+

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionCountFetcher.java
@@ -35,7 +35,7 @@ public class PartitionCountFetcher implements Callable<Boolean> {
   public PartitionCountFetcher(StreamConfig streamConfig) {
     _streamConfig = streamConfig;
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
-    _topicName = streamConfig.getKafkaTopicName();
+    _topicName = streamConfig.getTopicName();
   }
 
   public int getPartitionCount() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/PartitionOffsetFetcher.java
@@ -42,7 +42,7 @@ public class PartitionOffsetFetcher implements Callable<Boolean> {
     _partitionId = partitionId;
     _streamConfig = streamConfig;
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
-    _topicName = streamConfig.getKafkaTopicName();
+    _topicName = streamConfig.getTopicName();
   }
 
   public long getOffset() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
@@ -76,7 +76,7 @@ public class StreamConfig {
     Preconditions.checkNotNull(_streamType,
         "Must provide stream type in property " + StreamConfigProperties.STREAM_TYPE);
 
-    String streamTopicProperty =
+    final String streamTopicProperty =
         StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_TOPIC_NAME);
     _topicName = streamConfigMap.get(streamTopicProperty);
     Preconditions.checkNotNull(_topicName, "Must provide stream topic name in property " + streamTopicProperty);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfig.java
@@ -15,24 +15,21 @@
  */
 package com.linkedin.pinot.core.realtime.stream;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import com.google.common.base.Splitter;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.Realtime.Kafka.ConsumerType;
-import com.linkedin.pinot.common.utils.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
-import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
+import static com.linkedin.pinot.common.utils.EqualityUtils.*;
 
 
 /*
@@ -50,128 +47,161 @@ import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
 public class StreamConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamConfig.class);
 
-  private final String _kafkaTopicName;
+  private final String _streamType;
+  private final String _topicName;
   private final List<ConsumerType> _consumerTypes = new ArrayList<>(2);
+  private final String _offsetCriteria;
   private final String _zkBrokerUrl;
   private final String _bootstrapHosts;
   private final String _decoderClass;
   private String _consumerFactoryName;
-  private final long _kafkaConnectionTimeoutMillis;
-  private final int _kafkaFetchTimeoutMillis;
+  private final long _connectionTimeoutMillis;
+  private final int _fetchTimeoutMillis;
   private final Map<String, String> _decoderProperties = new HashMap<String, String>();
   private final Map<String, String> _kafkaConsumerProperties = new HashMap<String, String>();
   private final Map<String, String> _streamConfigMap = new HashMap<String, String>();
 
-  private static final long DEFAULT_KAFKA_CONNECTION_TIMEOUT_MILLIS = 30000L;
-  private static final int DEFAULT_KAFKA_FETCH_TIMEOUT_MILLIS = 5000;
+  private static final long DEFAULT_CONNECTION_TIMEOUT_MILLIS = 30000L;
+  private static final int DEFAULT_FETCH_TIMEOUT_MILLIS = 5000;
+  private static final String DEFAULT_CONSUMER_FACTORY_CLASS = SimpleConsumerFactory.class.getName();
+  private static final String DEFAULT_OFFSET_CRITERIA = "largest";
+
+  public enum ConsumerType {
+    SIMPLE,
+    HIGHLEVEL
+  }
 
   public StreamConfig(Map<String, String> streamConfigMap) {
-    _zkBrokerUrl =
-        streamConfigMap.get(StringUtil.join(".", Helix.DataSource.STREAM_PREFIX,
-            Helix.DataSource.Realtime.Kafka.HighLevelConsumer.ZK_CONNECTION_STRING));
+    _streamType = streamConfigMap.get(StreamConfigProperties.STREAM_TYPE);
+    Preconditions.checkNotNull(_streamType,
+        "Must provide stream type in property " + StreamConfigProperties.STREAM_TYPE);
 
-    final String bootstrapHostConfigKey = Helix.DataSource.STREAM_PREFIX + "." + Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST;
+    String streamTopicProperty =
+        StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_TOPIC_NAME);
+    _topicName = streamConfigMap.get(streamTopicProperty);
+    Preconditions.checkNotNull(_topicName, "Must provide stream topic name in property " + streamTopicProperty);
+
+    // TODO: Move zkBrokerURL and bootstrapHosts to kafka specific config objects
+    _zkBrokerUrl = streamConfigMap.get(KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_ZK_CONNECTION_STRING));
+
+    final String bootstrapHostConfigKey = KafkaStreamConfigProperties.constructStreamProperty(
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST);
     if (streamConfigMap.containsKey(bootstrapHostConfigKey)) {
       _bootstrapHosts = streamConfigMap.get(bootstrapHostConfigKey);
     } else {
       _bootstrapHosts = null;
     }
 
-    String consumerTypesCsv =streamConfigMap.get(StringUtil.join(".", Helix.DataSource.STREAM_PREFIX, Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE));
+    String consumerTypesCsv = streamConfigMap.get(
+        StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES));
     Iterable<String> parts = Splitter.on(',').trimResults().split(consumerTypesCsv);
     for (String part : parts) {
-      _consumerTypes.add(ConsumerType.valueOf(part));
+      _consumerTypes.add(ConsumerType.valueOf(part.toUpperCase()));
     }
     if (_consumerTypes.isEmpty()) {
       throw new RuntimeException("Empty consumer types: Must have 'highLevel' or 'simple'");
     }
     Collections.sort(_consumerTypes);
 
-    _kafkaTopicName =
-        streamConfigMap.get(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-            CommonConstants.Helix.DataSource.Realtime.Kafka.TOPIC_NAME));
-    _decoderClass =
-        streamConfigMap.get(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-            CommonConstants.Helix.DataSource.Realtime.Kafka.DECODER_CLASS));
+    String offsetCriteriaProperty = StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA);
+    String offsetCriteria = streamConfigMap.get(offsetCriteriaProperty);
+    if (offsetCriteria == null) {
+      _offsetCriteria = DEFAULT_OFFSET_CRITERIA;
+    } else {
+      _offsetCriteria = offsetCriteria;
+    }
 
-    _consumerFactoryName = streamConfigMap.get(StringUtil
-        .join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX, Helix.DataSource.Realtime.Kafka.CONSUMER_FACTORY));
+    _decoderClass = streamConfigMap.get(
+        StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_DECODER_CLASS));
+
+    String consumerFactoryProperty = StreamConfigProperties.constructStreamProperty(_streamType,
+        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS);
+    _consumerFactoryName = streamConfigMap.get(consumerFactoryProperty);
     if (_consumerFactoryName == null) {
-      _consumerFactoryName = Helix.DataSource.Realtime.Kafka.ConsumerFactory.SIMPLE_CONSUMER_FACTORY_STRING;
+       _consumerFactoryName = DEFAULT_CONSUMER_FACTORY_CLASS;
     }
     LOGGER.info("Setting consumer factory to {}", _consumerFactoryName);
 
-    final String kafkaConnectionTimeoutPropertyKey = StringUtil.join(".", Helix.DataSource.STREAM_PREFIX,
-        Helix.DataSource.Realtime.Kafka.KAFKA_CONNECTION_TIMEOUT_MILLIS);
-    long kafkaConnectionTimeoutMillis;
-    if (streamConfigMap.containsKey(kafkaConnectionTimeoutPropertyKey)) {
+    final String connectionTimeoutPropertyKey = StreamConfigProperties.constructStreamProperty(_streamType,
+        StreamConfigProperties.STREAM_CONNECTION_TIMEOUT_MILLIS);
+    long connectionTimeoutMillis;
+    if (streamConfigMap.containsKey(connectionTimeoutPropertyKey)) {
       try {
-        kafkaConnectionTimeoutMillis = Long.parseLong(streamConfigMap.get(kafkaConnectionTimeoutPropertyKey));
+        connectionTimeoutMillis = Long.parseLong(streamConfigMap.get(connectionTimeoutPropertyKey));
       } catch (Exception e) {
-        LOGGER.warn("Caught exception while parsing the Kafka connection timeout, defaulting to {} ms", e,
-            DEFAULT_KAFKA_CONNECTION_TIMEOUT_MILLIS);
-        kafkaConnectionTimeoutMillis = DEFAULT_KAFKA_CONNECTION_TIMEOUT_MILLIS;
+        LOGGER.warn("Caught exception while parsing the connection timeout, defaulting to {} ms", e,
+            DEFAULT_CONNECTION_TIMEOUT_MILLIS);
+        connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
       }
     } else {
-      kafkaConnectionTimeoutMillis = DEFAULT_KAFKA_CONNECTION_TIMEOUT_MILLIS;
+      connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
     }
-    _kafkaConnectionTimeoutMillis = kafkaConnectionTimeoutMillis;
+    _connectionTimeoutMillis = connectionTimeoutMillis;
 
-    final String kafkaFetchTimeoutPropertyKey = StringUtil.join(".", Helix.DataSource.STREAM_PREFIX,
-        Helix.DataSource.Realtime.Kafka.KAFKA_FETCH_TIMEOUT_MILLIS);
-    int kafkaFetchTimeoutMillis;
-    if (streamConfigMap.containsKey(kafkaFetchTimeoutPropertyKey)) {
+    final String fetchTimeoutPropertyKey =
+        StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS);
+    int fetchTimeoutMillis;
+    if (streamConfigMap.containsKey(fetchTimeoutPropertyKey)) {
       try {
-        kafkaFetchTimeoutMillis = Integer.parseInt(streamConfigMap.get(kafkaFetchTimeoutPropertyKey));
+        fetchTimeoutMillis = Integer.parseInt(streamConfigMap.get(fetchTimeoutPropertyKey));
       } catch (Exception e) {
-        LOGGER.warn("Caughe exception while parsing the Kafka fetch timeout, defaulting to {} ms", e,
-            DEFAULT_KAFKA_FETCH_TIMEOUT_MILLIS);
-        kafkaFetchTimeoutMillis = DEFAULT_KAFKA_FETCH_TIMEOUT_MILLIS;
+        LOGGER.warn("Caught exception while parsing the fetch timeout, defaulting to {} ms", e,
+            DEFAULT_FETCH_TIMEOUT_MILLIS);
+        fetchTimeoutMillis = DEFAULT_FETCH_TIMEOUT_MILLIS;
       }
     } else {
-      kafkaFetchTimeoutMillis = DEFAULT_KAFKA_FETCH_TIMEOUT_MILLIS;
+      fetchTimeoutMillis = DEFAULT_FETCH_TIMEOUT_MILLIS;
     }
-    _kafkaFetchTimeoutMillis = kafkaFetchTimeoutMillis;
+    _fetchTimeoutMillis = fetchTimeoutMillis;
 
     for (String key : streamConfigMap.keySet()) {
-      if (key.startsWith(CommonConstants.Helix.DataSource.STREAM_PREFIX + ".")) {
+      if (key.startsWith(StreamConfigProperties.STREAM_PREFIX)) {
         _streamConfigMap.put(key, streamConfigMap.get(key));
       }
-      if (key.startsWith(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-          CommonConstants.Helix.DataSource.Realtime.Kafka.DECODER_PROPS_PREFIX))) {
-        _decoderProperties.put(CommonConstants.Helix.DataSource.Realtime.Kafka.getDecoderPropertyKey(key),
+      String decoderPropPrefix =
+          StreamConfigProperties.constructStreamProperty(_streamType, StreamConfigProperties.DECODER_PROPS_PREFIX);
+      if (key.startsWith(decoderPropPrefix)) {
+        _decoderProperties.put(StreamConfigProperties.getPropertySuffix(key, decoderPropPrefix),
             streamConfigMap.get(key));
       }
-      if (key.startsWith(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-          Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX))) {
-        _kafkaConsumerProperties.put(CommonConstants.Helix.DataSource.Realtime.Kafka.getConsumerPropertyKey(key),
+
+      // TODO: Move kafkaConsumerProp to kafka specific StreamConfig
+      String kafkaConsumerPropPrefix =
+          KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.KAFKA_CONSUMER_PROP_PREFIX);
+      if (key.startsWith(kafkaConsumerPropPrefix)) {
+        _kafkaConsumerProperties.put(StreamConfigProperties.getPropertySuffix(key, kafkaConsumerPropPrefix),
             streamConfigMap.get(key));
       }
     }
   }
 
-  public boolean hasHighLevelKafkaConsumerType() {
-    return _consumerTypes.contains(ConsumerType.highLevel);
+  public boolean hasHighLevelConsumerType() {
+    return _consumerTypes.contains(ConsumerType.HIGHLEVEL);
   }
 
-  public boolean hasSimpleKafkaConsumerType() {
-    return _consumerTypes.contains(ConsumerType.simple);
+  public boolean hasLowLevelConsumerType() {
+    return _consumerTypes.contains(ConsumerType.SIMPLE);
   }
 
-  public long getKafkaConnectionTimeoutMillis() {
-    return _kafkaConnectionTimeoutMillis;
+  public long getConnectionTimeoutMillis() {
+    return _connectionTimeoutMillis;
   }
 
-  public int getKafkaFetchTimeoutMillis() {
-    return _kafkaFetchTimeoutMillis;
+  public int getFetchTimeoutMillis() {
+    return _fetchTimeoutMillis;
   }
 
-  public String getKafkaTopicName() {
-    return _kafkaTopicName;
+  public String getTopicName() {
+    return _topicName;
   }
 
   public List<ConsumerType> getConsumerTypes() {
     return _consumerTypes;
+  }
+
+  public String getOffsetCriteria() {
+    return _offsetCriteria;
   }
 
   public Map<String, String> getKafkaConfigs() {
@@ -210,8 +240,8 @@ public class StreamConfig {
     String[] keys = _streamConfigMap.keySet().toArray(new String[0]);
     Arrays.sort(keys);
     for (final String key : keys) {
-      if (key.startsWith(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-          CommonConstants.Helix.DataSource.KAFKA))) {
+      if (key.startsWith(StringUtil.join(".", StreamConfigProperties.STREAM_PREFIX,
+          KafkaStreamConfigProperties.STREAM_TYPE))) {
         result.append("  ");
         result.append(key);
         result.append(": ");
@@ -236,7 +266,7 @@ public class StreamConfig {
 
     StreamConfig that = (StreamConfig) o;
 
-    return isEqual(_kafkaTopicName, that._kafkaTopicName) &&
+    return isEqual(_topicName, that._topicName) &&
         isEqual(_consumerTypes, that._consumerTypes) &&
         isEqual(_zkBrokerUrl, that._zkBrokerUrl) &&
         isEqual(_decoderClass, that._decoderClass) &&
@@ -247,7 +277,7 @@ public class StreamConfig {
 
   @Override
   public int hashCode() {
-    int result = hashCodeOf(_kafkaTopicName);
+    int result = hashCodeOf(_topicName);
     result = hashCodeOf(result, _consumerTypes);
     result = hashCodeOf(result, _zkBrokerUrl);
     result = hashCodeOf(result, _decoderClass);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -6,6 +6,8 @@ import com.google.common.base.Joiner;
 public class StreamConfigProperties {
   public static final String DOT_SEPARATOR = ".";
   public static final String STREAM_PREFIX = "stream";
+  // TODO: this can be removed, check all properties before doing so
+  public static final String LLC_SUFFIX = ".llc";
 
   /**
    * Generic properties
@@ -15,12 +17,14 @@ public class StreamConfigProperties {
   public static final String STREAM_CONSUMER_TYPES = "consumer.type";
   public static final String STREAM_CONSUMER_FACTORY_CLASS = "consumer.factory.class.name";
   public static final String STREAM_CONSUMER_OFFSET_CRITERIA = "consumer.prop.auto.offset.reset";
-  public static final String STREAM_FETCH_TIMEOUT_MILLIS = "stream.fetch.timeout.millis";
-  public static final String STREAM_CONNECTION_TIMEOUT_MILLIS = "stream.connection.timeout.millis";
+  public static final String STREAM_FETCH_TIMEOUT_MILLIS = "fetch.timeout.millis";
+  public static final String STREAM_CONNECTION_TIMEOUT_MILLIS = "connection.timeout.millis";
   public static final String STREAM_DECODER_CLASS = "decoder.class.name";
-  public static final String DECODER_PROPS_PREFIX = "decoder";
+  public static final String DECODER_PROPS_PREFIX = "decoder.prop";
 
-  // Time threshold that will keep the realtime segment open for before we convert it into an offline segment
+  /**
+   * Time threshold that will keep the realtime segment open for before we convert it into an offline segment
+   */
   public static final String SEGMENT_FLUSH_THRESHOLD_TIME = "realtime.segment.flush.threshold.time";
 
   /**
@@ -77,8 +81,8 @@ public class StreamConfigProperties {
     return Joiner.on(DOT_SEPARATOR).join(STREAM_PREFIX, streamType, property);
   }
 
-  public static String getPropertySuffix(String incoming, String streamDecoderPropPrefix) {
-    return incoming.split(streamDecoderPropPrefix + ".")[1];
+  public static String getPropertySuffix(String incoming, String propertyPrefix) {
+    return incoming.split(propertyPrefix + ".")[1];
   }
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -38,7 +38,7 @@ public class StreamConfigProperties {
   public static final String DECODER_PROPS_PREFIX = "decoder.prop";
 
   /**
-   * Time threshold that will keep the realtime segment open for before we convert it into an offline segment
+   * Time threshold that will keep the realtime segment open for before we complete the segment
    */
   public static final String SEGMENT_FLUSH_THRESHOLD_TIME = "realtime.segment.flush.threshold.time";
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -1,0 +1,85 @@
+package com.linkedin.pinot.core.realtime.stream;
+
+import com.google.common.base.Joiner;
+
+
+public class StreamConfigProperties {
+  public static final String DOT_SEPARATOR = ".";
+  public static final String STREAM_PREFIX = "stream";
+
+  /**
+   * Generic properties
+   */
+  public static final String STREAM_TYPE = "streamType";
+  public static final String STREAM_TOPIC_NAME = "topic.name";
+  public static final String STREAM_CONSUMER_TYPES = "consumer.type";
+  public static final String STREAM_CONSUMER_FACTORY_CLASS = "consumer.factory.class.name";
+  public static final String STREAM_CONSUMER_OFFSET_CRITERIA = "consumer.prop.auto.offset.reset";
+  public static final String STREAM_FETCH_TIMEOUT_MILLIS = "stream.fetch.timeout.millis";
+  public static final String STREAM_CONNECTION_TIMEOUT_MILLIS = "stream.connection.timeout.millis";
+  public static final String STREAM_DECODER_CLASS = "decoder.class.name";
+  public static final String DECODER_PROPS_PREFIX = "decoder";
+
+  // Time threshold that will keep the realtime segment open for before we convert it into an offline segment
+  public static final String SEGMENT_FLUSH_THRESHOLD_TIME = "realtime.segment.flush.threshold.time";
+
+  /**
+   * Row count flush threshold for realtime segments. This behaves in a similar way for HLC and LLC. For HLC,
+   * since there is only one consumer per server, this size is used as the size of the consumption buffer and
+   * determines after how many rows we flush to disk. For example, if this threshold is set to two million rows,
+   * then a high level consumer would have a buffer size of two million.
+   *
+   * For LLC, this size is divided across all the segments assigned to a given server and is set on a per segment
+   * basis. Assuming a low level consumer server is assigned four Kafka partitions to consume from and a flush
+   * size of two million, then each consuming segment would have a flush size of five hundred thousand rows, for a
+   * total of two million rows in memory.
+   *
+   * Keep in mind that this NOT a hard threshold, as other tables can also be assigned to this server, and that in
+   * certain conditions (eg. if the number of servers, replicas of Kafka partitions changes) where Kafka partition
+   * to server assignment changes, it's possible to end up with more (or less) than this number of rows in memory.
+   *
+   * If this value is set to 0, then the consumers adjust the number of rows consumed by a partition such that
+   * the size of the completed segment is the desired size (see REALTIME_DESIRED_SEGMENT_SIZE), unless
+   * REALTIME_SEGMENT_FLUSH_TIME is reached first)
+   */
+  public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.size";
+
+  /*
+   * The desired size of a completed realtime segment.
+   * This config is used only if REALTIME_SEGMENT_FLUSH_SIZE is set
+   * to 0. Default value of REALTIME_SEGMENT_FLUSH_SIZE is "200M". Values are parsed using DataSize class.
+   *
+   * The value for this configuration should be chosen based on the amount of memory available on consuming
+   * machines, the number of completed segments that are expected to be resident on the machine and the amount
+   * of memory used by consuming machines. In other words:
+   *
+   *    numPartitionsInMachine * (consumingPartitionMemory + numPartitionsRetained * REALTIME_DESIRED_SEGMENT_SIZE)
+   *
+   * must be less than or equal to the total memory available to store pinot data.
+   *
+   * Note that consumingPartitionMemory will vary depending on the rows that are consumed.
+   *
+   * Not included here is any heap memory used (currently inverted index uses heap memory for consuming partitions).
+   */
+  public static final String SEGMENT_FLUSH_DESIRED_SIZE = "realtime.segment.flush.desired.size";
+
+  // Time threshold that controller will wait for the segment to be built by the server
+  public static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "realtime.segment.commit.timeoutSeconds";
+
+
+  /**
+   * Helper method to create a stream specific property
+   * @param streamType
+   * @param property
+   * @return
+   */
+  public static String constructStreamProperty(String streamType, String property) {
+    return Joiner.on(DOT_SEPARATOR).join(STREAM_PREFIX, streamType, property);
+  }
+
+  public static String getPropertySuffix(String incoming, String streamDecoderPropPrefix) {
+    return incoming.split(streamDecoderPropPrefix + ".")[1];
+  }
+
+}
+

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.core.realtime.stream;
 
 import com.google.common.base.Joiner;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamDecoderProvider.java
@@ -37,7 +37,7 @@ public abstract class StreamDecoderProvider {
     Map<String, String> decoderProperties = streamConfig.getDecoderProperties();
     try {
       decoder = (StreamMessageDecoder) Class.forName(decoderClass).newInstance();
-      decoder.init(decoderProperties, schema, streamConfig.getKafkaTopicName());
+      decoder.init(decoderProperties, schema, streamConfig.getTopicName());
     } catch (Exception e) {
       Utils.rethrowException(e);
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -22,7 +22,6 @@ import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
-import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
@@ -30,6 +29,7 @@ import com.linkedin.pinot.core.indexsegment.mutable.MutableSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.stream.PermanentConsumerException;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import com.linkedin.pinot.core.realtime.stream.StreamMessageDecoder;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.yammer.metrics.core.MetricsRegistry;
@@ -81,7 +81,7 @@ public class LLRealtimeSegmentDataManagerTest {
       + "    ], \n" + "    \"lazyLoad\": \"false\", \n" + "    \"loadMode\": \"HEAP\", \n"
       + "    \"segmentFormatVersion\": null, \n" + "    \"sortedColumn\": [], \n"
       + "    \"streamConfigs\": {\n" + "      \"realtime.segment.flush.threshold.size\": \"" + String.valueOf(maxRowsInSegment) + "\", \n"
-      + "      \"" + CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + "\": \"" + maxTimeForSegmentCloseMs + "\", \n"
+      + "      \"" + StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME + "\": \"" + maxTimeForSegmentCloseMs + "\", \n"
       + "      \"stream.kafka.broker.list\": \"broker:7777\", \n"
       + "      \"stream.kafka.consumer.prop.auto.offset.reset\": \"smallest\", \n"
       + "      \"stream.kafka.consumer.type\": \"simple\", \n"
@@ -184,7 +184,7 @@ public class LLRealtimeSegmentDataManagerTest {
     JSONObject tableIndexConfig = (JSONObject)tableConfigJson.get("tableIndexConfig");
     JSONObject streamConfigs = (JSONObject)tableIndexConfig.get("streamConfigs");
     {
-      streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME, "3h");
+      streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, "3h");
       TableConfig tableConfig = TableConfig.fromJSONConfig(tableConfigJson);
       InstanceZKMetadata instanceZKMetadata = new InstanceZKMetadata();
       Schema schema = Schema.fromString(makeSchema());
@@ -194,7 +194,7 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     {
-      streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME, "3h30m");
+      streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, "3h30m");
       TableConfig tableConfig = TableConfig.fromJSONConfig(tableConfigJson);
       InstanceZKMetadata instanceZKMetadata = new InstanceZKMetadata();
       Schema schema = Schema.fromString(makeSchema());
@@ -205,7 +205,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       final long segTime = 898789748357L;
-      streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME, String.valueOf(segTime));
+      streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, String.valueOf(segTime));
       TableConfig tableConfig = TableConfig.fromJSONConfig(tableConfigJson);
       InstanceZKMetadata instanceZKMetadata = new InstanceZKMetadata();
       Schema schema = Schema.fromString(makeSchema());

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -23,8 +23,6 @@ import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.config.TableTaskConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.Realtime.Kafka;
 import com.linkedin.pinot.common.utils.CommonConstants.Minion;
 import com.linkedin.pinot.common.utils.CommonConstants.Server;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
@@ -34,6 +32,9 @@ import com.linkedin.pinot.controller.helix.ControllerTest;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.realtime.impl.kafka.AvroRecordToPinotRowGenerator;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaStreamConfigProperties;
+import com.linkedin.pinot.core.realtime.stream.StreamConfig;
+import com.linkedin.pinot.core.realtime.stream.StreamConfigProperties;
 import com.linkedin.pinot.core.realtime.stream.StreamMessageDecoder;
 import com.linkedin.pinot.core.util.AvroUtils;
 import com.linkedin.pinot.minion.MinionStarter;
@@ -371,30 +372,40 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   protected void addRealtimeTable(String tableName, boolean useLlc, String kafkaBrokerList, String kafkaZkUrl,
-      String kafkaTopic, int realtimeSegmentFlushSize, File avroFile, String timeColumnName, String timeType,
+      String kafkaTopic, int realtimeSegmentFlushRows, File avroFile, String timeColumnName, String timeType,
       String schemaName, String brokerTenant, String serverTenant, String loadMode, String sortedColumn,
       List<String> invertedIndexColumns, List<String> noDictionaryColumns, TableTaskConfig taskConfig,
       String streamConsumerFactoryName) throws Exception {
     Map<String, String> streamConfigs = new HashMap<>();
-    streamConfigs.put("streamType", "kafka");
+    String streamType = "kafka";
+    streamConfigs.put(StreamConfigProperties.STREAM_TYPE, streamType);
     if (useLlc) {
       // LLC
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.simple.toString());
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
+      streamConfigs.put(
+          StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+          StreamConfig.ConsumerType.SIMPLE.toString());
+      streamConfigs.put(KafkaStreamConfigProperties.constructStreamProperty(
+          KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST), kafkaBrokerList);
     } else {
       // HLC
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_TYPE, Kafka.ConsumerType.highLevel.toString());
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.ZK_BROKER_URL, kafkaZkUrl);
-      streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, kafkaZkUrl);
+      streamConfigs.put(
+          StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+          StreamConfig.ConsumerType.HIGHLEVEL.toString());
+      streamConfigs.put(KafkaStreamConfigProperties.constructStreamProperty(
+          KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_ZK_CONNECTION_STRING), kafkaZkUrl);
     }
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.CONSUMER_FACTORY, streamConsumerFactoryName);
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.TOPIC_NAME, kafkaTopic);
-    AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;
-    streamConfigs.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS,
-        AvroFileSchemaKafkaAvroMessageDecoder.class.getName());
-    streamConfigs.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(realtimeSegmentFlushSize));
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS), streamConsumerFactoryName);
     streamConfigs.put(
-        DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET, "smallest");
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME),
+        kafkaTopic);
+    AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;
+    streamConfigs.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
+        AvroFileSchemaKafkaAvroMessageDecoder.class.getName());
+    streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, Integer.toString(realtimeSegmentFlushRows));
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), "smallest");
 
     TableConfig tableConfig = new TableConfig.Builder(Helix.TableType.REALTIME).setTableName(tableName)
         .setLLC(useLlc)


### PR DESCRIPTION
As part of the next steps for the issue: https://github.com/linkedin/pinot/issues/2583, we plan to unify all stream related configs into StreamConfigs and remove StreamProviderConfigs. We will also be introducing stream specific config classes such as KafkaStreamConfig. 
This is the first part of that step, which is moving over configs from CommonConstants into StreamConfigProperties, and separating out kafka stream related configs into KafkaStreamConfigProperties.
The follow up of this would be to clean up StreamConfigs and move all kafka specific fields into a KafkaStreamConfig.