### PR TITLE
Supporting delete api for different storage options

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -16,19 +16,26 @@
 package com.linkedin.pinot.controller;
 
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.filesystem.LocalPinotFS;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ControllerConf extends PropertiesConfiguration {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerConf.class);
+
   private static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   private static final String CONTROLLER_VIP_PORT = "controller.vip.port";
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
@@ -96,6 +103,28 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public ControllerConf() {
     super();
+  }
+
+  /**
+   * Returns the URI for the given path, appends the local (file) scheme to the URI if no scheme exists.
+   */
+  public static URI getUriFromPath(String path) throws URISyntaxException {
+    URI uri = new URI(path);
+    if (uri.getScheme() != null) {
+      return uri;
+    } else {
+      return new URI(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME, path, null);
+    }
+  }
+
+  public static URI constructSegmentLocation(String baseDataDir, String tableName, String segmentName) {
+    try {
+      return new URI(StringUtil.join(File.separator, baseDataDir, tableName, URLEncoder.encode(segmentName, "UTF-8")));
+    } catch (UnsupportedEncodingException | URISyntaxException e) {
+      LOGGER.error("Could not construct segment location with baseDataDir {}, tableName {}, segmentName {}",
+          baseDataDir, tableName, segmentName);
+      throw new RuntimeException(e);
+    }
   }
 
   public static String constructDownloadUrl(String tableName, String segmentName, String vip) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -108,12 +108,17 @@ public class ControllerConf extends PropertiesConfiguration {
   /**
    * Returns the URI for the given path, appends the local (file) scheme to the URI if no scheme exists.
    */
-  public static URI getUriFromPath(String path) throws URISyntaxException {
-    URI uri = new URI(path);
-    if (uri.getScheme() != null) {
-      return uri;
-    } else {
-      return new URI(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME, path, null);
+  public static URI getUriFromPath(String path) {
+    try {
+      URI uri = new URI(path);
+      if (uri.getScheme() != null) {
+        return uri;
+      } else {
+        return new URI(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME, path, null);
+      }
+    } catch (URISyntaxException e) {
+      LOGGER.error("Could not construct uri from path {}", path);
+      throw new RuntimeException(e);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -116,7 +116,7 @@ public class PinotHelixResourceManager {
   private final String _helixZkURL;
   private final String _helixClusterName;
   private final String _instanceId;
-  private final String _localDiskDir;
+  private final String _dataDir;
   private final long _externalViewOnlineToOfflineTimeoutMillis;
   private final boolean _isSingleTenantCluster;
   private final boolean _isUpdateStateModel;
@@ -130,20 +130,20 @@ public class PinotHelixResourceManager {
   private TableRebalancer _tableRebalancer;
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
-      @Nonnull String controllerInstanceId, String localDiskDir, long externalViewOnlineToOfflineTimeoutMillis,
+      @Nonnull String controllerInstanceId, String dataDir, long externalViewOnlineToOfflineTimeoutMillis,
       boolean isSingleTenantCluster, boolean isUpdateStateModel) {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(zkURL);
     _helixClusterName = helixClusterName;
     _instanceId = controllerInstanceId;
-    _localDiskDir = localDiskDir;
+    _dataDir = dataDir;
     _externalViewOnlineToOfflineTimeoutMillis = externalViewOnlineToOfflineTimeoutMillis;
     _isSingleTenantCluster = isSingleTenantCluster;
     _isUpdateStateModel = isUpdateStateModel;
   }
 
   public PinotHelixResourceManager(@Nonnull String zkURL, @Nonnull String helixClusterName,
-      @Nonnull String controllerInstanceId, @Nonnull String localDiskDir) {
-    this(zkURL, helixClusterName, controllerInstanceId, localDiskDir, DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS,
+      @Nonnull String controllerInstanceId, @Nonnull String dataDir) {
+    this(zkURL, helixClusterName, controllerInstanceId, dataDir, DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS,
         false, false);
   }
 
@@ -164,7 +164,7 @@ public class PinotHelixResourceManager {
     _propertyStore = _helixZkManager.getHelixPropertyStore();
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
     _keyBuilder = _helixDataAccessor.keyBuilder();
-    _segmentDeletionManager = new SegmentDeletionManager(_localDiskDir, _helixAdmin, _helixClusterName, _propertyStore);
+    _segmentDeletionManager = new SegmentDeletionManager(_dataDir, _helixAdmin, _helixClusterName, _propertyStore);
     ZKMetadataProvider.setClusterTenantIsolationEnabled(_propertyStore, _isSingleTenantCluster);
     _tableRebalancer = new TableRebalancer(_helixZkManager, _helixAdmin, _helixClusterName);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -193,9 +193,6 @@ public class SegmentDeletionManager {
           // Overwrites the file if it already exists in the target directory.
           pinotFS.move(fileToMoveURI, deletedSegmentDirURI);
           LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMoveURI.toString(), deletedSegmentDirURI.toString());
-          if (!pinotFS.delete(fileToMoveURI)) {
-            LOGGER.warn("Could not delete file", segmentId, fileToMoveURI.toString());
-          }
         } else {
           CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
           switch (tableType) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -15,9 +15,19 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.SegmentName;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.filesystem.PinotFS;
+import com.linkedin.pinot.filesystem.PinotFSFactory;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -40,10 +50,6 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.SegmentName;
 
 public class SegmentDeletionManager {
 
@@ -52,14 +58,14 @@ public class SegmentDeletionManager {
   private static final long DEFAULT_DELETION_DELAY_SECONDS = 2L;
 
   private final ScheduledExecutorService _executorService;
-  private final String _localDiskDir;
+  private final String _dataDir;
   private final String _helixClusterName;
   private final HelixAdmin _helixAdmin;
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private final String DELETED_SEGMENTS = "Deleted_Segments";
 
-  public SegmentDeletionManager(String localDiskDir, HelixAdmin helixAdmin, String helixClusterName, ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    _localDiskDir = localDiskDir;
+  public SegmentDeletionManager(String dataDir, HelixAdmin helixAdmin, String helixClusterName, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _dataDir = dataDir;
     _helixAdmin = helixAdmin;
     _helixClusterName = helixClusterName;
     _propertyStore = propertyStore;
@@ -168,37 +174,51 @@ public class SegmentDeletionManager {
 
   protected void removeSegmentFromStore(String tableNameWithType, String segmentId) {
     final String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-    if (_localDiskDir != null) {
-      File fileToMove = new File(new File(_localDiskDir, rawTableName), segmentId);
-      if (fileToMove.exists()) {
-        File targetDir = new File(new File(_localDiskDir, DELETED_SEGMENTS), rawTableName);
-        try {
-          // Overwrites the file if it already exists in the target directory.
-          FileUtils.copyFileToDirectory(fileToMove, targetDir, false);
-          LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), targetDir.getAbsolutePath());
-          if (!fileToMove.delete()) {
-            LOGGER.warn("Could not delete file", segmentId, fileToMove.getAbsolutePath());
-          }
-        } catch (IOException e) {
-          LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), targetDir.getAbsolutePath(), e);
-        }
-      } else {
-        CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-        switch (tableType) {
-          case OFFLINE:
-            LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
-            break;
-          case REALTIME:
-            if (SegmentName.isLowLevelConsumerSegmentName(segmentId)) {
-              LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
-            }
-            break;
-          default:
-            LOGGER.warn("Unsupported table type {} when deleting segment {}", tableType, segmentId);
-        }
+    if (_dataDir != null) {
+      URI deletedSegmentDirURI;
+      URI fileToMoveURI;
+      PinotFS pinotFS;
+      try {
+        URI dataDirURI = ControllerConf.getUriFromPath(_dataDir);
+        fileToMoveURI = ControllerConf.constructSegmentLocation(_dataDir, rawTableName, segmentId);
+        pinotFS = PinotFSFactory.create(dataDirURI.getScheme());
+        deletedSegmentDirURI = ControllerConf.getUriFromPath(StringUtil.join(File.separator, _dataDir, DELETED_SEGMENTS, rawTableName));
+      } catch (URISyntaxException e) {
+        LOGGER.error("Could not create DELETED_SEGMENTS uri with dataDir {}, tableName {}", _dataDir, rawTableName);
+        throw new RuntimeException(e);
       }
+
+      try {
+        if (pinotFS.exists(fileToMoveURI)) {
+          // Overwrites the file if it already exists in the target directory.
+          pinotFS.move(fileToMoveURI, deletedSegmentDirURI);
+          LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMoveURI.toString(), deletedSegmentDirURI.toString());
+          if (!pinotFS.delete(fileToMoveURI)) {
+            LOGGER.warn("Could not delete file", segmentId, fileToMoveURI.toString());
+          }
+        } else {
+          CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+          switch (tableType) {
+            case OFFLINE:
+              LOGGER.warn("Not found segment file for segment {}" + fileToMoveURI.toString());
+              break;
+            case REALTIME:
+              if (SegmentName.isLowLevelConsumerSegmentName(segmentId)) {
+                LOGGER.warn("Not found segment file for segment {}" + fileToMoveURI.toString());
+              }
+              break;
+            default:
+              LOGGER.warn("Unsupported table type {} when deleting segment {}", tableType, segmentId);
+          }
+        }
+
+      } catch (IOException e) {
+        LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMoveURI.toString(),
+            deletedSegmentDirURI.toString(), e);
+      }
+
     } else {
-      LOGGER.info("localDiskDir is not configured, won't delete segment {} from disk", segmentId);
+      LOGGER.info("dataDir is not configured, won't delete segment {} from disk", segmentId);
     }
   }
 
@@ -207,8 +227,8 @@ public class SegmentDeletionManager {
    * @param retentionInDays: retention for deleted segments in days
    */
   public void removeAgedDeletedSegments(int retentionInDays) {
-    if (_localDiskDir != null) {
-      File deletedDir = new File(_localDiskDir, DELETED_SEGMENTS);
+    if (_dataDir != null) {
+      File deletedDir = new File(_dataDir, DELETED_SEGMENTS);
       // Check that the directory for deleted segments exists
       if (!deletedDir.isDirectory()) {
         LOGGER.warn("Deleted segment directory {} does not exist or it is not directory.", deletedDir.getAbsolutePath());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -16,7 +16,10 @@
 package com.linkedin.pinot.controller.helix.core.util;
 
 import com.google.common.io.Files;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.controller.helix.core.SegmentDeletionManager;
+import com.linkedin.pinot.filesystem.LocalPinotFS;
+import com.linkedin.pinot.filesystem.PinotFSFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import junit.framework.Assert;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
@@ -137,9 +141,9 @@ public class SegmentDeletionManagerTest {
     FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
     Collection<String> segments;
     if (useSet) {
-      segments = new HashSet<String>();
+      segments = new HashSet<>();
     } else {
-      segments = new ArrayList<String>();
+      segments = new ArrayList<>();
     }
 
     segments.addAll(segmentsThatShouldBeDeleted());
@@ -153,7 +157,7 @@ public class SegmentDeletionManagerTest {
   }
 
   @Test
-  public void testAllFailed() throws Exception {
+  public void testAllFailed() {
     testAllFailed(segmentsFailingPropStore());
     testAllFailed(segmentsInIdealStateOrExtView());
     List<String> segments = segmentsFailingPropStore();
@@ -162,7 +166,7 @@ public class SegmentDeletionManagerTest {
   }
 
   @Test
-  public void allPassed() throws Exception {
+  public void allPassed() {
     HelixAdmin helixAdmin = makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
     FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
@@ -175,7 +179,7 @@ public class SegmentDeletionManagerTest {
     Assert.assertTrue(deletionManager.segmentsRemovedFromStore.containsAll(segments));
   }
 
-  private void testAllFailed(List<String> segments) throws Exception {
+  private void testAllFailed(List<String> segments) {
     HelixAdmin helixAdmin =  makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
     FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
@@ -188,6 +192,11 @@ public class SegmentDeletionManagerTest {
 
   @Test
   public void testRemoveDeletedSegments() throws Exception {
+    PropertiesConfiguration pinotFSConfig = new PropertiesConfiguration();
+    pinotFSConfig.addProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY + ".class",
+        LocalPinotFS.class.getName());
+    PinotFSFactory.init(pinotFSConfig);
+
     HelixAdmin helixAdmin = makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
     File tempDir = Files.createTempDir();

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -73,8 +73,7 @@ public class LocalPinotFS extends PinotFS {
     if (!srcFile.isDirectory()) {
       dstFile.getParentFile().mkdirs();
       FileUtils.moveFile(srcFile, dstFile);
-    }
-    if (srcFile.isDirectory()) {
+    } else {
       Files.move(srcFile.toPath(), dstFile.toPath());
     }
     return true;


### PR DESCRIPTION
* This PR adds support to delete Pinot segments in different storage systems using the delete api.
* We use PinotFS methods in order to do so.
* Test coverage in SegmentDeletionManagerTest and DeleteAPI Integration Test