### PR TITLE
Get quickstart-realtime working again

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
@@ -69,7 +69,7 @@ public class KafkaJSONMessageDecoder implements StreamMessageDecoder<byte[]> {
     if (message.has(columnName) && !message.isNull(columnName)) {
       Object entry;
       if (dimensionSpec.isSingleValueField()) {
-        entry = stringToDataType(dimensionSpec, message.getString(columnName));
+        entry = stringToDataType(dimensionSpec, message.get(columnName).toString());
       } else {
         JSONArray jsonArray = message.getJSONArray(columnName);
         Object[] array = new Object[jsonArray.length()];

--- a/pinot-tools/src/main/resources/sample_data/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/sample_data/meetupRsvp_realtime_table_config.json
@@ -18,6 +18,7 @@
       "stream.kafka.topic.name": "meetupRSVPEvents",
       "stream.kafka.decoder.class.name": "com.linkedin.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder",
       "stream.kafka.hlc.zk.connect.string": "localhost:2191/kafka",
+      "stream.kafka.consumer.factory.class.name": "com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory",
       "stream.kafka.zk.broker.url": "localhost:2191/kafka"
     }
   },


### PR DESCRIPTION
Added the consumer factor in config, since this is now mandatory configuration for a stream.

Fixed the call to JSONObject.getString(). We bumped up org.json version from 20170516 to 20080701
in commit aa3a4c9b861bd5405a28ac6e6e86deeb16e6b809. During this time JSONObject changed to
throw exception if JSONObject.getString() is called on an object that is NOT a string type.
Used to be that the call automatically converts the value to a string, but not anymore.

Changed the call to get the object and call toString() on it (what 20170516 did)