### PR TITLE
Reduce the ZK access for segment metadata fetching

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -27,6 +27,7 @@ import com.linkedin.pinot.common.utils.SchemaUtils;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.common.utils.StringUtil;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+@SuppressWarnings("unused")
 public class ZKMetadataProvider {
   private ZKMetadataProvider() {
   }
@@ -281,6 +283,10 @@ public class ZKMetadataProvider {
     return schema;
   }
 
+  /**
+   * NOTE: this method is very expensive, use {@link #getSegments(ZkHelixPropertyStore, String)} instead if only segment
+   * segment names are needed.
+   */
   public static List<OfflineSegmentZKMetadata> getOfflineSegmentZKMetadataListForTable(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
     List<OfflineSegmentZKMetadata> resultList = new ArrayList<>();
@@ -301,6 +307,10 @@ public class ZKMetadataProvider {
     return resultList;
   }
 
+  /**
+   * NOTE: this method is very expensive, use {@link #getSegments(ZkHelixPropertyStore, String)} instead if only segment
+   * segment names are needed.
+   */
   public static List<RealtimeSegmentZKMetadata> getRealtimeSegmentZKMetadataListForTable(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
     List<RealtimeSegmentZKMetadata> resultList = new ArrayList<>();
@@ -321,7 +331,10 @@ public class ZKMetadataProvider {
     return resultList;
   }
 
-  @Nonnull
+  /**
+   * NOTE: this method is very expensive, use {@link #getLLCRealtimeSegments(ZkHelixPropertyStore, String)} instead if
+   * only segment names are needed.
+   */
   public static List<LLCRealtimeSegmentZKMetadata> getLLCRealtimeSegmentZKMetadataListForTable(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
     List<LLCRealtimeSegmentZKMetadata> resultList = new ArrayList<>();
@@ -345,6 +358,44 @@ public class ZKMetadataProvider {
     return resultList;
   }
 
+  /**
+   * Returns the segments for the given table.
+   *
+   * @param propertyStore Helix property store
+   * @param tableNameWithType Table name with type suffix
+   * @return List of segment names
+   */
+  public static List<String> getSegments(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    String segmentsPath = constructPropertyStorePathForResource(tableNameWithType);
+    if (propertyStore.exists(segmentsPath, AccessOption.PERSISTENT)) {
+      return propertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Returns the LLC realtime segments for the given table.
+   *
+   * @param propertyStore Helix property store
+   * @param realtimeTableName Realtime table name
+   * @return List of LLC realtime segment names
+   */
+  public static List<String> getLLCRealtimeSegments(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String realtimeTableName) {
+    List<String> llcRealtimeSegments = new ArrayList<>();
+    String segmentsPath = constructPropertyStorePathForResource(realtimeTableName);
+    if (propertyStore.exists(segmentsPath, AccessOption.PERSISTENT)) {
+      List<String> segments = propertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT);
+      for (String segment : segments) {
+        if (SegmentName.isLowLevelConsumerSegmentName(segment)) {
+          llcRealtimeSegments.add(segment);
+        }
+      }
+    }
+    return llcRealtimeSegments;
+  }
+
   public static void setClusterTenantIsolationEnabled(ZkHelixPropertyStore<ZNRecord> propertyStore,
       boolean isSingleTenantCluster) {
     final ZNRecord znRecord;
@@ -360,7 +411,7 @@ public class ZKMetadataProvider {
     propertyStore.set(path, znRecord, AccessOption.PERSISTENT);
   }
 
-  public static Boolean getClusterTenantIsolationEnabled(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public static boolean getClusterTenantIsolationEnabled(ZkHelixPropertyStore<ZNRecord> propertyStore) {
     String controllerConfigPath = constructPropertyStorePathForControllerConfig(CLUSTER_TENANT_ISOLATION_ENABLED_KEY);
     if (propertyStore.exists(controllerConfigPath, AccessOption.PERSISTENT)) {
       ZNRecord znRecord = propertyStore.get(controllerConfigPath, null, AccessOption.PERSISTENT);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
 import com.linkedin.pinot.common.config.SegmentPartitionConfig;
@@ -69,7 +68,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -827,46 +825,71 @@ public class PinotLLCRealtimeSegmentManager {
   }
 
   /**
-   * Given a table name, returns a list of metadata for all segments of that table from the property store
-   * @param tableNameWithType
-   * @return
+   * Returns the LLC realtime segments for the given table.
+   *
+   * @param realtimeTableName Realtime table name
+   * @return List of LLC realtime segment names
    */
   @VisibleForTesting
-  protected List<LLCRealtimeSegmentZKMetadata> getAllSegmentMetadata(String tableNameWithType) {
-    return ZKMetadataProvider.getLLCRealtimeSegmentZKMetadataListForTable(_helixManager.getHelixPropertyStore(),
-        tableNameWithType);
+  protected List<String> getAllSegments(String realtimeTableName) {
+    return ZKMetadataProvider.getLLCRealtimeSegments(_propertyStore, realtimeTableName);
   }
 
   /**
-   * Gets latest 2 metadata. We need only the 2 latest metadata for each partition in order to perform repairs
-   * @param tableNameWithType
-   * @return
+   * Returns the LLC realtime segment ZK metadata for the given table and segment.
+   *
+   * @param realtimeTableName Realtime table name
+   * @param segmentName Segment name (String)
+   * @return LLC realtime segment ZK metadata
    */
   @VisibleForTesting
-  protected Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> getLatestMetadata(
-      String tableNameWithType) {
-    List<LLCRealtimeSegmentZKMetadata> metadatas = getAllSegmentMetadata(tableNameWithType);
+  protected LLCRealtimeSegmentZKMetadata getSegmentMetadata(String realtimeTableName, String segmentName) {
+    return (LLCRealtimeSegmentZKMetadata) ZKMetadataProvider.getRealtimeSegmentZKMetadata(_propertyStore,
+        realtimeTableName, segmentName);
+  }
 
-    Comparator<LLCRealtimeSegmentZKMetadata> comparator = (o1, o2) -> {
-      LLCSegmentName s1 = new LLCSegmentName(o1.getSegmentName());
-      LLCSegmentName s2 = new LLCSegmentName(o2.getSegmentName());
-      return s2.compareTo(s1);
-    };
+  /**
+   * Returns the latest 2 LLC realtime segment ZK metadata for each partition.
+   *
+   * @param realtimeTableName Realtime table name
+   * @return Map from partition to array of latest LLC realtime segment ZK metadata
+   */
+  @VisibleForTesting
+  protected Map<Integer, LLCRealtimeSegmentZKMetadata[]> getLatestMetadata(String realtimeTableName) {
+    List<String> llcRealtimeSegments = getAllSegments(realtimeTableName);
 
-    Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> partitionToLatestSegments = new HashMap<>();
-
-    for (LLCRealtimeSegmentZKMetadata metadata : metadatas) {
-      LLCSegmentName segmentName = new LLCSegmentName(metadata.getSegmentName());
-      final int partitionId = segmentName.getPartitionId();
-      MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata> latestSegments = partitionToLatestSegments.get(partitionId);
-      if (latestSegments == null) {
-        latestSegments = MinMaxPriorityQueue.orderedBy(comparator).maximumSize(2).create();
-        partitionToLatestSegments.put(partitionId, latestSegments);
-      }
-      latestSegments.offer(metadata);
+    Map<Integer, LLCSegmentName[]> partitionToLatestSegmentsMap = new HashMap<>();
+    for (String llcRealtimeSegment : llcRealtimeSegments) {
+      LLCSegmentName segmentName = new LLCSegmentName(llcRealtimeSegment);
+      partitionToLatestSegmentsMap.compute(segmentName.getPartitionId(), (partitionId, segmentNames) -> {
+        if (segmentNames == null) {
+          return new LLCSegmentName[]{segmentName, null};
+        } else {
+          if (segmentName.getSequenceNumber() > segmentNames[0].getSequenceNumber()) {
+            segmentNames[1] = segmentNames[0];
+            segmentNames[0] = segmentName;
+          } else if (segmentNames[1] == null || segmentName.getSequenceNumber() > segmentNames[1].getSequenceNumber()) {
+            segmentNames[1] = segmentName;
+          }
+          return segmentNames;
+        }
+      });
     }
 
-    return partitionToLatestSegments;
+    Map<Integer, LLCRealtimeSegmentZKMetadata[]> partitionToLatestMetadataMap = new HashMap<>();
+    for (Map.Entry<Integer, LLCSegmentName[]> entry : partitionToLatestSegmentsMap.entrySet()) {
+      LLCSegmentName[] latestSegments = entry.getValue();
+      LLCRealtimeSegmentZKMetadata latestMetadata =
+          getSegmentMetadata(realtimeTableName, latestSegments[0].getSegmentName());
+      LLCRealtimeSegmentZKMetadata secondLatestMetadata = null;
+      if (latestSegments[1] != null) {
+        secondLatestMetadata = getSegmentMetadata(realtimeTableName, latestSegments[1].getSegmentName());
+      }
+      partitionToLatestMetadataMap.put(entry.getKey(),
+          new LLCRealtimeSegmentZKMetadata[]{latestMetadata, secondLatestMetadata});
+    }
+
+    return partitionToLatestMetadataMap;
   }
 
   /**
@@ -1033,8 +1056,7 @@ public class PinotLLCRealtimeSegmentManager {
     final long now = getCurrentTimeMs();
 
     // Get the metadata for the latest 2 segments of each partition
-    Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> partitionToLatestMetadata =
-        getLatestMetadata(tableNameWithType);
+    Map<Integer, LLCRealtimeSegmentZKMetadata[]> partitionToLatestMetadata = getLatestMetadata(tableNameWithType);
 
     // Find partitions for which there is no metadata at all. These are new partitions that we need to start consuming.
     Set<Integer> newPartitions = new HashSet<>(partitionCount);
@@ -1078,9 +1100,10 @@ public class PinotLLCRealtimeSegmentManager {
     //    a. Create a new segment (with the next seq number)
     //       and restart consumption from the same offset (if possible) or a newer offset (if realtime stream does not have the same offset).
     //       In latter case, report data loss.
-    for (Map.Entry<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> entry : partitionToLatestMetadata.entrySet()) {
+    for (Map.Entry<Integer, LLCRealtimeSegmentZKMetadata[]> entry : partitionToLatestMetadata.entrySet()) {
       int partition = entry.getKey();
-      LLCRealtimeSegmentZKMetadata latestMetadata = entry.getValue().pollFirst();
+      LLCRealtimeSegmentZKMetadata[] latestMetadataArray = entry.getValue();
+      LLCRealtimeSegmentZKMetadata latestMetadata = latestMetadataArray[0];
       final String segmentId = latestMetadata.getSegmentName();
       final LLCSegmentName segmentName = new LLCSegmentName(segmentId);
 
@@ -1171,13 +1194,12 @@ public class PinotLLCRealtimeSegmentManager {
             partition, segmentId);
 
         // If there was a prev segment in the same partition, then we need to fix it to be ONLINE.
-        LLCRealtimeSegmentZKMetadata prevMetadata = entry.getValue().pollLast();
-
-        if (prevMetadata == null && skipNewPartitions) {
+        LLCRealtimeSegmentZKMetadata secondLatestMetadata = latestMetadataArray[1];
+        if (secondLatestMetadata == null && skipNewPartitions) {
           continue;
         }
-        if (prevMetadata != null) {
-          onlineSegments.add(prevMetadata.getSegmentName());
+        if (secondLatestMetadata != null) {
+          onlineSegments.add(secondLatestMetadata.getSegmentName());
         }
         consumingSegments.add(segmentId);
       }


### PR DESCRIPTION
1. Added getSegments() and getLLCRealtimeSegments() in ZKMetadataProvider to only fetch the name of the segments
2. Change code to only fetch segment names if possible