### PR TITLE
Disable LLC validation when LLC is not enabled

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -32,6 +32,7 @@ import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegment
 import com.linkedin.pinot.core.realtime.stream.StreamConfig;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -130,7 +131,11 @@ public class ValidationManager {
           if (_enableSegmentLevelValidation) {
             updateRealtimeDocumentCount(tableConfig);
           }
-          _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
+          Map<String, String> streamConfigMap =  tableConfig.getIndexingConfig().getStreamConfigs();
+          StreamConfig streamConfig = new StreamConfig(streamConfigMap);
+          if (streamConfig.hasLowLevelConsumerType()) {
+            _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
+          }
         }
       } catch (Exception e) {
         LOGGER.warn("Caught exception while validating table: {}", tableNameWithType, e);


### PR DESCRIPTION
We attempt to validate llc segments of a table even if the table has only hlc segments.
Part of the exercise of validating llc segments is to check if number of stream partitions have
increased. For Kafka llc, this check needs a broker config (Kafka hlc does not need
broker config). Since the broker config is missing from stream config, we end up throwing an exception
in the controller.

This creates an unnecessary exception log for these tables.

The exception is also visible if we let quick-start-realtime.sh run long enough, creating a bad user
experience.

There are no other side-effects to this exception. We log the exception and move on to validate the next
table.