### PR TITLE
Add LimitStringLengthRecordReader to limit the length of string columns

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -57,6 +57,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
   private static final String DEFAULT_METRIC_NULL_VALUE_OF_STRING = "null";
   private static final byte[] DEFAULT_METRIC_NULL_VALUE_OF_BYTES = NULL_BYTE_ARRAY_VALUE;
 
+  private static final int DEFAULT_STRING_LENGTH_LIMIT = 512;
+
   @ConfigKey("name")
   protected String _name;
 
@@ -70,6 +72,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
 
   @ConfigKey("defaultNullValue")
   private transient String _stringDefaultNullValue;
+
+  @ConfigKey("stringLengthLimit")
+  private int _stringLengthLimit = DEFAULT_STRING_LENGTH_LIMIT;
 
   // Transform function to generate this column, can be based on other columns
   protected String _transformFunction;
@@ -235,6 +240,15 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
     }
   }
 
+  public int getStringLengthLimit() {
+    return _stringLengthLimit;
+  }
+
+  // Required by JSON de-serializer. DO NOT REMOVE.
+  public void setStringLengthLimit(int stringLengthLimit) {
+    _stringLengthLimit = stringLengthLimit;
+  }
+
   /**
    * Transform function if defined else null.
    * @return
@@ -260,6 +274,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
     jsonObject.addProperty("dataType", _dataType.name());
     if (!_isSingleValueField) {
       jsonObject.addProperty("singleValueField", false);
+    }
+    if (_dataType == DataType.STRING && _stringLengthLimit != DEFAULT_STRING_LENGTH_LIMIT) {
+      jsonObject.addProperty("stringLengthLimit", _stringLengthLimit);
     }
     appendDefaultNullValue(jsonObject);
     return jsonObject;
@@ -326,7 +343,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
     FieldSpec that = (FieldSpec) o;
     return EqualityUtils.isEqual(_name, that._name) && EqualityUtils.isEqual(_dataType, that._dataType) && EqualityUtils
         .isEqual(_isSingleValueField, that._isSingleValueField) && EqualityUtils.isEqual(
-        getStringValue(_defaultNullValue), getStringValue(that._defaultNullValue));
+        getStringValue(_defaultNullValue), getStringValue(that._defaultNullValue)) && EqualityUtils.isEqual(
+        _stringLengthLimit, that._stringLengthLimit);
   }
 
   @Override
@@ -335,6 +353,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
     result = EqualityUtils.hashCodeOf(result, _dataType);
     result = EqualityUtils.hashCodeOf(result, _isSingleValueField);
     result = EqualityUtils.hashCodeOf(result, getStringValue(_defaultNullValue));
+    result = EqualityUtils.hashCodeOf(result, _stringLengthLimit);
     return result;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/LimitStringLengthRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/LimitStringLengthRecordReader.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.readers;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.GenericRow;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code LimitStringLengthRecordReader} class is the record reader that limits the length of the string fields
+ * based on the limit set in the schema field specs.
+ */
+public class LimitStringLengthRecordReader implements RecordReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LimitStringLengthRecordReader.class);
+
+  private final RecordReader _recordReader;
+  private final Map<String, Integer> _lengthLimits = new HashMap<>();
+
+  private long _numStringsTrimmed;
+
+  public LimitStringLengthRecordReader(RecordReader recordReader) {
+    _recordReader = recordReader;
+    for (FieldSpec fieldSpec : recordReader.getSchema().getAllFieldSpecs()) {
+      if (fieldSpec.getDataType() == FieldSpec.DataType.STRING) {
+        int lengthLimit = fieldSpec.getStringLengthLimit();
+        if (lengthLimit > 0) {
+          _lengthLimits.put(fieldSpec.getName(), lengthLimit);
+          LOGGER.info("Limiting length of column: {} to: {}", fieldSpec.getName(), lengthLimit);
+        }
+      }
+    }
+  }
+
+  public long getNumStringsTrimmed() {
+    return _numStringsTrimmed;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return _recordReader.hasNext();
+  }
+
+  @Override
+  public GenericRow next() throws IOException {
+    return next(new GenericRow());
+  }
+
+  @Override
+  public GenericRow next(GenericRow reuse) throws IOException {
+    GenericRow next = _recordReader.next(reuse);
+    for (Map.Entry<String, Integer> entry : _lengthLimits.entrySet()) {
+      String column = entry.getKey();
+      int lengthLimit = entry.getValue();
+
+      // The inner record reader should already replace missing value with default null value
+      Object value = next.getValue(column);
+      assert value != null;
+
+      if (value instanceof String) {
+        // Single-valued column
+        String stringValue = (String) value;
+        if (stringValue.length() > lengthLimit) {
+          next.putField(column, stringValue.substring(0, lengthLimit));
+          _numStringsTrimmed++;
+        }
+      } else {
+        // Multi-valued column
+        assert value instanceof Object[];
+        Object[] values = (Object[]) value;
+        int length = values.length;
+        for (int i = 0; i < length; i++) {
+          assert values[i] instanceof String;
+          String stringValue = (String) values[i];
+          if (stringValue.length() > lengthLimit) {
+            values[i] = stringValue.substring(0, lengthLimit);
+            _numStringsTrimmed++;
+          }
+        }
+      }
+    }
+    return next;
+  }
+
+  @Override
+  public void rewind() throws IOException {
+    _recordReader.rewind();
+  }
+
+  @Override
+  public Schema getSchema() {
+    return _recordReader.getSchema();
+  }
+
+  @Override
+  public void close() throws IOException {
+    _recordReader.close();
+
+    if (_numStringsTrimmed > 0) {
+      LOGGER.warn("Number of strings trimmed: {}", _numStringsTrimmed);
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
+import com.linkedin.pinot.core.data.readers.LimitStringLengthRecordReader;
 import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.data.readers.RecordReaderFactory;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -99,7 +100,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
   @Override
   public void init(SegmentGeneratorConfig config) throws Exception {
-    init(config, new RecordReaderSegmentCreationDataSource(RecordReaderFactory.getRecordReader(config)));
+    init(config, new RecordReaderSegmentCreationDataSource(
+        new LimitStringLengthRecordReader(RecordReaderFactory.getRecordReader(config))));
   }
 
   public void init(SegmentGeneratorConfig config, SegmentCreationDataSource dataSource) throws Exception {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/LimitStringLengthRecordReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/LimitStringLengthRecordReaderTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.readers;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.GenericRow;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class LimitStringLengthRecordReaderTest {
+  private static final String SV_COLUMN = "testSVColumn";
+  private static final String MV_COLUMN = "testMVColumn";
+  private static final int LENGTH_LIMIT = 10;
+  private static final int MAX_LENGTH = 20;
+  private static final int NUM_ROWS = 100;
+  private static final int NUM_MULTI_VALUES = 5;
+
+  @Test
+  public void testTrimString() throws IOException {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(SV_COLUMN, FieldSpec.DataType.STRING)
+        .addMultiValueDimension(MV_COLUMN, FieldSpec.DataType.STRING)
+        .build();
+    schema.getFieldSpecFor(SV_COLUMN).setStringLengthLimit(LENGTH_LIMIT);
+    schema.getFieldSpecFor(MV_COLUMN).setStringLengthLimit(LENGTH_LIMIT);
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    long expectedNumStringsTrimmed = 0;
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = new GenericRow();
+      String singleValue = RandomStringUtils.random(MAX_LENGTH);
+      if (singleValue.length() > LENGTH_LIMIT) {
+        expectedNumStringsTrimmed++;
+      }
+      row.putField(SV_COLUMN, singleValue);
+      Object[] multiValue = new Object[NUM_MULTI_VALUES];
+      for (int j = 0; j < NUM_MULTI_VALUES; j++) {
+        String value = RandomStringUtils.random(MAX_LENGTH);
+        if (value.length() > LENGTH_LIMIT) {
+          expectedNumStringsTrimmed++;
+        }
+        multiValue[j] = value;
+      }
+      row.putField(MV_COLUMN, multiValue);
+
+      rows.add(row);
+    }
+
+    try (LimitStringLengthRecordReader recordReader = new LimitStringLengthRecordReader(
+        new GenericRowRecordReader(rows, schema))) {
+      while (recordReader.hasNext()) {
+        GenericRow next = recordReader.next();
+        assertTrue(((String) next.getValue(SV_COLUMN)).length() <= LENGTH_LIMIT);
+        Object[] multiValue = (Object[]) next.getValue(MV_COLUMN);
+        assertEquals(multiValue.length, NUM_MULTI_VALUES);
+        for (int i = 0; i < NUM_MULTI_VALUES; i++) {
+          assertTrue(((String) multiValue[i]).length() <= LENGTH_LIMIT);
+        }
+      }
+      assertEquals(recordReader.getNumStringsTrimmed(), expectedNumStringsTrimmed);
+    }
+  }
+}


### PR DESCRIPTION
Motivation:
Recently, we run into issues where bad data is getting indexed into Pinot.
The length of one single string value is more than 1M, and cause the
dictionary size to be huge (>2G) and also cause int overflow and then crash
the server. In most of the cases, super long string is not even queriable,
and trying to index them is usually caused by client code bug. So we decide
to add a configurable limit to the length of string columns. If the value
for the column goes over the limit, the value will be trimmed to be the
length limit.

1. Added "stringLengthLimit" into FieldSpec, so each field (column) can have
  different length limit
2. The default limit is 512 (string length but not decoded bytes length).
  The feature can be disabled by setting the limit to a value <= 0
3. Added LimitStringLengthRecordReader that works on the existing record
  readers but trim strings that are longer than the length limit