### PR TITLE
[PINOT-7008] Include the brokerRequest in the log message when group-by operator times out

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -156,7 +156,8 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       boolean opCompleted = operatorLatch.await(_timeOutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
-        String errorMessage = "Timed out while combining group-by results after " + _timeOutMs + "ms";
+        String errorMessage = "Timed out while combining group-by results after " + _timeOutMs + "ms"
+            + " Broker request: " + _brokerRequest;
         LOGGER.error(errorMessage);
         return new IntermediateResultsBlock(new TimeoutException(errorMessage));
       }


### PR DESCRIPTION
Currently, when we see group-by timeouts on the server side, its unclear which request the server timed out on. At best we can correlate with broker logs to guess which request might have triggered the issue. This change includes the (deconstrcuted) broker request in the log to provide more clues. The code does not have access to the pql, but a log like this should still provide valuable info:
"Timed out while combining group-by results after 14985ms Broker request: BrokerRequest(querySource:QuerySource(tableName:Test_OFFLINE), aggregationsInfo:[AggregationInfo(aggregationType:count, aggregationParams:{column=*}, isInSelectList:true)], groupBy:GroupBy(topN:10, expressions:[id]))"