### PR TITLE
Adding overwrite parameter to move in PinotFS

### DIFF
--- a/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
+++ b/pinot-azure-filesystem/src/main/java/com/linkedin/pinot/filesystem/AzurePinotFS.java
@@ -89,7 +89,10 @@ public class AzurePinotFS extends PinotFS {
   }
 
   @Override
-  public boolean move(URI srcUri, URI dstUri) throws IOException {
+  public boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException {
+    if (exists(dstUri) && !overwrite) {
+      return false;
+    }
     //rename the file
     return _adlStoreClient.rename(srcUri.getPath(), dstUri.getPath());
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -184,7 +184,7 @@ public class SegmentDeletionManager {
       try {
         if (pinotFS.exists(fileToMoveURI)) {
           // Overwrites the file if it already exists in the target directory.
-          pinotFS.move(fileToMoveURI, deletedSegmentDestURI);
+          pinotFS.move(fileToMoveURI, deletedSegmentDestURI, true);
           LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMoveURI.toString(), deletedSegmentDestURI.toString());
         } else {
           if (!SegmentName.isHighLevelConsumerSegmentName(segmentId)) {

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -79,10 +79,9 @@ public class LocalPinotFS extends PinotFS {
     // Makes all parent directories for dst file if they don't exist
     if (!srcFile.isDirectory()) {
       dstFile.getParentFile().mkdirs();
-      FileUtils.moveFile(srcFile, dstFile);
-    } else {
-      Files.move(srcFile.toPath(), dstFile.toPath());
     }
+
+    Files.move(srcFile.toPath(), dstFile.toPath());
 
     return true;
   }
@@ -141,25 +140,11 @@ public class LocalPinotFS extends PinotFS {
     return new File(uri).isDirectory();
   }
 
-  private String encodeURI(String uri) {
-    String encodedStr;
-    try {
-      encodedStr = URLEncoder.encode(uri, DEFAULT_ENCODING);
-    } catch (UnsupportedEncodingException e) {
-      LOGGER.warn("Could not encode uri {}", uri);
-      throw new RuntimeException(e);
-    }
-    return encodedStr;
+  private String encodeURI(String uri) throws UnsupportedEncodingException {
+    return URLEncoder.encode(uri, DEFAULT_ENCODING);
   }
 
-  private String decodeURI(String uri) {
-    String decodedStr;
-    try {
-      decodedStr = URLDecoder.decode(uri, DEFAULT_ENCODING);
-    } catch (UnsupportedEncodingException e) {
-      LOGGER.warn("Could not decode uri {}", uri);
-      throw new RuntimeException(e);
-    }
-    return decodedStr;
+  private String decodeURI(String uri) throws UnsupportedEncodingException {
+    return URLDecoder.decode(uri, DEFAULT_ENCODING);
   }
 }

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/LocalPinotFS.java
@@ -76,11 +76,6 @@ public class LocalPinotFS extends PinotFS {
       }
     }
 
-    // Makes all parent directories for dst file if they don't exist
-    if (!srcFile.isDirectory()) {
-      dstFile.getParentFile().mkdirs();
-    }
-
     Files.move(srcFile.toPath(), dstFile.toPath());
 
     return true;

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -51,7 +51,7 @@ public abstract class PinotFS implements Closeable {
    * it will overwrite. Will work either for moving a directory or a file.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
-   * @param overwrite
+   * @param overwrite true if we want to overwrite the dstURI, false otherwise
    * @return true if move is successful
    * @throws IOException on failure
    */

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -48,7 +48,8 @@ public abstract class PinotFS implements Closeable {
   /**
    * Moves the file from the src to dst. Does not keep the original file. If the dst has parent directories
    * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
-   * it will overwrite. Will work either for moving a directory or a file.
+   * it will overwrite. Will work either for moving a directory or a file. Currently assumes that both the srcUri
+   * and the dstUri are of the same time (both files or both directories).
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @param overwrite true if we want to overwrite the dstURI, false otherwise

--- a/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
+++ b/pinot-filesystem/src/main/java/com/linkedin/pinot/filesystem/PinotFS.java
@@ -51,10 +51,11 @@ public abstract class PinotFS implements Closeable {
    * it will overwrite. Will work either for moving a directory or a file.
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
+   * @param overwrite
    * @return true if move is successful
    * @throws IOException on failure
    */
-  public abstract boolean move(URI srcUri, URI dstUri) throws IOException;
+  public abstract boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException;
 
   /**
    * Copies a file from src to dst. Keeps the original file. If the dst has parent directories that haven't

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -92,7 +92,11 @@ public class LocalPinotFSTest {
 
     // Check that method deletes dst directory during move and is successful by overwriting dir
     Assert.assertTrue(_newTmpDir.exists());
-    localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI());
+
+    // Expected that a move without overwrite will not succeed
+    Assert.assertEquals(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false), false);
+
+    localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true);
     Assert.assertEquals(_absoluteTmpDirPath.length(), 0);
 
     localPinotFS.delete(secondTestFileUri);

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/LocalPinotFSTest.java
@@ -84,6 +84,17 @@ public class LocalPinotFSTest {
     File thirdTestFile = new File(_absoluteTmpDirPath, "thirdTestFile");
     Assert.assertTrue(thirdTestFile.createNewFile(), "Could not create file " + thirdTestFile.getPath());
 
+    // Tests recursive move works
+    File testDir = new File(_absoluteTmpDirPath, "testDir");
+    Assert.assertTrue(testDir.mkdir(), "Could not make directory " + testDir.getAbsolutePath());
+    File testDirFile = new File(testDir, "testFile");
+    Assert.assertTrue(testDirFile.createNewFile(), "Could not create file " + testDir.getAbsolutePath());
+    File testDir2 = new File(_absoluteTmpDirPath, "testDir2");
+    File testDirFile2 = new File(testDir2, "testFile");
+    Assert.assertFalse(localPinotFS.exists(testDirFile2.toURI()));
+    localPinotFS.move(testDir.toURI(), testDir2.toURI(), true);
+    Assert.assertTrue(localPinotFS.exists(testDirFile2.toURI()));
+
     // Check file copy to location where something already exists still works
     localPinotFS.copy(testFileUri, thirdTestFile.toURI());
     // Check length of file
@@ -94,9 +105,9 @@ public class LocalPinotFSTest {
     Assert.assertTrue(_newTmpDir.exists());
 
     // Expected that a move without overwrite will not succeed
-    Assert.assertEquals(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false), false);
+    Assert.assertFalse(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), false));
 
-    localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true);
+    Assert.assertTrue(localPinotFS.move(_absoluteTmpDirPath.toURI(), _newTmpDir.toURI(), true));
     Assert.assertEquals(_absoluteTmpDirPath.length(), 0);
 
     localPinotFS.delete(secondTestFileUri);

--- a/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
+++ b/pinot-filesystem/src/test/java/com/linkedin/pinot/filesystem/PinotFSFactoryTest.java
@@ -80,7 +80,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public boolean move(URI srcUri, URI dstUri) throws IOException {
+    public boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException {
       return true;
     }
 

--- a/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/com/linkedin/pinot/filesystem/HadoopPinotFS.java
@@ -75,7 +75,10 @@ public class HadoopPinotFS extends PinotFS {
   }
 
   @Override
-  public boolean move(URI srcUri, URI dstUri) throws IOException {
+  public boolean move(URI srcUri, URI dstUri, boolean overwrite) throws IOException {
+    if (exists(dstUri) && !overwrite) {
+      return false;
+    }
     return _hadoopFS.rename(new Path(srcUri), new Path(dstUri));
   }
 


### PR DESCRIPTION
* Currently the callers of the PinotFS interface do not have the option to choose whether to overwrite the file at the final destination
* This PR adds a boolean parameter to the PinotFS interface to allow this.
* Added test in LocalPinotFSTest
