### PR TITLE
[TE] rootcause - support query params for external setup of investigation

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -52,8 +52,15 @@ const ROOTCAUSE_SESSION_PERMISSIONS_READ_WRITE = 'READ_WRITE';
 export default Controller.extend({
   queryParams: [
     'metricId',
+    'sessionId',
     'anomalyId',
-    'sessionId'
+    'contextUrnsInit',
+    'selectedUrnsInit',
+    'anomalyUrnsInit',
+    'anomalyRange',
+    'analysisRange',
+    'granularity',
+    'compareMode'
   ],
 
   //


### PR DESCRIPTION
This PR adds one-time query params to set up the RCA investigation view of ThirdEye via an external link. Supported arguments are:
* contextUrnsInit (comma separated urns - metrics under investigation)
* selectedUrnsInit (comma separated urns - selected auxiliary metrics)
* anomalyUrnsInit (comma separated urns - anomalies and associated metrics)
* anomalyRange (comma separated tuple, the start and end of the investigation period)
* analysisRange (comma separated tuple, the start and end of the display range)
* granularity (display granularity for time series)
* compareMode (default baseline for analysis and display)