### PR TITLE
Add a flag numGroupsLimitReached to mark responses that hit the number of groups limit

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -52,6 +52,8 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // This metric track the number of broker responses with not all servers responded.
   // (numServersQueried > numServersResponded)
   BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED("badResponses", false),
+  // This metric track the number of broker responses with number of groups limit reached (potential bad responses).
+  BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED("badResponses", false),
 
   // These metrics track the cost of the query.
   DOCUMENTS_SCANNED("documents", false),

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
@@ -92,6 +92,11 @@ public interface BrokerResponse {
   long getTotalDocs();
 
   /**
+   * Returns whether the number of groups limit has been reached.
+   */
+  boolean isNumGroupsLimitReached();
+
+  /**
    * Get number of exceptions recorded in the response.
    */
   int getExceptionsSize();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -39,7 +39,9 @@ import org.json.JSONObject;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo"})
+@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded",
+    "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "totalDocs", "numGroupsLimitReached",
+    "timeUsedMs", "segmentStatistics", "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -53,6 +55,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _numEntriesScannedInFilter = 0L;
   private long _numEntriesScannedPostFilter = 0L;
   private long _totalDocs = 0L;
+  private boolean _numGroupsLimitReached = false;
   private long _timeUsedMs = 0L;
 
   private SelectionResults _selectionResults;
@@ -181,6 +184,17 @@ public class BrokerResponseNative implements BrokerResponse {
     _totalDocs = totalDocs;
   }
 
+  @JsonProperty("numGroupsLimitReached")
+  @Override
+  public boolean isNumGroupsLimitReached() {
+    return _numGroupsLimitReached;
+  }
+
+  @JsonProperty("numGroupsLimitReached")
+  public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
+    _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
   @JsonProperty("timeUsedMs")
   public long getTimeUsedMs() {
     return _timeUsedMs;
@@ -213,25 +227,21 @@ public class BrokerResponseNative implements BrokerResponse {
   }
 
   @Override
-  public String toJsonString()
-      throws IOException {
+  public String toJsonString() throws IOException {
     return OBJECT_MAPPER.writeValueAsString(this);
   }
 
   @Override
-  public JSONObject toJson()
-      throws IOException, JSONException {
+  public JSONObject toJson() throws IOException, JSONException {
     return new JSONObject(toJsonString());
   }
 
-  public static BrokerResponseNative fromJsonString(String jsonString)
-      throws IOException {
+  public static BrokerResponseNative fromJsonString(String jsonString) throws IOException {
     return OBJECT_MAPPER.readValue(jsonString, new TypeReference<BrokerResponseNative>() {
     });
   }
 
-  public static BrokerResponseNative fromJsonObject(JSONObject jsonObject)
-      throws IOException {
+  public static BrokerResponseNative fromJsonObject(JSONObject jsonObject) throws IOException {
     return fromJsonString(jsonObject.toString());
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -30,6 +30,7 @@ public interface DataTable {
   String NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY = "numEntriesScannedInFilter";
   String NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY = "numEntriesScannedPostFilter";
   String TOTAL_DOCS_METADATA_KEY = "totalDocs";
+  String NUM_GROUPS_LIMIT_REACHED_KEY = "numGroupsLimitReached";
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";
   String TRACE_INFO_METADATA_KEY = "traceInfo";
   String REQUEST_ID_METADATA_KEY = "requestId";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/CombineGroupByOperator.java
@@ -193,6 +193,10 @@ public class CombineGroupByOperator extends BaseOperator<IntermediateResultsBloc
       mergedBlock.setNumEntriesScannedInFilter(executionStatistics.getNumEntriesScannedInFilter());
       mergedBlock.setNumEntriesScannedPostFilter(executionStatistics.getNumEntriesScannedPostFilter());
       mergedBlock.setNumTotalRawDocs(executionStatistics.getNumTotalRawDocs());
+      // NOTE: numGroups might go slightly over numGroupsLimit because the comparison is not atomic
+      if (numGroups.get() >= _numGroupsLimit) {
+        mergedBlock.setNumGroupsLimitReached(true);
+      }
 
       return mergedBlock;
     } catch (Exception e) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -53,6 +53,7 @@ public class IntermediateResultsBlock implements Block {
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
   private long _numTotalRawDocs;
+  private boolean _numGroupsLimitReached;
 
   /**
    * Constructor for selection result.
@@ -176,6 +177,10 @@ public class IntermediateResultsBlock implements Block {
     _numTotalRawDocs = numTotalRawDocs;
   }
 
+  public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
+    _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
   @Nonnull
   public DataTable getDataTable()
       throws Exception {
@@ -275,6 +280,9 @@ public class IntermediateResultsBlock implements Block {
     dataTable.getMetadata()
         .put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, String.valueOf(_numEntriesScannedPostFilter));
     dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(_numTotalRawDocs));
+    if (_numGroupsLimitReached) {
+      dataTable.getMetadata().put(DataTable.NUM_GROUPS_LIMIT_REACHED_KEY, "true");
+    }
     if (_processingExceptions != null && _processingExceptions.size() > 0) {
       for (ProcessingException exception : _processingExceptions) {
         dataTable.addException(exception);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -64,6 +64,12 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     _numGroupsLimit = DEFAULT_NUM_GROUPS_LIMIT;
   }
 
+  @VisibleForTesting
+  public InstancePlanMakerImplV2(int maxInitialResultHolderCapacity, int numGroupsLimit) {
+    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
+    _numGroupsLimit = numGroupsLimit;
+  }
+
   /**
    * Constructor for usage when client requires to pass {@link QueryExecutorConfig} to this class.
    * <ul>

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -77,6 +77,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     long numEntriesScannedInFilter = 0L;
     long numEntriesScannedPostFilter = 0L;
     long numTotalRawDocs = 0L;
+    boolean numGroupsLimitReached = false;
 
     // Cache a data schema from data tables (try to cache one with data rows associated with it).
     DataSchema cachedDataSchema = null;
@@ -119,6 +120,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
       if (numTotalRawDocsString != null) {
         numTotalRawDocs += Long.parseLong(numTotalRawDocsString);
       }
+      numGroupsLimitReached |= Boolean.valueOf(metadata.get(DataTable.NUM_GROUPS_LIMIT_REACHED_KEY));
 
       // After processing the metadata, remove data tables without data rows inside.
       DataSchema dataSchema = dataTable.getDataSchema();
@@ -142,6 +144,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     brokerResponseNative.setNumEntriesScannedInFilter(numEntriesScannedInFilter);
     brokerResponseNative.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
     brokerResponseNative.setTotalDocs(numTotalRawDocs);
+    brokerResponseNative.setNumGroupsLimitReached(numGroupsLimitReached);
 
     // Update broker metrics.
     String tableName = brokerRequest.getQuerySource().getTableName();

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -16,7 +16,10 @@
 package com.linkedin.pinot.queries;
 
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
+import com.linkedin.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest {
@@ -357,5 +360,16 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     brokerResponse = getBrokerResponseForQuery(query + MV_GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 400000L, 0L, 800000L, 400000L,
         new String[]{"2147483647"});
+  }
+
+  @Test
+  public void testNumGroupsLimit() {
+    String query = "SELECT COUNT(*) FROM testTable GROUP BY column6";
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    assertFalse(brokerResponse.isNumGroupsLimitReached());
+
+    brokerResponse = getBrokerResponseForQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -16,7 +16,10 @@
 package com.linkedin.pinot.queries;
 
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
+import com.linkedin.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleValueQueriesTest {
@@ -362,5 +365,16 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     brokerResponse = getBrokerResponseForQueryWithFilter(query + GROUP_BY);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 73548L, 120000L,
         new String[]{"2146232405", "999309554"});
+  }
+
+  @Test
+  public void testNumGroupsLimit() {
+    String query = "SELECT COUNT(*) FROM testTable GROUP BY column1";
+
+    BrokerResponseNative brokerResponse = getBrokerResponseForQuery(query);
+    assertFalse(brokerResponse.isNumGroupsLimitReached());
+
+    brokerResponse = getBrokerResponseForQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 }


### PR DESCRIPTION
1. Add the flag into the query response
2. Add the flag into the query log
3. Add a metric to track the number of queries hitting the limit