### PR TITLE
[TE] new anomaly resolution labels

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
@@ -4,7 +4,6 @@
     <li class="range-pill-selectors__item {{if range.isActive "range-pill-selectors__item--active"}}" {{action "onRangeOptionClick" range}} data-value={{range.value}}>
       {{range.name}}
       {{#if (eq range.name "Custom")}}
-        {{log "uiDateFormat: " uiDateFormat}}
         : {{date-range-picker
             class=inputClassName
             timePicker=true

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -27,9 +27,10 @@ const OFFSETS = ['current', 'predicted', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
  * @type {Object}
  */
 const ANOMALY_OPTIONS_MAPPING = {
-  ANOMALY: 'Yes (True Anomaly)',
-  ANOMALY_NEW_TREND: 'Yes (But New Trend)',
-  NOT_ANOMALY: 'No (False Alarm)',
+  ANOMALY: 'Yes, it\'s unexpected',
+  ANOMALY_EXPECTED: 'It\'s an expected temporary change (E.g. Holiday)',
+  ANOMALY_NEW_TREND: 'It\'s an expected permanent change',
+  NOT_ANOMALY: 'No significant change observed',
   NO_FEEDBACK: 'To Be Determined'
 };
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
@@ -67,17 +67,21 @@
               </div>
               <div class="te-tooltip__body te-tooltip__body--large">
                 <div>
-                  <span class="te-tooltip__title te-tooltip__title--small">True Anomaly</span>
+                  <span class="te-tooltip__title te-tooltip__title--small">Yes, its unexpected</span>
                 </div>
                 <p>Similar anomalies should continue to be detected.</p>
                 <div>
-                  <span class="te-tooltip__title te-tooltip__title--small">False Alarm</span>
+                  <span class="te-tooltip__title te-tooltip__title--small">Its an expected temporary change</span>
+                </div>
+                <p>Anomaly is caused by predictable events, such as holidays. Similar anomalies will continue to be detected.</p>
+                <div>
+                  <span class="te-tooltip__title te-tooltip__title--small">Its an expected permanent change</span>
+                </div>
+                <p>Metric is experiencing a non-temporary change. Algorithm should adapt to new pattern.</p>
+                <div>
+                  <span class="te-tooltip__title te-tooltip__title--small">No significant change observed</span>
                 </div>
                 <p>Similar anomalies should not be detected.</p>
-                <div>
-                  <span class="te-tooltip__title te-tooltip__title--small">True but new trend</span>
-                </div>
-                <p>Anomaly is expected and metric is experiencing a non-temporary change. Similar anomalies should be ignored.</p>
                 <div>
                   <span class="te-tooltip__title">Why is this important?</span>
                 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
@@ -61,7 +61,7 @@
           Is this an anomaly?
           <span>
             <i class="glyphicon glyphicon-question-sign"></i>
-            {{#tooltip-on-element class="te-tooltip te-tooltip--large te-tooltip--cover" as |popover|}}
+            {{#tooltip-on-element side='right' class="te-tooltip te-tooltip--large te-tooltip--cover" as |popover|}}
               <div class="te-tooltip__header">
                 <span class="te-tooltip__title">What do the options mean?</span>
               </div>

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -53,19 +53,16 @@ export default Component.extend({
      */
      onChangeAnomalyResponse: async function(humanizedAnomaly, selectedResponse, inputObj) {
       const responseObj = anomalyUtil.anomalyResponseObj.find(res => res.name === selectedResponse);
-
       set(inputObj, 'selected', selectedResponse);
-      let res;
       try {
         const id = humanizedAnomaly.get('id');
         // Save anomaly feedback
-        res = await anomalyUtil.updateAnomalyFeedback(id, responseObj.value);
+        await anomalyUtil.updateAnomalyFeedback(id, responseObj.value);
         // We make a call to ensure our new response got saved
-        res = await anomalyUtil.verifyAnomalyFeedback(id, responseObj.status);
+        const savedAnomaly = await anomalyUtil.verifyAnomalyFeedback(id);
         // TODO: right now we will update the union wrapper cached record for this anomaly
         humanizedAnomaly.set('anomaly.feedback', responseObj.value);
-
-        const filterMap = getWithDefault(res, 'searchFilters.statusFilterMap', null);
+        const filterMap = getWithDefault(savedAnomaly, 'searchFilters.statusFilterMap', null);
         if (filterMap && filterMap.hasOwnProperty(responseObj.status)) {
           humanizedAnomaly.set('anomalyFeedback', selectedResponse);
           set(this, 'showResponseSaved', true);

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -69,28 +69,28 @@
       </h4>
       <a class="te-self-serve__side-link te-self-serve__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
-      {{#if filteredAnomalies}}
-        {{!-- Dimension selector --}}
-        {{#if alertHasDimensions}}
-          <div class="te-form__select te-form__select--wider col-md-3">
-            {{#power-select
-              triggerId="select-dimension"
-              triggerClass="te-form__select"
-              options=dimensionOptions
-              searchEnabled=true
-              searchPlaceholder="Type to filter..."
-              matchTriggerWidth=true
-              matchContentWidth=true
-              selected=selectedDimension
-              onchange=(action "onSelectDimension")
-              as |dimension|
-            }}
-              {{dimension}}
-            {{/power-select}}
-          </div>
-        {{/if}}
-        {{!-- Resolution selector --}}
-        <div class="col-md-3">
+      {{!-- Dimension selector --}}
+      {{#if alertHasDimensions}}
+        <div class="te-form__select te-form__select--wider col-md-3">
+          {{#power-select
+            triggerId="select-dimension"
+            triggerClass="te-form__select"
+            options=dimensionOptions
+            searchEnabled=true
+            searchPlaceholder="Type to filter..."
+            matchTriggerWidth=true
+            matchContentWidth=true
+            selected=selectedDimension
+            onchange=(action "onSelectDimension")
+            as |dimension|
+          }}
+            {{dimension}}
+          {{/power-select}}
+        </div>
+      {{/if}}
+      {{!-- Resolution selector --}}
+      {{#if totalAnomalies}}
+        <div class="col-md-3 {{if (not alertHasDimensions) "te-form__select--left"}}">
           {{#power-select
             triggerId="select-resolution"
             triggerClass="te-form__select"
@@ -274,7 +274,7 @@
                         triggerClass="te-anomaly-table__select"
                         options=responseOptions
                         searchEnabled=false
-                        selected=anomaly.anomalyFeedback
+                        selected=(get labelMap anomaly.anomalyFeedback)
                         onchange=(action "onChangeAnomalyResponse" anomaly)
                         as |response|
                       }}
@@ -282,7 +282,7 @@
                       {{/power-select}}
                     {{/if}}
                  </td>
-                 <td class="te-anomaly-table__cell">
+                 <td class="te-anomaly-table__cell te-anomaly-table__cell--feedback">
                     <div class="te-anomaly-table__link-wrapper">
                       {{#link-to 'rootcause' (query-params anomalyId=anomaly.anomalyId) target="_blank" class="te-anomaly-table__link"}}
                         Investigate

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
@@ -4,12 +4,14 @@
  * @exports manage/alert/tune
  */
 import _ from 'lodash';
-import Controller from '@ember/controller';
 import moment from 'moment';
+import Controller from '@ember/controller';
+import { later } from '@ember/runloop';
 import { isPresent } from "@ember/utils";
 import { computed, set, get, getProperties, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { buildDateEod } from 'thirdeye-frontend/utils/utils';
+import { anomalyResponseMap } from 'thirdeye-frontend/utils/anomaly';
 import { buildAnomalyStats } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
@@ -268,6 +270,10 @@ export default Controller.extend({
       // Number the list
       filteredAnomalies.forEach((anomaly) => {
         set(anomaly, 'index', num);
+        setProperties(anomaly, {
+          index: num,
+          feedbackLabel: anomalyResponseMap[anomaly.anomalyFeedback] || anomaly.anomalyFeedback
+        });
         num++;
       });
 
@@ -431,6 +437,9 @@ export default Controller.extend({
         // When user wants to preview using "current" settings, our request does not contain custom params.
         this.send('triggerTuningSequence', defaultConfig);
       }
+
+      // Reset table filter
+      set(this, 'filterBy', 'All');
     }
   }
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
@@ -163,96 +163,94 @@
       {{/if}}
 
       {{!-- Alert anomaly table --}}
-      {{#if diffedAnomalies}}
-        <table class="te-anomaly-table te-anomaly-table-tuning">
-          <thead>
-            <tr class="te-anomaly-table__row te-anomaly-table__row--metrics">
-              <td colspan="5">
-                <ul class="te-anomaly-table-stats">
-                  {{#each tableStats as |metric|}}
-                    <li class="te-anomaly-table-stats__category {{if metric.isActive "te-anomaly-table-stats__category--active"}}" {{action "toggleCategory" metric.label}}>
-                      <div class="te-anomaly-table-stats__content te-anomaly-table-stats__content--number">
-                        {{metric.count}}
-                      </div>
-                      <div class="te-anomaly-table-stats__content te-anomaly-table-stats__content--text">
-                        {{metric.label}}
-                      </div>
-                    </li>
-                  {{/each}}
-                </ul>
-              </td>
-            </tr>
-            <tr class="te-anomaly-table__row te-anomaly-table__head">
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
-                  Start/Duration (PDT)
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               {{#if alertHasDimensions}}
-                  <th class="te-anomaly-table__cell-head">Dimensions</th>
-               {{/if}}
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
-                  Severity Score
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
-                  Current/WoW
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
-                  Resolution
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
+      <table class="te-anomaly-table te-anomaly-table-tuning">
+        <thead>
+          <tr class="te-anomaly-table__row te-anomaly-table__row--metrics">
+            <td colspan="5">
+              <ul class="te-anomaly-table-stats">
+                {{#each tableStats as |metric|}}
+                  <li class="te-anomaly-table-stats__category {{if metric.isActive "te-anomaly-table-stats__category--active"}}" {{action "toggleCategory" metric.label}}>
+                    <div class="te-anomaly-table-stats__content te-anomaly-table-stats__content--number">
+                      {{metric.count}}
+                    </div>
+                    <div class="te-anomaly-table-stats__content te-anomaly-table-stats__content--text">
+                      {{metric.label}}
+                    </div>
+                  </li>
+                {{/each}}
+              </ul>
+            </td>
+          </tr>
+          <tr class="te-anomaly-table__row te-anomaly-table__head">
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
+                Start/Duration (PDT)
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+              </a>
              </th>
-            </tr>
-          </thead>
+             {{#if alertHasDimensions}}
+                <th class="te-anomaly-table__cell-head">Dimensions</th>
+             {{/if}}
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
+                Severity Score
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
+                Current/WoW
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
+                Resolution
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+              </a>
+           </th>
+          </tr>
+        </thead>
 
-          <tbody>
-            {{#each diffedAnomalies as |anomaly|}}
-              <tr class="te-anomaly-table__row">
+        <tbody>
+          {{#each diffedAnomalies as |anomaly|}}
+            <tr class="te-anomaly-table__row">
+               <td class="te-anomaly-table__cell">
+                <ul class="te-anomaly-table__list">
+                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--shadow">{{anomaly.index}}</li>
+                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">{{anomaly.startDateStr}}</li>
+                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--lighter">{{anomaly.durationStr}}</li>
+                </ul>
+               </td>
+               {{#if alertHasDimensions}}
                  <td class="te-anomaly-table__cell">
                   <ul class="te-anomaly-table__list">
-                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--shadow">{{anomaly.index}}</li>
-                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">{{anomaly.startDateStr}}</li>
-                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--lighter">{{anomaly.durationStr}}</li>
+                   {{#each anomaly.dimensionList as |dimension|}}
+                      <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller">
+                        {{dimension.dimensionKey}}: <span class="stronger">{{dimension.dimensionVal}}</span>
+                      </li>
+                   {{else}}
+                      -
+                   {{/each}}
                   </ul>
                  </td>
-                 {{#if alertHasDimensions}}
-                   <td class="te-anomaly-table__cell">
-                    <ul class="te-anomaly-table__list">
-                     {{#each anomaly.dimensionList as |dimension|}}
-                        <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller">
-                          {{dimension.dimensionKey}}: <span class="stronger">{{dimension.dimensionVal}}</span>
-                        </li>
-                     {{else}}
-                        -
-                     {{/each}}
-                    </ul>
-                   </td>
-                 {{/if}}
-                 <td class="te-anomaly-table__cell">{{anomaly.severityScore}}</td>
-                 <td class="te-anomaly-table__cell">
-                   <ul class="te-anomaly-table__list">
-                      <li>{{anomaly.shownCurrent}} / {{anomaly.shownBaseline}}</li>
-                      <li class="te-anomaly-table__value-label te-anomaly-table__value-label--{{calculate-direction anomaly.shownChangeRate}}">
-                        ({{anomaly.shownChangeRate}}%)
-                      </li>
-                   </ul>
-                 </td>
-                 <td class="te-anomaly-table__cell">
-                    {{anomaly.anomalyFeedback}}
-                 </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      {{/if}}
+               {{/if}}
+               <td class="te-anomaly-table__cell">{{anomaly.severityScore}}</td>
+               <td class="te-anomaly-table__cell">
+                 <ul class="te-anomaly-table__list">
+                    <li>{{anomaly.shownCurrent}} / {{anomaly.shownBaseline}}</li>
+                    <li class="te-anomaly-table__value-label te-anomaly-table__value-label--{{calculate-direction anomaly.shownChangeRate}}">
+                      ({{anomaly.shownChangeRate}}%)
+                    </li>
+                 </ul>
+               </td>
+               <td class="te-anomaly-table__cell">
+                  {{anomaly.feedbackLabel}}
+               </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
     </div>
   {{/if}}
 

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -41,12 +41,19 @@
       color: app-shade(black, 4);
     }
 
-    &:last-child {
+    &--feedback {
       max-width: 90px;
       text-align: center;
       padding: 4px 0 0 0;
       vertical-align: baseline;
     }
+
+/*    &:last-child {
+      max-width: 90px;
+      text-align: center;
+      padding: 4px 0 0 0;
+      vertical-align: baseline;
+    }*/
   }
 
   &__cell-head {
@@ -140,7 +147,7 @@
 
   &__select {
     display: inline-block;
-    width: 180px;
+    width: 200px;
 
     &--margin-right {
       margin-right: 30px;

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -47,13 +47,6 @@
       padding: 4px 0 0 0;
       vertical-align: baseline;
     }
-
-/*    &:last-child {
-      max-width: 90px;
-      text-align: center;
-      padding: 4px 0 0 0;
-      vertical-align: baseline;
-    }*/
   }
 
   &__cell-head {

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -161,6 +161,10 @@ body {
       display: inline-block;
       color: app-shade(black, 7);
     }
+
+    &--left {
+      margin-left: -15px;
+    }
   }
 
   &__new-sub {

--- a/thirdeye/thirdeye-frontend/app/utils/anomaly.js
+++ b/thirdeye/thirdeye-frontend/app/utils/anomaly.js
@@ -18,19 +18,32 @@ export const anomalyResponseObj = [
     value: 'NO_FEEDBACK',
     status: 'Not Resolved'
   },
-  { name: 'True anomaly',
+  { name: 'Yes - unexpected',
     value: 'ANOMALY',
     status: 'Confirmed Anomaly'
   },
-  { name: 'False alarm',
-    value: 'NOT_ANOMALY',
-    status: 'False Alarm'
+  { name: 'Expected temporary change',
+    value: 'ANOMALY_EXPECTED',
+    status: 'Expected Anomaly'
   },
-  { name: 'Confirmed - New Trend',
+  { name: 'Expected permanent change',
     value: 'ANOMALY_NEW_TREND',
     status: 'New Trend'
+  },
+  { name: 'No change observed',
+    value: 'NOT_ANOMALY',
+    status: 'False Alarm'
   }
 ];
+
+/**
+ * Mapping for anomalyResponseObj 'status' to 'name' for easy lookup
+ */
+export let anomalyResponseMap = {};
+anomalyResponseObj.forEach((obj) => {
+  anomalyResponseMap[obj.status] = obj.name;
+});
+
 
 /**
  * Update feedback status on any anomaly
@@ -129,6 +142,7 @@ export function pluralizeTime(time, unit) {
 
 export default {
   anomalyResponseObj,
+  anomalyResponseMap,
   updateAnomalyFeedback,
   getFormatedDuration,
   verifyAnomalyFeedback,

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -72,7 +72,7 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
     const isNullChangeRate = Number.isNaN(Number(changeRate));
     // Set 'not reviewed' label
     if (!anomaly.anomalyFeedback) {
-      anomaly.anomalyFeedback = 'Not reviewed yet';
+      anomaly.anomalyFeedback = 'Not Resolved';
     }
     // Add missing properties
     Object.assign(anomaly, {

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -33,12 +33,12 @@ module('Acceptance | rootcause', async function(hooks) {
         '/rootcause?metricId=1',
         'link is correct');
       assert.equal(
-        $(rcEl.LABEL).get(0).innerText,
+        $(rcEl.LABEL).get(0).innerText.trim(),
         'pageViews',
         'metric label is correct'
       );
       assert.equal(
-        $(rcEl.SELECTED_METRIC).get(0).innerText,
+        $(rcEl.SELECTED_METRIC).get(0).innerText.trim(),
         'pageViews',
         'selected metric is correct'
       );
@@ -70,7 +70,7 @@ module('Acceptance | rootcause', async function(hooks) {
         'Cause of anomaly is unknown',
         'comments are correct');
       assert.equal(
-        $(rcEl.BASELINE).get(0).innerText,
+        $(rcEl.BASELINE).get(0).innerText.trim(),
         'WoW',
         'default baseline is correct');
     });
@@ -81,7 +81,7 @@ module('Acceptance | rootcause', async function(hooks) {
     const $tabLinks = $(`${rcEl.TABS} .thirdeye-link`);
 
     assert.equal(
-      $tabLinks.get(0).innerText,
+      $tabLinks.get(0).innerText.trim(),
       'Metrics',
       'default tab is correct');
     assert.ok(
@@ -95,7 +95,7 @@ module('Acceptance | rootcause', async function(hooks) {
       $(rcEl.HEATMAP_DROPDOWN).get(0),
       'heatmap dropdown exists');
     assert.equal(
-      $(rcEl.SELECTED_HEATMAP_MODE).get(4).innerText,
+      $(rcEl.SELECTED_HEATMAP_MODE).get(4).innerText.trim(),
       'Change in Contribution',
       'default heatmap mode is correct');
 

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-alert-tuning-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-alert-tuning-test.js
@@ -29,7 +29,7 @@ module('Acceptance | tune alert settings', function(hooks) {
 
     // Verify default search results
     assert.equal(
-      $(selfServeConst.RESULTS_TITLE).get(0).innerText,
+      $(selfServeConst.RESULTS_TITLE).get(0).innerText.trim(),
       'Alerts Found(5)',
       'Number of alerts displayed and title are correct.'
     );

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-import-metric-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-import-metric-test.js
@@ -19,7 +19,7 @@ module('Acceptance | import metric', function(hooks) {
     await visit(`/self-serve/create-alert`);
 
     assert.equal(
-      $(selfServeConst.SECONDARY_LINK).get(0).innerText,
+      $(selfServeConst.SECONDARY_LINK).get(0).innerText.trim(),
       importLinkText,
       'Import link appears.'
     );
@@ -67,7 +67,7 @@ module('Acceptance | import metric', function(hooks) {
     await click(selfServeConst.SUBMIT_BUTTON);
 
     assert.equal(
-      $(selfServeConst.IMPORT_WARNING).get(0).innerText,
+      $(selfServeConst.IMPORT_WARNING).get(0).innerText.trim(),
       importWarning,
       'Non-existent dashboard name results in warning'
     );
@@ -98,7 +98,7 @@ module('Acceptance | import metric', function(hooks) {
       'At least one metric was imported'
     );
     assert.equal(
-      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText,
+      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText.trim(),
       'Onboard Another Dashboard',
       'Submit button mode changed correctly'
     );
@@ -111,7 +111,7 @@ module('Acceptance | import metric', function(hooks) {
     await click(selfServeConst.SUBMIT_BUTTON);
 
     assert.equal(
-      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText,
+      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText.trim(),
       'Import Metrics',
       'Submit button mode changed correctly'
     );
@@ -170,7 +170,7 @@ module('Acceptance | import metric', function(hooks) {
       'At least one metric was imported'
     );
     assert.equal(
-      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText,
+      $(selfServeConst.SUBMIT_BUTTON).get(0).innerText.trim(),
       'Onboard Another Dashboard',
       'Submit button mode changed correctly'
     );

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -50,7 +50,7 @@ module('Acceptance | create alert', function(hooks) {
 
     // Fields are now enabled with defaults and load correct options, graph is loaded
     assert.equal(
-      $granularityDropdown.find(selfServeConst.SELECTED_ITEM).get(0).innerText,
+      $granularityDropdown.find(selfServeConst.SELECTED_ITEM).get(0).innerText.trim(),
       '5_MINUTES',
       'granularity field (representative) is enabled after metric is selected'
     );
@@ -113,14 +113,14 @@ module('Acceptance | create alert', function(hooks) {
 
     await click(selfServeConst.SUBGROUP_SELECT);
     assert.equal(
-      $(selfServeConst.OPTION_ITEM).get(0).innerText,
+      $(selfServeConst.OPTION_ITEM).get(0).innerText.trim(),
       selectedConfigGroup,
       'The config group associated with the selected app is found in the group selection options.'
     );
 
     await selectChoose(selfServeConst.SUBGROUP_SELECT, selectedConfigGroup);
     assert.equal(
-      $(selfServeConst.CONFIG_GROUP_ALERTS).get(0).innerText,
+      $(selfServeConst.CONFIG_GROUP_ALERTS).get(0).innerText.trim(),
       `See all alerts monitored by: ${selectedConfigGroup}`,
       'Custom accordion block with alert table for selected group appears'
     );
@@ -133,7 +133,7 @@ module('Acceptance | create alert', function(hooks) {
     await fillIn(selfServeConst.CONFIG_RECIPIENTS_INPUT, toRecipients);
     await triggerKeyEvent(selfServeConst.CONFIG_RECIPIENTS_INPUT, 'keyup', '8');
     assert.equal(
-      $(selfServeConst.EMAIL_WARNING).get(0).innerText,
+      $(selfServeConst.EMAIL_WARNING).get(0).innerText.trim(),
       `Warning: ${toRecipients} is already included in this group.`,
       'Duplicate email warning appears correctly.'
     );
@@ -172,7 +172,7 @@ module('Acceptance | create alert', function(hooks) {
     );
 
     assert.equal(
-      $(selfServeConst.ALERT_ACTIVE_LABEL).get(0).innerText,
+      $(selfServeConst.ALERT_ACTIVE_LABEL).get(0).innerText.trim(),
       'ACTIVE',
       'Alert status label is set to active.'
     );

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/range-pill-selectors/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/range-pill-selectors/component-test.js
@@ -77,15 +77,15 @@ module('Integration | Component | range pill selectors', function(hooks) {
       `range-pill-selectors__item--active`,
       'Pill selected as default is highlighted');
     assert.equal(
-      $rangeTitle.get(0).innerText,
+      $rangeTitle.get(0).innerText.trim(),
       'Testing range pills',
       'Title of range pills is correct');
     assert.equal(
-      $rangePill.get(0).innerText,
+      $rangePill.get(0).innerText.trim(),
       'Last 30 Days',
       'Label of first pill is correct');
     assert.equal(
-      $rangePill.get(1).innerText,
+      $rangePill.get(1).innerText.trim(),
       '3 Months',
       'Label of 2nd pill is correct');
     assert.equal(
@@ -109,12 +109,12 @@ module('Integration | Component | range pill selectors', function(hooks) {
       'Range picker modal is displayed');
     await wait();
     assert.equal(
-      $rangePresets.get(0).innerText,
+      $rangePresets.get(0).innerText.trim(),
       'Today',
       'Range picker preset #1 is good');
     await wait();
     assert.equal(
-      $rangePresets.get(1).innerText,
+      $rangePresets.get(1).innerText.trim(),
       'Last 2 weeks',
       'Range picker preset #2 is good');
 

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-dimensions-settings/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-dimensions-settings/component-test.js
@@ -64,7 +64,7 @@ module('Integration | Component | rootcause-dimensions-settings', function(hooks
     );
 
     assert.equal(
-      $selectErrorField.innerText,
+      $selectErrorField.innerText.trim(),
       'false',
       'One-side-error default value is false'
     );

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/self-serve-alert-details/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/self-serve-alert-details/component-test.js
@@ -30,13 +30,13 @@ module('Integration | Component | self serve alert details', function(hooks) {
     const renderedPropNames = optionsToString(this.$(propTitleSel));
 
     assert.equal(
-      this.$(headerSel).get(0).innerText,
+      this.$(headerSel).get(0).innerText.trim(),
       'ACTIVE',
       'correctly displays alert status'
     );
 
     assert.equal(
-      this.$(titleSel).get(0).innerText,
+      this.$(titleSel).get(0).innerText.trim(),
       'test_function_1',
       'correctly displays alert title'
     );

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/shared/common-tabs/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/shared/common-tabs/component-test.js
@@ -32,7 +32,7 @@ module('Integration | Component | shared/common-tabs', function(hooks) {
     const $tabs = this.$('.common-tabs ul li');
 
     // Testing tabs
-    assert.equal($tabs.get(0).innerText, 'Metrics', 'Name of the first tab matches `Metrics` is correct.');
-    assert.equal($tabs.get(1).innerText, 'Dimensions', 'Name of the first tab matches `Dimensions` is correct.');
+    assert.equal($tabs.get(0).innerText.trim(), 'Metrics', 'Name of the first tab matches `Metrics` is correct.');
+    assert.equal($tabs.get(1).innerText.trim(), 'Dimensions', 'Name of the first tab matches `Dimensions` is correct.');
   });
 });

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/stats-cards/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/stats-cards/component-test.js
@@ -24,43 +24,43 @@ module('Integration | Component | stats cards', function(hooks) {
 
     // Testing titles of all cards
     assert.equal(
-      $title.get(0).innerText,
+      $title.get(0).innerText.trim(),
       stats[0][0],
       'title of 1st card is correct');
     assert.equal(
-      $title.get(1).innerText,
+      $title.get(1).innerText.trim(),
       stats[1][0],
       'title of 2nd card is correct');
     assert.equal(
-      $title.get(2).innerText,
+      $title.get(2).innerText.trim(),
       stats[2][0],
       'title of 3rd card is correct');
 
     // Testing descriptions of all cards
     assert.equal(
-      $description.get(0).innerText,
+      $description.get(0).innerText.trim(),
       stats[0][1],
       'description of 1st card is correct');
     assert.equal(
-      $description.get(1).innerText,
+      $description.get(1).innerText.trim(),
       stats[1][1],
       'description of 2nd card is correct');
     assert.equal(
-      $description.get(2).innerText,
+      $description.get(2).innerText.trim(),
       stats[2][1],
       'description of 3rd card is correct');
 
     // Testing values of all cards
     assert.equal(
-      $number.get(0).innerText,
+      $number.get(0).innerText.trim(),
       stats[0][2],
       'value of 1st card is correct');
     assert.equal(
-      $number.get(1).innerText,
+      $number.get(1).innerText.trim(),
       stats[1][2],
       'value of 2nd card is correct');
     assert.equal(
-      $number.get(2).innerText,
+      $number.get(2).innerText.trim(),
       stats[2][2],
       'value of 3rd card is correct');
   });


### PR DESCRIPTION
Introducing new anomaly resolution labels across Self-service flows (Alert page, Tuning page) and home dashboard (everywhere resolution options exist). Also resolving some UX problems with anomaly table interactions, making sure anomaly filtering by dimension and resolution label works properly.

Trimmed `innerText` strings in multiple tests to avoid brittleness.

<img width="467" alt="screen shot 2018-10-23 at 11 01 13 am" src="https://user-images.githubusercontent.com/11814420/47374429-8abe0880-d6b3-11e8-9ca2-52b59842ad27.png">
<img width="917" alt="screen shot 2018-10-23 at 11 01 37 am" src="https://user-images.githubusercontent.com/11814420/47374443-901b5300-d6b3-11e8-8c39-112d3b97bf92.png">

Still refining styling/positioning here:
<img width="1186" alt="screen shot 2018-10-23 at 11 25 28 am" src="https://user-images.githubusercontent.com/11814420/47375691-70d1f500-d6b6-11e8-987d-9d9136930690.png">
