### PR TITLE
[TE] Configurable properties for alert schemes

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DetectionAlertConfigBean.java
@@ -37,7 +37,7 @@ public class DetectionAlertConfigBean extends AbstractBean {
   String cronExpression;
   String application;
 
-  List<String> alertSchemes;
+  Map<String, Map<String, Object>> alertSchemes;
   AlertConfigBean.SubjectType subjectType = AlertConfigBean.SubjectType.ALERT;
 
   Map<Long, Long> vectorClocks;
@@ -117,11 +117,11 @@ public class DetectionAlertConfigBean extends AbstractBean {
     this.subjectType = subjectType;
   }
 
-  public List<String> getAlertSchemes() {
+  public Map<String, Map<String, Object>> getAlertSchemes() {
     return alertSchemes;
   }
 
-  public void setAlertSchemes(List<String> alertSchemes) {
+  public void setAlertSchemes(Map<String, Map<String, Object>> alertSchemes) {
     this.alertSchemes = alertSchemes;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detection/alert/scheme/DetectionEmailAlerter.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/DetectionAlertTaskFactoryTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/DetectionAlertTaskFactoryTest.java
@@ -30,13 +30,18 @@ public class DetectionAlertTaskFactoryTest {
   private DAOTestBase testDAOProvider;
   private DetectionAlertConfigDTO alertConfigDTO;
   private DetectionAlertConfigManager alertConfigDAO;
-  private List<String> alerters;
+  private Map<String, Map<String, Object>> alerters;
 
   @BeforeMethod
   public void beforeClass() throws Exception {
-    alerters = new ArrayList<>();
-    alerters.add("com.linkedin.thirdeye.detection.alert.scheme.RandomAlerter");
-    alerters.add("com.linkedin.thirdeye.detection.alert.scheme.AnotherRandomAlerter");
+    Map<String, Object> randomAlerter = new HashMap<>();
+    randomAlerter.put("className", "com.linkedin.thirdeye.detection.alert.scheme.RandomAlerter");
+    Map<String, Object> anotherRandomAlerter = new HashMap<>();
+    anotherRandomAlerter.put("className", "com.linkedin.thirdeye.detection.alert.scheme.AnotherRandomAlerter");
+
+    alerters = new HashMap<>();
+    alerters.put("randomScheme", randomAlerter);
+    alerters.put("anotherRandomScheme", anotherRandomAlerter);
 
     this.testDAOProvider = DAOTestBase.getInstance();
     DAORegistry daoRegistry = DAORegistry.getInstance();
@@ -49,7 +54,7 @@ public class DetectionAlertTaskFactoryTest {
     testDAOProvider.cleanup();
   }
 
-  private DetectionAlertConfigDTO createAlertConfig(List<String> schemes, String filter) {
+  private DetectionAlertConfigDTO createAlertConfig(Map<String, Map<String, Object>> schemes, String filter) {
     Map<String, Object> properties = new HashMap<>();
     properties.put("className", filter);
     properties.put("detectionConfigIds", Collections.singletonList(1000));
@@ -107,7 +112,7 @@ public class DetectionAlertTaskFactoryTest {
    */
   @Test
   public void testLoadDefaultAlertSchemes() throws Exception {
-    DetectionAlertConfigDTO alertConfig = createAlertConfig(Collections.<String>emptyList(),
+    DetectionAlertConfigDTO alertConfig = createAlertConfig(Collections.emptyMap(),
         "com.linkedin.thirdeye.detection.alert.filter.ToAllRecipientsDetectionAlertFilter");
     DetectionAlertTaskFactory detectionAlertTaskFactory = new DetectionAlertTaskFactory();
     Set<DetectionAlertScheme> detectionAlertSchemes = detectionAlertTaskFactory.loadAlertSchemes(alertConfig,

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/SendAlertTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detection/alert/SendAlertTest.java
@@ -112,7 +112,9 @@ public class SendAlertTest {
     properties.put(PROP_RECIPIENTS, PROP_RECIPIENTS_VALUE);
     properties.put(PROP_DETECTION_CONFIG_IDS, Collections.singletonList(this.detectionConfigId));
 
-    this.alertConfigDTO.setAlertSchemes(Collections.singletonList("com.linkedin.thirdeye.detection.alert.scheme.DetectionEmailAlerter"));
+    Map<String, Object> emailScheme = new HashMap<>();
+    emailScheme.put("className", "com.linkedin.thirdeye.detection.alert.scheme.DetectionEmailAlerter");
+    this.alertConfigDTO.setAlertSchemes(Collections.singletonMap("EmailScheme", emailScheme));
     this.alertConfigDTO.setProperties(properties);
     this.alertConfigDTO.setFrom(FROM_ADDRESS_VALUE);
     this.alertConfigDTO.setName(ALERT_NAME_VALUE);


### PR DESCRIPTION
Change:
* Modified the detection alert config to read additional parameters for alert schemes.

Sample Config:
```
{
    "id": 1234,
    ...    
    "alertSchemes": {
          "randomScheme" : {
                "className": "DetectionAlertScheme_RandomClassName",
                "<param>": "<value>"
         },
         "anotherScheme" : {
               "className": "DetectionAlertScheme_AnotherRandomClassName",
               "<param>": "<value>"
         }
    },
    ...
}