### PR TITLE
[TE] frontend - RCA anomaly label text shorten

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -27,11 +27,11 @@ const OFFSETS = ['current', 'predicted', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
  * @type {Object}
  */
 const ANOMALY_OPTIONS_MAPPING = {
-  ANOMALY: 'Yes, it\'s unexpected',
-  ANOMALY_EXPECTED: 'It\'s an expected temporary change (E.g. Holiday)',
-  ANOMALY_NEW_TREND: 'It\'s an expected permanent change',
-  NOT_ANOMALY: 'No significant change observed',
-  NO_FEEDBACK: 'To Be Determined'
+  ANOMALY: 'Yes - unexpected',
+  ANOMALY_EXPECTED: 'Expected temporary change',
+  ANOMALY_NEW_TREND: 'Expected permanent change',
+  NOT_ANOMALY: 'No change observed',
+  NO_FEEDBACK: 'Not reviewed yet'
 };
 
 export default Component.extend({

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/template.hbs
@@ -91,7 +91,7 @@
           </span>
         </div>
         {{#each options as |option|}}
-          <div class="col-xs-2 rootcause-anomaly__radio-button-item">
+          <div class="rootcause-anomaly__radio-button-item">
             {{#radio-button value=option groupValue=status changed=(action "onFeedback")}}
               <span class="te-radio__option">{{get optionsMapping option}}</span>
             {{/radio-button}}

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-radio.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-radio.scss
@@ -2,6 +2,7 @@
   &__option {
     font-size: 14px;
     line-height: 20px;
+    padding-left: 3px;
     color: app-shade(black, 9);
     font-weight: normal;
   }


### PR DESCRIPTION
Making anomaly response labels shorter/sweeter:
<img width="1156" alt="screen shot 2018-10-24 at 3 19 28 pm" src="https://user-images.githubusercontent.com/11814420/47458865-4c524780-d7a0-11e8-8ab1-3a71bd69ec1a.png">
