### PR TITLE
Adding RetentionManager Support for Pluggable Storage

### DIFF
--- a/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
@@ -142,8 +142,8 @@ public class AzurePinotFS extends PinotFS {
     }
 
     if (!recursive) {
-      List<String> shallowDirPaths = new ArrayList<>();
       List<DirectoryEntry> shallowDirectoryEntries = _adlStoreClient.enumerateDirectory(rootDir.fullName);
+      List<String> shallowDirPaths = new ArrayList<>(shallowDirectoryEntries.size());
       for (DirectoryEntry directoryEntry : shallowDirectoryEntries) {
         shallowDirPaths.add(directoryEntry.fullName);
       }
@@ -209,7 +209,8 @@ public class AzurePinotFS extends PinotFS {
     try {
       dirEntry = _adlStoreClient.getDirectoryEntry(uri.getPath());
     } catch (IOException e) {
-      return false;
+      LOGGER.error("Could not get directory entry for {}", uri);
+      throw new RuntimeException(e);
     }
 
     return dirEntry.type.equals(DirectoryEntryType.DIRECTORY);
@@ -220,7 +221,8 @@ public class AzurePinotFS extends PinotFS {
     try {
       return _adlStoreClient.getDirectoryEntry(uri.getPath()).lastModifiedTime.getTime();
     } catch (IOException e) {
-      return 0L;
+      LOGGER.error("Could not get directory entry for {}", uri);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.filesystem.PinotFSFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +49,7 @@ public class FileUploadPathProvider {
     String dataDir = controllerConf.getDataDir();
     try {
       // URIs that are allowed to be remote
-      _baseDataDirURI = getUriFromPath(dataDir);
+      _baseDataDirURI = ControllerConf.getUriFromPath(dataDir);
       LOGGER.info("Data directory: {}", _baseDataDirURI);
       _schemasTmpDirURI = new URI(_baseDataDirURI + SCHEMAS_TEMP);
       LOGGER.info("Schema temporary directory: {}", _schemasTmpDirURI);
@@ -65,7 +64,7 @@ public class FileUploadPathProvider {
         LOGGER.info("Local temporary directory is not configured, use data directory as the local temporary directory");
         _localTempDirURI = _baseDataDirURI;
       } else {
-        _localTempDirURI = getUriFromPath(localTempDir);
+        _localTempDirURI = ControllerConf.getUriFromPath(localTempDir);
       }
       LOGGER.info("Local temporary directory: {}", _localTempDirURI);
       if (!_localTempDirURI.getScheme().equalsIgnoreCase(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME)) {
@@ -83,18 +82,6 @@ public class FileUploadPathProvider {
       _vip = controllerConf.generateVipUrl();
     } catch (Exception e) {
       throw new InvalidControllerConfigException("Caught exception while initializing file upload path provider", e);
-    }
-  }
-
-  /**
-   * Returns the URI for the given path, appends the local (file) scheme to the URI if no scheme exists.
-   */
-  private static URI getUriFromPath(String path) throws URISyntaxException {
-    URI uri = new URI(path);
-    if (uri.getScheme() != null) {
-      return uri;
-    } else {
-      return new URI(CommonConstants.Segment.LOCAL_SEGMENT_SCHEME, path, null);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -227,16 +227,16 @@ public class SegmentDeletionManager {
         return;
       }
 
-      for (String dir : tableNameDirs) {
-        URI uri = ControllerConf.getUriFromPath(dir);
+      for (String tableNameDir : tableNameDirs) {
+        URI tableNameURI = ControllerConf.getUriFromPath(tableNameDir);
         // Get files that are aged
-        final String[] targetFiles = pinotFS.listFiles(uri, false);
+        final String[] targetFiles = pinotFS.listFiles(tableNameURI, false);
         int numFilesDeleted = 0;
         for (String targetFile : targetFiles) {
           URI targetURI = ControllerConf.getUriFromPath(targetFile);
           Date dateToDelete = DateTime.now().minusDays(retentionInDays).toDate();
           if (pinotFS.lastModified(targetURI) < dateToDelete.getTime()) {
-            if (!pinotFS.delete(targetURI, false)) {
+            if (!pinotFS.delete(targetURI, true)) {
               LOGGER.warn("Cannot remove file {} from deleted directory.", targetURI.toString());
             } else {
               numFilesDeleted ++;
@@ -246,8 +246,8 @@ public class SegmentDeletionManager {
 
         if (numFilesDeleted == targetFiles.length) {
           // Delete directory if it's empty
-          if (!pinotFS.delete(uri, true)) {
-            LOGGER.warn("The directory {} cannot be removed.", dir);
+          if (!pinotFS.delete(tableNameURI, false)) {
+            LOGGER.warn("The directory {} cannot be removed.", tableNameDir);
           }
         }
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -230,7 +230,7 @@ public class SegmentDeletionManager {
       for (String currentDir : deletedDirFiles) {
         URI currentURI = ControllerConf.getUriFromPath(currentDir);
         // Get files that are aged
-        String[] targetFiles = pinotFS.listFiles(currentURI, false);
+        final String[] targetFiles = pinotFS.listFiles(currentURI, false);
         int numFilesDeleted = 0;
         for (String targetFile : targetFiles) {
           URI targetURI = ControllerConf.getUriFromPath(targetFile);

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.Files;
-import java.util.Collection;
+import java.util.Arrays;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -114,10 +114,17 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public String[] listFiles(URI fileUri) throws IOException {
+  public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
     File file = new File(decodeURI(fileUri.getRawPath()));
-    Collection<File> files = FileUtils.listFiles(file, null, true);
-    return files.stream().map(File::getPath).toArray(String[]::new);
+    if (!recursive) {
+      return file.list();
+    } else {
+      File[] files = file.listFiles();
+      if (files == null) {
+        return new String[0];
+      }
+      return Arrays.stream(files).map(File::getPath).toArray(String[]::new);
+    }
   }
 
   @Override
@@ -131,15 +138,36 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean isDirectory(URI uri) throws IOException {
-    return new File(uri).isDirectory();
+  public boolean isDirectory(URI uri) {
+    File file = new File(decodeURI(uri.getRawPath()));
+    return file.isDirectory();
   }
 
-  private String encodeURI(String uri) throws UnsupportedEncodingException {
-    return URLEncoder.encode(uri, DEFAULT_ENCODING);
+  @Override
+  public long lastModified(URI uri) {
+    File file = new File(decodeURI(uri.getRawPath()));
+    return file.lastModified();
   }
 
-  private String decodeURI(String uri) throws UnsupportedEncodingException {
-    return URLDecoder.decode(uri, DEFAULT_ENCODING);
+  private String encodeURI(String uri) {
+    String encodedStr;
+    try {
+      encodedStr = URLEncoder.encode(uri, DEFAULT_ENCODING);
+    } catch (UnsupportedEncodingException e) {
+      LOGGER.warn("Could not encode uri {}", uri);
+      throw new RuntimeException(e);
+    }
+    return encodedStr;
+  }
+
+  private String decodeURI(String uri) {
+    String decodedStr;
+    try {
+      decodedStr = URLDecoder.decode(uri, DEFAULT_ENCODING);
+    } catch (UnsupportedEncodingException e) {
+      LOGGER.warn("Could not decode uri {}", uri);
+      throw new RuntimeException(e);
+    }
+    return decodedStr;
   }
 }

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -117,13 +117,13 @@ public class LocalPinotFS extends PinotFS {
   public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
     File file = new File(decodeURI(fileUri.getRawPath()));
     if (!recursive) {
-      return file.list();
+      return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
     } else {
       File[] files = file.listFiles();
       if (files == null) {
         return new String[0];
       }
-      return Arrays.stream(files).map(File::getPath).toArray(String[]::new);
+      return Arrays.stream(files).map(File::getAbsolutePath).toArray(String[]::new);
     }
   }
 

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
@@ -117,13 +119,13 @@ public class LocalPinotFS extends PinotFS {
   public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
     File file = new File(decodeURI(fileUri.getRawPath()));
     if (!recursive) {
-      return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
+      return Arrays.stream(file.list())
+          .map(s -> new File(file, s))
+          .map(File::getAbsolutePath).toArray(String[]::new);
     } else {
-      File[] files = file.listFiles();
-      if (files == null) {
-        return new String[0];
-      }
-      return Arrays.stream(files).map(File::getAbsolutePath).toArray(String[]::new);
+       return Files.walk(Paths.get(fileUri)).
+           filter(s -> !s.equals(file.toPath()))
+           .map(Path::toString).toArray(String[]::new);
     }
   }
 

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -53,9 +53,13 @@ public class LocalPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean delete(URI segmentUri) throws IOException {
+  public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
     File file = new File(decodeURI(segmentUri.getRawPath()));
     if (file.isDirectory()) {
+      // Returns false if directory isn't empty
+      if (listFiles(segmentUri, false).length > 0 && !forceDelete) {
+        return false;
+      }
       // Throws an IOException if it is unable to delete
       FileUtils.deleteDirectory(file);
     } else {

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -49,7 +49,7 @@ public abstract class PinotFS implements Closeable {
    * Moves the file from the src to dst. Does not keep the original file. If the dst has parent directories
    * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
    * it will overwrite. Will work either for moving a directory or a file. Currently assumes that both the srcUri
-   * and the dstUri are of the same time (both files or both directories).
+   * and the dstUri are of the same type (both files or both directories).
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @param overwrite true if we want to overwrite the dstURI, false otherwise
@@ -61,7 +61,7 @@ public abstract class PinotFS implements Closeable {
   /**
    * Copies a file from src to dst. Keeps the original file. If the dst has parent directories that haven't
    * been created, this method will create all the necessary parent directories. If dst already exists, it will overwrite.
-   * Works both for moving a directory and a file.
+   * Works both for moving a directory and a file. Assumes that srcUri and dstUri are of the same type (both files and directories)
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return true if copy is successful

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -55,6 +55,8 @@ public abstract class PinotFS implements Closeable {
    * and the dstUri are of the same type (both files or both directories). If srcUri is a file, it will move the file to
    * dstUri's location. If srcUri is a directory, it will move the directory to dstUri. Does not support moving a file under a
    * directory.
+   *
+   * For example, if a/b/c is moved to x/y/z, in the case of overwrite, a/b/c will be renamed to x/y/z.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @param overwrite true if we want to overwrite the dstURI, false otherwise
@@ -65,11 +67,8 @@ public abstract class PinotFS implements Closeable {
   public abstract boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException;
 
   /**
-   * Copies a file from src to dst. Keeps the original file. If the dst has parent directories that haven't
-   * been created, this method will create all the necessary parent directories. If dst already exists, it will overwrite.
-   * Works both for copying a directory and a file. If srcUri is a file, it will copy the file to
-   * dstUri's location. If srcUri is a directory, it will copy the directory to dstUri. Does not support copying a file under a
-   * directory.
+   * Same as move except the srcUri is not retained. For example, if x/y/z is copied to a/b/c, x/y/z will be retained
+   * and x/y/z will also be present as a/b/c
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return true if copy is successful

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -40,32 +40,41 @@ public abstract class PinotFS implements Closeable {
   /**
    * Deletes the file at the location provided. If the segmentUri is a directory, it will delete the entire directory.
    * @param segmentUri URI of the segment
+   * @param forceDelete true if we want the uri and any suburis to always be deleted, true if we want delete to fail
+   *                    when we want to delete a directory and that directory is not empty
    * @return true if delete is successful else false
    * @throws IOException IO failure
+   * @throws Exception if segmentUri is not valid or present
    */
-  public abstract boolean delete(URI segmentUri) throws IOException;
+  public abstract boolean delete(URI segmentUri, boolean forceDelete) throws IOException;
 
   /**
    * Moves the file from the src to dst. Does not keep the original file. If the dst has parent directories
    * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
    * it will overwrite. Will work either for moving a directory or a file. Currently assumes that both the srcUri
-   * and the dstUri are of the same type (both files or both directories).
+   * and the dstUri are of the same type (both files or both directories). If srcUri is a file, it will move the file to
+   * dstUri's location. If srcUri is a directory, it will move the directory to dstUri. Does not support moving a file under a
+   * directory.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @param overwrite true if we want to overwrite the dstURI, false otherwise
    * @return true if move is successful
    * @throws IOException on failure
+   * @throws Exception if srcUri is not present or valid
    */
   public abstract boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException;
 
   /**
    * Copies a file from src to dst. Keeps the original file. If the dst has parent directories that haven't
    * been created, this method will create all the necessary parent directories. If dst already exists, it will overwrite.
-   * Works both for moving a directory and a file. Assumes that srcUri and dstUri are of the same type (both files and directories)
+   * Works both for copying a directory and a file. If srcUri is a file, it will copy the file to
+   * dstUri's location. If srcUri is a directory, it will copy the directory to dstUri. Does not support copying a file under a
+   * directory.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return true if copy is successful
    * @throws IOException on IO Failure
+   * @throws Exception if srcUri is not present or valid
    */
   public abstract boolean copy(URI srcUri, URI dstUri) throws IOException;
 
@@ -82,6 +91,7 @@ public abstract class PinotFS implements Closeable {
    * @param fileUri location of file
    * @return the number of bytes
    * @throws IOException on IO Failure
+   * @throws Exception if fileUri is not valid or present
    */
   public abstract long length(URI fileUri) throws IOException;
 
@@ -93,6 +103,7 @@ public abstract class PinotFS implements Closeable {
    * @param recursive if we want to list files recursively
    * @return an array of strings that contains file paths
    * @throws IOException see specific implementation
+   * @throws Exception if fileUri is not valid or present
    */
   public abstract String[] listFiles(URI fileUri, boolean recursive) throws IOException;
 
@@ -100,7 +111,7 @@ public abstract class PinotFS implements Closeable {
    * Copies a file from a remote filesystem to the local one. Keeps the original file.
    * @param srcUri location of current file on remote filesystem
    * @param dstFile location of destination on local filesystem
-   * @throws Exception
+   * @throws Exception if srcUri is not valid or present
    */
   public abstract void copyToLocalFile(URI srcUri, File dstFile) throws Exception;
 
@@ -110,6 +121,7 @@ public abstract class PinotFS implements Closeable {
    * @param srcFile location of src file on local disk
    * @param dstUri location of dst on remote filesystem
    * @throws IOException for IO Error
+   * @throws Exception if fileUri is not valid or present
    */
   public abstract void copyFromLocalFile(File srcFile, URI dstUri) throws Exception;
 
@@ -117,6 +129,7 @@ public abstract class PinotFS implements Closeable {
    * Allows us the ability to determine whether the uri is a directory.
    * @param uri location of file or directory
    * @return true if uri is a directory, false otherwise.
+   * @throws Exception if uri is not valid or present
    */
   public abstract boolean isDirectory(URI uri);
 
@@ -125,6 +138,7 @@ public abstract class PinotFS implements Closeable {
    * @param uri
    * @return A long value representing the time the file was last modified, measured in milliseconds since epoch
    * (00:00:00 GMT, January 1, 1970) or 0L if the file does not exist or if an I/O error occurs
+   * @throws Exception if uri is not valid or present
    */
   public abstract long lastModified(URI uri);
 

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -90,10 +90,11 @@ public abstract class PinotFS implements Closeable {
    * Throws exception if this abstract pathname is not valid, or if
    * an I/O error occurs.
    * @param fileUri location of file
+   * @param recursive if we want to list files recursively
    * @return an array of strings that contains file paths
    * @throws IOException see specific implementation
    */
-  public abstract String[] listFiles(URI fileUri) throws IOException;
+  public abstract String[] listFiles(URI fileUri, boolean recursive) throws IOException;
 
   /**
    * Copies a file from a remote filesystem to the local one. Keeps the original file.
@@ -117,7 +118,15 @@ public abstract class PinotFS implements Closeable {
    * @param uri location of file or directory
    * @return true if uri is a directory, false otherwise.
    */
-  public abstract boolean isDirectory(URI uri) throws IOException;
+  public abstract boolean isDirectory(URI uri);
+
+  /**
+   * Returns the age of the file
+   * @param uri
+   * @return A long value representing the time the file was last modified, measured in milliseconds since epoch
+   * (00:00:00 GMT, January 1, 1970) or 0L if the file does not exist or if an I/O error occurs
+   */
+  public abstract long lastModified(URI uri);
 
   /**
    * For certain filesystems, we may need to close the filesystem and do relevant operations to prevent leaks.

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -124,7 +124,7 @@ public class LocalPinotFSTest {
     Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true));
     Assert.assertEquals(_absoluteTmpDirPath.length(), 0);
 
-    localPinotFS.delete(secondTestFileUri);
+    localPinotFS.delete(secondTestFileUri, true);
     // Check deletion from final location worked
     Assert.assertTrue(!localPinotFS.exists(secondTestFileUri));
 

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -85,16 +85,29 @@ public class LocalPinotFSTest {
     File thirdTestFile = new File(_absoluteTmpDirPath, "thirdTestFile");
     Assert.assertTrue(thirdTestFile.createNewFile(), "Could not create file " + thirdTestFile.getPath());
 
-    // Tests recursive move works
-    File testDir = new File(_absoluteTmpDirPath, "testDir");
+    File newAbsoluteTempDirPath = new File(_absoluteTmpDirPath, "absoluteTwo");
+    Assert.assertTrue(newAbsoluteTempDirPath.mkdir());
+
+    // Create a testDir and file underneath directory
+    File testDir = new File(newAbsoluteTempDirPath, "testDir");
     Assert.assertTrue(testDir.mkdir(), "Could not make directory " + testDir.getAbsolutePath());
     File testDirFile = new File(testDir, "testFile");
+    // Assert that recursive list files and nonrecursive list files are as expected
     Assert.assertTrue(testDirFile.createNewFile(), "Could not create file " + testDir.getAbsolutePath());
-    File testDir2 = new File(_absoluteTmpDirPath, "testDir2");
-    File testDirFile2 = new File(testDir2, "testFile");
-    Assert.assertFalse(localPinotFS.exists(testDirFile2.toURI()));
-    localPinotFS.move(testDir.toURI(), testDir2.toURI(), true);
-    Assert.assertTrue(localPinotFS.exists(testDirFile2.toURI()));
+    Assert.assertEquals(localPinotFS.listFiles(newAbsoluteTempDirPath.toURI(), false), new String[]{testDir.getAbsolutePath()});
+    Assert.assertEquals(localPinotFS.listFiles(newAbsoluteTempDirPath.toURI(), true),
+        new String[]{testDir.getAbsolutePath(), testDirFile.getAbsolutePath()});
+
+    // Create another parent dir so we can test recursive move
+    File newAbsoluteTempDirPath3 = new File(_absoluteTmpDirPath, "absoluteThree");
+    Assert.assertTrue(newAbsoluteTempDirPath3.mkdir());
+    Assert.assertEquals(newAbsoluteTempDirPath3.listFiles().length, 0);
+
+    localPinotFS.move(newAbsoluteTempDirPath.toURI(), newAbsoluteTempDirPath3.toURI(), true);
+    Assert.assertFalse(localPinotFS.exists(newAbsoluteTempDirPath.toURI()));
+    Assert.assertTrue(localPinotFS.exists(newAbsoluteTempDirPath3.toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(newAbsoluteTempDirPath3, "testDir").toURI()));
+    Assert.assertTrue(localPinotFS.exists(new File(new File(newAbsoluteTempDirPath3, "testDir"), "testFile").toURI()));
 
     // Check file copy to location where something already exists still works
     localPinotFS.copy(testFileUri, thirdTestFile.toURI());

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -144,7 +144,6 @@ public class LocalPinotFSTest {
     Assert.assertTrue(newTestFile.createNewFile(), "Could not create file " + newTestFile.getPath());
 
     localPinotFS.copy(firstTempDir.toURI(), secondTempDir.toURI());
-    localPinotFS.listFiles(secondTempDir.toURI(), true);
     Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), true).length, 1);
 
     // len of dir = exception

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -64,6 +64,7 @@ public class LocalPinotFSTest {
     URI testFileUri = testFile.toURI();
     // Check whether a directory exists
     Assert.assertTrue(localPinotFS.exists(_absoluteTmpDirPath.toURI()));
+    Assert.assertTrue(localPinotFS.lastModified(_absoluteTmpDirPath.toURI()) > 0L);
     Assert.assertTrue(localPinotFS.isDirectory(_absoluteTmpDirPath.toURI()));
     // Check whether a file exists
     Assert.assertTrue(localPinotFS.exists(testFileUri));
@@ -75,7 +76,7 @@ public class LocalPinotFSTest {
     Assert.assertTrue(!localPinotFS.exists(secondTestFileUri));
 
     localPinotFS.copy(testFileUri, secondTestFileUri);
-    Assert.assertEquals(2, localPinotFS.listFiles(_absoluteTmpDirPath.toURI()).length);
+    Assert.assertEquals(2, localPinotFS.listFiles(_absoluteTmpDirPath.toURI(), true).length);
 
     // Check file copy worked when file was not created
     Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
@@ -130,8 +131,8 @@ public class LocalPinotFSTest {
     Assert.assertTrue(newTestFile.createNewFile(), "Could not create file " + newTestFile.getPath());
 
     localPinotFS.copy(firstTempDir.toURI(), secondTempDir.toURI());
-    localPinotFS.listFiles(secondTempDir.toURI());
-    Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI()).length, 1);
+    localPinotFS.listFiles(secondTempDir.toURI(), true);
+    Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), true).length, 1);
 
     // len of dir = exception
     try {
@@ -147,13 +148,5 @@ public class LocalPinotFSTest {
     Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
     localPinotFS.copyToLocalFile(testFile.toURI(), new File(secondTestFileUri));
     Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
-
-    // List files on a file - exception if file already exists
-    try {
-      localPinotFS.listFiles(thirdTestFile.toURI());
-      fail();
-    } catch (IllegalArgumentException e) {
-
-    }
   }
 }

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
@@ -75,7 +75,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public boolean delete(URI segmentUri) throws IOException {
+    public boolean delete(URI segmentUri, boolean forceDelete) throws IOException {
       return true;
     }
 

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
@@ -100,7 +100,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public String[] listFiles(URI fileUri) throws IOException {
+    public String[] listFiles(URI fileUri, boolean recursive) throws IOException {
       return null;
     }
 
@@ -113,8 +113,13 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public boolean isDirectory(URI uri) throws IOException {
+    public boolean isDirectory(URI uri) {
       return false;
+    }
+
+    @Override
+    public long lastModified(URI uri) {
+      return 0L;
     }
   }
 }

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
@@ -185,7 +185,8 @@ public class HadoopPinotFS extends PinotFS {
     try {
       return _hadoopFS.getFileStatus(new Path(uri)).getModificationTime();
     } catch (IOException e) {
-      return 0L;
+      LOGGER.error("Could not get file status for {}", uri);
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
* This PR will allow us to fully add support for pluggable storage in RetentionManager, which will allow us to age out segments that are deleted.
* Adds lastModified method to PinotFS.
* Changing listFiles to include files and directories and have an option for recursive or not
* Changing isDirectory to not throw an IOException
* Adding test for lastModified
* Fixing AzurePinotFS bug in listFiles
* Test coverage in SegmentDeletionManagerTest