### PR TITLE
Support .tar.gz upload for pluggable storage

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -293,14 +293,14 @@ public class PinotSegmentUploadRestletResource {
           throw new UnsupportedOperationException("Unsupported upload type: " + uploadType);
       }
 
-      zkDownloadUri = getZkDownloadURIForSegmentUpload(segmentMetadata, provider);
-
       // This boolean is here for V1 segment upload, where we keep the segment in the downloadURI sent in the header.
       // We will deprecate this behavior eventually.
       if (!moveSegmentToFinalLocation) {
         LOGGER.info("Setting zkDownloadUri to {} for segment {} of table {}, skipping move", currentSegmentLocationURI,
             segmentMetadata.getName(), segmentMetadata.getTableName());
         zkDownloadUri = currentSegmentLocationURI;
+      } else {
+        zkDownloadUri = getZkDownloadURIForSegmentUpload(segmentMetadata, provider);
       }
 
       String clientAddress = InetAddress.getByName(request.getRemoteAddr()).getHostName();
@@ -340,7 +340,7 @@ public class PinotSegmentUploadRestletResource {
       // Receiving .tar.gz segment upload for pluggable storage
       LOGGER.info("Using configured data dir {} for segment {} of table {}", _controllerConf.getDataDir(),
           segmentMetadata.getName(), segmentMetadata.getTableName());
-      return StringUtil.join(File.separator, provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
+      return StringUtil.join("/", provider.getBaseDataDirURI().toString(), segmentMetadata.getTableName(),
           URLEncoder.encode(segmentMetadata.getName(), "UTF-8"));
     }
   }


### PR DESCRIPTION
* Currently, when we receive a segment file, we assume that the end destination is local. We assume that if we are uploading to deep storage, the upload will always come through URI upload.
* However, for minion uploads, where we will change the segment locally and re-upload, we will need to support uploading segment files.
* This PR adds the flexibility for the zkDownloadURI to be configured using deep storage rather than always having it be http/https