### PR TITLE
Cleaning up crypter initialization

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -193,6 +193,7 @@ public class CommonConstants {
     public static final String VERSION_HTTP_HEADER = "Pinot-Controller-Version";
     public static final String SEGMENT_NAME_HTTP_HEADER = "Pinot-Segment-Name";
     public static final String TABLE_NAME_HTTP_HEADER = "Pinot-Table-Name";
+    public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
   }
 
   public static class Minion {
@@ -213,6 +214,7 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "storage.factory";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "segment.fetcher";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "segment.uploader";
+    public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "crypter";
   }
 
   public static class Metric {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -38,6 +38,7 @@ import com.linkedin.pinot.controller.helix.core.rebalance.RebalanceSegmentStrate
 import com.linkedin.pinot.controller.helix.core.relocation.RealtimeSegmentRelocator;
 import com.linkedin.pinot.controller.helix.core.retention.RetentionManager;
 import com.linkedin.pinot.controller.validation.ValidationManager;
+import com.linkedin.pinot.core.crypt.PinotCrypterFactory;
 import com.linkedin.pinot.filesystem.PinotFSFactory;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
@@ -125,6 +126,7 @@ public class ControllerStarter {
     Configuration pinotFSConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     Configuration segmentFetcherFactoryConfig =
         _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
+    Configuration pinotCrypterConfig = _config.subset(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
 
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");
@@ -140,6 +142,13 @@ public class ControllerStarter {
           .init(segmentFetcherFactoryConfig);
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while initializing SegmentFetcherFactory", e);
+    }
+
+    LOGGER.info("Initializing PinotCrypterFactory");
+    try {
+      PinotCrypterFactory.init(pinotCrypterConfig);
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while initializing PinotCrypterFactory", e);
     }
 
     LOGGER.info("Starting Pinot Helix resource manager and connecting to Zookeeper");

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -387,7 +387,6 @@ public class PinotSegmentUploadRestletResource {
   private void decryptFile(String crypterClassHeader, File tempEncryptedFile, File tempDecryptedFile) {
     PinotCrypter pinotCrypter = PinotCrypterFactory.create(crypterClassHeader);
     LOGGER.info("Using crypter class {}", pinotCrypter.getClass().getName());
-    pinotCrypter.init(_controllerConf.subset(CommonConstants.Segment.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER));
     pinotCrypter.decrypt(tempEncryptedFile, tempDecryptedFile);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/PinotCrypterFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/crypt/PinotCrypterFactory.java
@@ -15,6 +15,10 @@
  */
 package com.linkedin.pinot.core.crypt;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,20 +28,54 @@ import org.slf4j.LoggerFactory;
  */
 public class PinotCrypterFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(PinotCrypterFactory.class);
+  // Map of lower case simple class name to PinotCrypter object
+  private static Map<String, PinotCrypter> _crypterMap = new HashMap<>();
+  private static final String NOOP_PINOT_CRYPTER = "nooppinotcrypter";
+  private static final String CLASS = "class";
 
   // Prevent factory from being instantiated
   private PinotCrypterFactory() {
 
   }
 
-  public static PinotCrypter create(String crypterClassName) {
-    try {
-      LOGGER.info("Instantiating PinotCrypter class {}", crypterClassName);
-      PinotCrypter pinotCrypter =  (PinotCrypter) Class.forName(crypterClassName).newInstance();
-      return pinotCrypter;
-    } catch (Exception e) {
-      LOGGER.warn("Unable to instantiate {}, creating default crypter {}", crypterClassName, NoOpPinotCrypter.class.getName(), e);
-      return new NoOpPinotCrypter();
+  /**
+   * Initializes map of crypter classes at startup time. Will initialize map with lower case simple class names.
+   * @param config
+   */
+  public static void init(Configuration config) {
+    // Get schemes and their respective classes
+    Iterator<String> keys = config.subset(CLASS).getKeys();
+    if (!keys.hasNext()) {
+      LOGGER.info("Did not find any crypter classes in the configuration");
     }
+    while (keys.hasNext()) {
+      String key = keys.next();
+      String className = (String) config.getProperty(CLASS + "." + key);
+      LOGGER.info("Got crypter class name {}, full crypter path {}, starting to initialize", key, className);
+
+      try {
+        PinotCrypter pinotCrypter = (PinotCrypter) Class.forName(className).newInstance();
+        pinotCrypter.init(config.subset(key));
+
+        LOGGER.info("Initializing PinotCrypter for scheme {}, classname {}", key, className);
+        _crypterMap.put(key.toLowerCase(), pinotCrypter);
+      } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+        LOGGER.error("Could not instantiate crypter for class {}", className, e);
+        throw new RuntimeException(e);
+      }
+    }
+
+    if (!_crypterMap.containsKey(NOOP_PINOT_CRYPTER)) {
+      LOGGER.info("DefaultPinotCrypter not configured, adding as default");
+      _crypterMap.put(NOOP_PINOT_CRYPTER, new NoOpPinotCrypter());
+    }
+  }
+
+  public static PinotCrypter create(String crypterClassName) {
+    PinotCrypter pinotCrypter = _crypterMap.get(crypterClassName.toLowerCase());
+    if (pinotCrypter == null) {
+      throw new RuntimeException("Pinot crypter not configured for class name: " + crypterClassName);
+    }
+    return pinotCrypter;
   }
 }

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.common.utils.ClientSSLContextGenerator;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
+import com.linkedin.pinot.core.crypt.PinotCrypterFactory;
 import com.linkedin.pinot.filesystem.PinotFSFactory;
 import com.linkedin.pinot.minion.events.EventObserverFactoryRegistry;
 import com.linkedin.pinot.minion.events.MinionEventObserverFactory;
@@ -140,6 +141,11 @@ public class MinionStarter {
     Configuration segmentFetcherFactoryConfig =
         _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
     SegmentFetcherFactory.getInstance().init(segmentFetcherFactoryConfig);
+
+    LOGGER.info("Initializing pinot crypter");
+    Configuration pinotCrypterConfig =
+        _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
+    PinotCrypterFactory.init(pinotCrypterConfig);
 
     // Need to do this before we start receiving state transitions.
     LOGGER.info("Initializing ssl context for segment uploader");

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -61,9 +61,11 @@ public class SegmentFetcherAndLoader {
     Configuration pinotFSConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     Configuration segmentFetcherFactoryConfig =
         config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY);
+    Configuration pinotCrypterConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
 
     PinotFSFactory.init(pinotFSConfig);
     SegmentFetcherFactory.getInstance().init(segmentFetcherFactoryConfig);
+    PinotCrypterFactory.init(pinotCrypterConfig);
 
     _crypterConfig = config.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_PINOT_CRYPTER);
   }


### PR DESCRIPTION
* Cleaning up crypter initialization so that the crypter classes are created upon controller/server/minion startup.
* Changed the way crypter is initialized in segment upload accordingly
* Configs will be prefixed with crypter.class.${CRYPTER_CLASS_NAME}, and each crypter will call init with the subset of configs from the ${CRYPTER_CLASS_NAME}
* Added unit test for custom crypter