### PR TITLE
Remove references to kafka from generic classes

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/DefaultHelixBrokerConfig.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/DefaultHelixBrokerConfig.java
@@ -32,7 +32,6 @@ public class DefaultHelixBrokerConfig {
 
     brokerConf.addProperty("pinot.broker.routing.table.builder.default.offline.class", "balanced");
     brokerConf.addProperty("pinot.broker.routing.table.builder.default.offline.numOfRoutingTables", "10");
-    brokerConf.addProperty("pinot.broker.routing.table.builder.default.realtime.class", "Kafkahighlevelconsumerbased");
     brokerConf.addProperty("pinot.broker.routing.table.builder.tables", "");
 
     //client properties

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -18,8 +18,8 @@ package com.linkedin.pinot.broker.routing;
 import com.linkedin.pinot.broker.routing.builder.BalancedRandomRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.DefaultOfflineRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.DefaultRealtimeRoutingTableBuilder;
-import com.linkedin.pinot.broker.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
-import com.linkedin.pinot.broker.routing.builder.KafkaLowLevelConsumerRoutingTableBuilder;
+import com.linkedin.pinot.broker.routing.builder.HighLevelConsumerBasedRoutingTableBuilder;
+import com.linkedin.pinot.broker.routing.builder.LowLevelConsumerRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.PartitionAwareOfflineRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.PartitionAwareRealtimeRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.RoutingTableBuilder;
@@ -47,8 +47,8 @@ public class RoutingTableBuilderFactory {
     DefaultOffline,
     DefaultRealtime,
     BalancedRandom,
-    KafkaLowLevel,
-    KafkaHighLevel,
+    KafkaLowLevel, // This should ideally be LowLevel and HighLevel. But we cannot rename these, else all tables which reference these in the configs will break
+    KafkaHighLevel,// We will keep these prefixed with "Kafka", but they are intended to work for any stream
     PartitionAwareOffline,
     PartitionAwareRealtime
   }
@@ -96,10 +96,10 @@ public class RoutingTableBuilderFactory {
         builder = new DefaultRealtimeRoutingTableBuilder();
         break;
       case KafkaHighLevel:
-        builder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
+        builder = new HighLevelConsumerBasedRoutingTableBuilder();
         break;
       case KafkaLowLevel:
-        builder = new KafkaLowLevelConsumerRoutingTableBuilder();
+        builder = new LowLevelConsumerRoutingTableBuilder();
         break;
       case PartitionAwareOffline:
         SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
@@ -124,7 +124,7 @@ public class RoutingTableBuilderFactory {
         }
         break;
       case PartitionAwareRealtime:
-        // Check that the table uses LLC kafka consumer.
+        // Check that the table uses LL consumer.
         StreamConfig streamConfig = new StreamConfig(tableConfig.getIndexingConfig().getStreamConfigs());
 
         if (streamConfig.getConsumerTypes().size() == 1 && streamConfig.hasLowLevelConsumerType()) {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -41,8 +41,8 @@ public class DefaultRealtimeRoutingTableBuilder extends BaseRoutingTableBuilder 
 
   @Override
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, BrokerMetrics brokerMetrics) {
-    _realtimeHLCRoutingTableBuilder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
-    _realtimeLLCRoutingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
+    _realtimeHLCRoutingTableBuilder = new HighLevelConsumerBasedRoutingTableBuilder();
+    _realtimeLLCRoutingTableBuilder = new LowLevelConsumerRoutingTableBuilder();
     _realtimeHLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
     _realtimeLLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore, brokerMetrics);
   }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/GeneratorBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/GeneratorBasedRoutingTableBuilder.java
@@ -31,7 +31,7 @@ import org.apache.helix.model.InstanceConfig;
 
 /**
  * Routing table builder that uses a random routing table generator to create multiple routing tables. See a more
- * detailed explanation of the algorithm in {@link KafkaLowLevelConsumerRoutingTableBuilder} and
+ * detailed explanation of the algorithm in {@link LowLevelConsumerRoutingTableBuilder} and
  * {@link LargeClusterRoutingTableBuilder}.
  */
 public abstract class GeneratorBasedRoutingTableBuilder extends BaseRoutingTableBuilder {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/HighLevelConsumerBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/HighLevelConsumerBasedRoutingTableBuilder.java
@@ -26,7 +26,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 
 
-public class KafkaHighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableBuilder {
+public class HighLevelConsumerBasedRoutingTableBuilder extends BaseRoutingTableBuilder {
 
   @Override
   public void computeRoutingTableFromExternalView(String tableName, ExternalView externalView,

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
@@ -88,25 +88,25 @@ public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTa
     @Override
     public void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
       // 1. Gather all segments and group them by partition, sorted by sequence number
-      Map<String, SortedSet<SegmentName>> sortedSegmentsByPartition =
+      Map<String, SortedSet<SegmentName>> sortedSegmentsByStreamPartition =
           LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
       // 2. Ensure that for each partition, we have at most one Helix partition (Pinot segment) in consuming state
       Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
           LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
-              sortedSegmentsByPartition);
+              sortedSegmentsByStreamPartition);
 
       // 3. Sort all the segments to be used during assignment in ascending order of replicas
 
       // PriorityQueue throws IllegalArgumentException when given a size of zero
       RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigList);
 
-      for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByPartition.entrySet()) {
-        String partition = entry.getKey();
+      for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByStreamPartition.entrySet()) {
+        String partitionId = entry.getKey();
         SortedSet<SegmentName> segmentNames = entry.getValue();
 
         // The only segment name which is allowed to be in CONSUMING state or null
-        SegmentName validConsumingSegment = allowedSegmentInConsumingStateByPartition.get(partition);
+        SegmentName validConsumingSegment = allowedSegmentInConsumingStateByPartition.get(partitionId);
 
         for (SegmentName segmentName : segmentNames) {
           List<String> validServers = new ArrayList<>();

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilder.java
@@ -35,10 +35,10 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Routing table builder for the Kafka low level consumer.
+ * Routing table builder for the low level consumer.
  */
-public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTableBuilder {
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaLowLevelConsumerRoutingTableBuilder.class);
+public class LowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LowLevelConsumerRoutingTableBuilder.class);
 
   private int _targetNumServersPerQuery = 8;
 
@@ -63,15 +63,15 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
 
   @Override
   protected RoutingTableGenerator buildRoutingTableGenerator() {
-    return new KafkaLowLevelConsumerRoutingTableGenerator();
+    return new LowLevelConsumerRoutingTableGenerator();
   }
 
-  private class KafkaLowLevelConsumerRoutingTableGenerator extends BaseRoutingTableGenerator {
+  private class LowLevelConsumerRoutingTableGenerator extends BaseRoutingTableGenerator {
     // We build the routing table based off the external view here. What we want to do is to make sure that we uphold
     // the guarantees clients expect (no duplicate records, eventual consistency) and spreading the load as equally as
     // possible between the servers.
     //
-    // Each Kafka partition contains a fraction of the data, so we need to make sure that we query all partitions.
+    // Each partition contains a fraction of the data, so we need to make sure that we query all partitions.
     // Because in certain unlikely degenerate scenarios, we can consume overlapping data until segments are flushed (at
     // which point the overlapping data is discarded during the reconciliation process with the controller), we need to
     // ensure that the query that is sent has only one partition in CONSUMING state in order to avoid duplicate records.
@@ -81,32 +81,32 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
 
     private Map<String, List<String>> _segmentToServersMap = new HashMap<>();
 
-    public KafkaLowLevelConsumerRoutingTableGenerator() {
+    public LowLevelConsumerRoutingTableGenerator() {
       super(_targetNumServersPerQuery);
     }
 
     @Override
     public void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
-      // 1. Gather all segments and group them by Kafka partition, sorted by sequence number
-      Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition =
+      // 1. Gather all segments and group them by partition, sorted by sequence number
+      Map<String, SortedSet<SegmentName>> sortedSegmentsByPartition =
           LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
-      // 2. Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
-      Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition =
-          KafkaLowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
-              sortedSegmentsByKafkaPartition);
+      // 2. Ensure that for each partition, we have at most one Helix partition (Pinot segment) in consuming state
+      Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
+          LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
+              sortedSegmentsByPartition);
 
       // 3. Sort all the segments to be used during assignment in ascending order of replicas
 
       // PriorityQueue throws IllegalArgumentException when given a size of zero
       RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigList);
 
-      for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByKafkaPartition.entrySet()) {
-        String kafkaPartition = entry.getKey();
+      for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByPartition.entrySet()) {
+        String partition = entry.getKey();
         SortedSet<SegmentName> segmentNames = entry.getValue();
 
         // The only segment name which is allowed to be in CONSUMING state or null
-        SegmentName validConsumingSegment = allowedSegmentInConsumingStateByKafkaPartition.get(kafkaPartition);
+        SegmentName validConsumingSegment = allowedSegmentInConsumingStateByPartition.get(partition);
 
         for (SegmentName segmentName : segmentNames) {
           List<String> validServers = new ArrayList<>();
@@ -143,8 +143,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
             handleNoServingHost(segmentNameStr);
           }
 
-          // If this segment is the segment allowed in CONSUMING state, don't process segments after it in that Kafka
-          // partition
+          // If this segment is the segment allowed in CONSUMING state, don't process segments after it in that partition
           if (segmentName.equals(validConsumingSegment)) {
             break;
           }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelRoutingTableBuilderUtil.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LowLevelRoutingTableBuilderUtil.java
@@ -24,25 +24,25 @@ import org.apache.helix.model.ExternalView;
 
 
 /**
- * Util class for Kafka low level routing table builder.
+ * Util class for low level routing table builder.
  */
-public class KafkaLowLevelRoutingTableBuilderUtil {
+public class LowLevelRoutingTableBuilderUtil {
 
   /**
    * Compute the map of allowed 'consuming' segments for each partition.
    *
    * @param externalView helix external view
-   * @param sortedSegmentsByKafkaPartition map of Kafka partition to sorted set of segment names.
+   * @param sortedSegmentsByPartition map of partition to sorted set of segment names.
    * @return map of allowed consuming segment for each partition for routing.
    */
   public static Map<String, SegmentName> getAllowedConsumingStateSegments(ExternalView externalView,
-      Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition) {
-    Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition = new HashMap<>();
-    for (String kafkaPartition : sortedSegmentsByKafkaPartition.keySet()) {
-      SortedSet<SegmentName> sortedSegmentsForKafkaPartition = sortedSegmentsByKafkaPartition.get(kafkaPartition);
+      Map<String, SortedSet<SegmentName>> sortedSegmentsByPartition) {
+    Map<String, SegmentName> allowedSegmentInConsumingStateByPartition = new HashMap<>();
+    for (String partition : sortedSegmentsByPartition.keySet()) {
+      SortedSet<SegmentName> sortedSegmentsForPartition = sortedSegmentsByPartition.get(partition);
       SegmentName lastAllowedSegmentInConsumingState = null;
 
-      for (SegmentName segmentName : sortedSegmentsForKafkaPartition) {
+      for (SegmentName segmentName : sortedSegmentsForPartition) {
         Map<String, String> helixPartitionState = externalView.getStateMap(segmentName.getSegmentName());
         boolean allInConsumingState = true;
         int replicasInConsumingState = 0;
@@ -79,9 +79,9 @@ public class KafkaLowLevelRoutingTableBuilderUtil {
       }
 
       if (lastAllowedSegmentInConsumingState != null) {
-        allowedSegmentInConsumingStateByKafkaPartition.put(kafkaPartition, lastAllowedSegmentInConsumingState);
+        allowedSegmentInConsumingStateByPartition.put(partition, lastAllowedSegmentInConsumingState);
       }
     }
-    return allowedSegmentInConsumingStateByKafkaPartition;
+    return allowedSegmentInConsumingStateByPartition;
   }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -38,7 +38,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
 /**
- * Partition aware routing table builder for the Kafka low level consumer.
+ * Partition aware routing table builder for the low level consumer.
  *
  * In contrast to the offline partition aware routing builder where the replica group aware segment assignment can be
  * assumed, we do not use the concept of replica group for a realtime table. The routing look up table is simply built
@@ -69,14 +69,14 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
       }
     }
 
-    // Gather all segments and group them by Kafka partition, sorted by sequence number
-    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition =
+    // Gather all segments and group them by partition, sorted by sequence number
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByPartition =
         LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
-    // Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
-    Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition =
-        KafkaLowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
-            sortedSegmentsByKafkaPartition);
+    // Ensure that for each partition, we have at most one Helix partition (Pinot segment) in consuming state
+    Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
+        LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
+            sortedSegmentsByPartition);
 
     RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
 
@@ -85,7 +85,7 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
     for (String segmentName : segmentSet) {
       int partitionId = getPartitionId(segmentName);
       SegmentName validConsumingSegment =
-          allowedSegmentInConsumingStateByKafkaPartition.get(Integer.toString(partitionId));
+          allowedSegmentInConsumingStateByPartition.get(Integer.toString(partitionId));
 
       Map<Integer, String> replicaToServerMap = new HashMap<>();
       int replicaId = 0;

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -69,14 +69,14 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
       }
     }
 
-    // Gather all segments and group them by partition, sorted by sequence number
-    Map<String, SortedSet<SegmentName>> sortedSegmentsByPartition =
+    // Gather all segments and group them by stream partition id, sorted by sequence number
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByStreamPartition =
         LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
     // Ensure that for each partition, we have at most one Helix partition (Pinot segment) in consuming state
     Map<String, SegmentName> allowedSegmentInConsumingStateByPartition =
         LowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
-            sortedSegmentsByPartition);
+            sortedSegmentsByStreamPartition);
 
     RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigs);
 

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.broker.routing;
 
-import com.linkedin.pinot.broker.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
+import com.linkedin.pinot.broker.routing.builder.HighLevelConsumerBasedRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.RoutingTableBuilder;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableConfig.Builder;
@@ -153,7 +153,7 @@ public class RoutingTableTest {
 
   @Test(enabled=false)
   public void testKafkaHighLevelConsumerBasedRoutingTable() throws Exception {
-    RoutingTableBuilder routingStrategy = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
+    RoutingTableBuilder routingStrategy = new HighLevelConsumerBasedRoutingTableBuilder();
     final String group0 = "testResource0_REALTIME_1433316466991_0";
     final String group1 = "testResource1_REALTIME_1433316490099_1";
     final String group2 = "testResource2_REALTIME_1436589344583_1";

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerRoutingTableBuilderTest.java
@@ -46,8 +46,8 @@ public class KafkaHighLevelConsumerRoutingTableBuilderTest {
 
     Random random = new Random();
 
-    KafkaHighLevelConsumerBasedRoutingTableBuilder routingTableBuilder =
-        new KafkaHighLevelConsumerBasedRoutingTableBuilder();
+    HighLevelConsumerBasedRoutingTableBuilder routingTableBuilder =
+        new HighLevelConsumerBasedRoutingTableBuilder();
     routingTableBuilder.init(new BaseConfiguration(), new TableConfig(), null, null);
 
     String tableNameWithType = "table_REALTIME";

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/LowLevelConsumerRoutingTableBuilderTest.java
@@ -38,15 +38,15 @@ import static org.testng.Assert.*;
 /**
  * Test for the Kafka low level consumer routing table builder.
  */
-public class KafkaLowLevelConsumerRoutingTableBuilderTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaLowLevelConsumerRoutingTableBuilderTest.class);
+public class LowLevelConsumerRoutingTableBuilderTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LowLevelConsumerRoutingTableBuilderTest.class);
 
   @Test
   public void testAllOnlineRoutingTable() {
     final int ITERATIONS = 50;
     Random random = new Random();
 
-    KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
+    LowLevelConsumerRoutingTableBuilder routingTableBuilder = new LowLevelConsumerRoutingTableBuilder();
     routingTableBuilder.init(new BaseConfiguration(), new TableConfig(), null, null);
 
     long totalNanos = 0L;
@@ -154,7 +154,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
     final int ONLINE_SEGMENT_COUNT = 8;
     final int CONSUMING_SEGMENT_COUNT = SEGMENT_COUNT - ONLINE_SEGMENT_COUNT;
 
-    KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
+    LowLevelConsumerRoutingTableBuilder routingTableBuilder = new LowLevelConsumerRoutingTableBuilder();
     routingTableBuilder.init(new BaseConfiguration(), new TableConfig(), null, null);
 
     List<SegmentName> segmentNames = new ArrayList<SegmentName>();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -18,8 +18,6 @@ package com.linkedin.pinot.common.config;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.startree.hll.HllConfig;
 import java.lang.reflect.Field;
-import java.util.Set;
-import java.util.TreeSet;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.slf4j.Logger;
@@ -45,7 +43,7 @@ public class SegmentsValidationAndRetentionConfig {
   private String segmentPushType;
 
   @ConfigKey(value = "replication")
-  private String replication; // For high-level kafka consumers, the number of replicas should be same as num server instances
+  private String replication; // For high-level consumers, the number of replicas should be same as num server instances
 
   @ConfigKey(value = "schemaName")
   private String schemaName;
@@ -65,7 +63,7 @@ public class SegmentsValidationAndRetentionConfig {
   @NestedConfig
   private HllConfig hllConfig;
 
-  // Number of replicas per partition of low-level kafka consumers. This config is used for realtime tables only.
+  // Number of replicas per partition of low-level consumers. This config is used for realtime tables only.
   @ConfigKey(value = "replicasPerPartition")
   private String replicasPerPartition;
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ValidationMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ValidationMetrics.java
@@ -189,7 +189,7 @@ public class ValidationMetrics {
    * Updates the non consuming partition count metric.
    *
    * @param resource The resource for which the gauge is updated
-   * @param partitionCount Number of Kafka partitions that do not have any segment in CONSUMING state.
+   * @param partitionCount Number of partitions that do not have any segment in CONSUMING state.
    */
   public void updateNonConsumingPartitionCountMetric(final String resource, final int partitionCount) {
     final String fullGaugeName = makeGaugeName(resource, "NonConsumingPartitionCount");

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -20,13 +20,13 @@ import com.alibaba.fastjson.JSONObject;
 
 /*
  * This class encapsulates the segment completion protocol used by the server and the controller for
- * low-level kafka consumer realtime segments. The protocol has two requests: SegmentConsumedRequest
+ * low-level consumer realtime segments. The protocol has two requests: SegmentConsumedRequest
  * and SegmentCommitRequest.It has a response that may contain different status codes depending on the state machine
  * that the controller drives for that segment. All responses have two elements -- status and an offset.
  *
  * The overall idea is that when a server has completed consuming a segment until the "end criteria" that
  * is set (in the table configuration), it sends a SegmentConsumedRequest to the controller (leader).  The
- * controller may respond with a HOLD, asking the server to NOT consume any new kafka messages, but get back
+ * controller may respond with a HOLD, asking the server to NOT consume any new messages, but get back
  * to the controller after a while.
  *
  * Meanwhile, the controller co-ordinates the SegmentConsumedRequest messages from replicas and selects a server
@@ -43,7 +43,7 @@ public class SegmentCompletionProtocol {
 
   /**
    * MAX_HOLD_TIME_MS is the maximum time (msecs) for which a server will be in HOLDING state, after which it will
-   * send in a SegmentConsumedRequest with its current offset in kafka.
+   * send in a SegmentConsumedRequest with its current offset in the stream.
    */
   public static final long MAX_HOLD_TIME_MS = 3000;
   /**
@@ -63,7 +63,7 @@ public class SegmentCompletionProtocol {
     /** Server should send SegmentConsumedRequest after waiting for less than MAX_HOLD_TIME_MS */
     HOLD,
 
-    /** Server should consume kafka events to catch up to the offset contained in this response */
+    /** Server should consume stream events to catch up to the offset contained in this response */
     CATCH_UP,
 
     /** Server should discard the rows in memory */

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -69,17 +69,6 @@ public class CommonConstants {
         BucketizedSegmentAssignmentStrategy,
         ReplicaGroupSegmentAssignmentStrategy
       }
-
-      public enum RoutingTableBuilderName {
-        DefaultOffline,
-        DefaultRealtime,
-        BalancedRandom,
-        KafkaLowLevel,
-        KafkaHighLevel,
-        PartitionAwareOffline,
-        PartitionAwareRealtime
-      }
-
     }
 
     public static class Instance {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -198,7 +198,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask {
             // Count number of online replicas. Ignore if state is CONSUMING.
             // It is possible for a segment to be ONLINE in idealstate, and CONSUMING in EV for a short period of time.
             // So, ignore this combination. If a segment exists in this combination for a long time, we will get
-            // kafka-partition-not-consuming alert anyway.
+            // low level-partition-not-consuming alert anyway.
             if (serverAndState.getValue().equals(ONLINE) || serverAndState.getValue().equals(CONSUMING)) {
               nReplicas++;
             }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1106,7 +1106,7 @@ public class PinotHelixResourceManager {
 
         /*
          * PinotRealtimeSegmentManager sets up watches on table and segment path. When a table gets created,
-         * it expects the INSTANCE path in propertystore to be set up so that it can get the kafka group ID and
+         * it expects the INSTANCE path in propertystore to be set up so that it can get the group ID and
          * create (high-level consumer) segments for that table.
          * So, we need to set up the instance first, before adding the table resource for HLC new table creation.
          *

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -102,12 +102,12 @@ public class PinotTableIdealStateBuilder {
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(realtimeTableConfig);
     final List<String> realtimeInstances =
         HelixHelper.getInstancesWithTag(helixManager, realtimeTagConfig.getConsumingServerTag());
-    IdealState idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, 1);
+    IdealState idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, 1);
     if (realtimeInstances.size() % Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()) != 0) {
       throw new RuntimeException(
           "Number of instance in current tenant should be an integer multiples of the number of replications");
     }
-    setupInstanceConfigForKafkaHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
+    setupInstanceConfigForHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
         Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()),
         realtimeTableConfig.getIndexingConfig().getStreamConfigs(), zkHelixPropertyStore, realtimeInstances);
     return idealState;
@@ -129,7 +129,7 @@ public class PinotTableIdealStateBuilder {
           "Invalid value for replicasPerPartition, expected a number: " + replicasPerPartitionStr, e);
     }
     if (idealState == null) {
-      idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, nReplicas);
+      idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, nReplicas);
     }
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
     try {
@@ -151,7 +151,7 @@ public class PinotTableIdealStateBuilder {
     }
   }
 
-  public static IdealState buildEmptyKafkaConsumerRealtimeIdealStateFor(String realtimeTableName, int replicaCount) {
+  public static IdealState buildEmptyRealtimeIdealStateFor(String realtimeTableName, int replicaCount) {
     final CustomModeISBuilder customModeIdealStateBuilder = new CustomModeISBuilder(realtimeTableName);
     customModeIdealStateBuilder
         .setStateModel(PinotHelixSegmentOnlineOfflineStateModelGenerator.PINOT_SEGMENT_ONLINE_OFFLINE_STATE_MODEL)
@@ -162,7 +162,7 @@ public class PinotTableIdealStateBuilder {
     return idealState;
   }
 
-  private static void setupInstanceConfigForKafkaHighLevelConsumer(String realtimeTableName, int numDataInstances,
+  private static void setupInstanceConfigForHighLevelConsumer(String realtimeTableName, int numDataInstances,
       int numDataReplicas, Map<String, String> streamProviderConfig,
       ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore, List<String> instanceList) {
     int numInstancesPerReplica = numDataInstances / numDataReplicas;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Realtime segment manager, which assigns realtime segments to server instances so that they can consume from Kafka.
+ * Realtime segment manager, which assigns realtime segments to server instances so that they can consume from the stream.
  */
 public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkChildListener, IZkDataListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotRealtimeSegmentManager.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -149,7 +149,7 @@ public class SegmentCompletionManager {
   }
 
   /**
-   * This method is to be called when a server calls in with the segmentConsumed() API, reporting an offset in kafka
+   * This method is to be called when a server calls in with the segmentConsumed() API, reporting an offset in the stream
    * that it currently has (i.e. next offset that it will consume, if it continues to consume).
    */
   public SegmentCompletionProtocol.Response segmentConsumed(SegmentCompletionProtocol.Request.Params reqParams) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -95,7 +95,7 @@ public class HelixSetupUtils {
           LOGGER.info("State model {} already updated to contain CONSUMING state", segmentStateModelName);
           return;
         } else {
-          LOGGER.info("Updating {} to add states for low level kafka consumers", segmentStateModelName);
+          LOGGER.info("Updating {} to add states for low level consumers", segmentStateModelName);
           StateModelDefinition newStateModelDef = PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition();
           ZkClient zkClient = new ZkClient(zkPath);
           zkClient.waitUntilConnected(CommonConstants.Helix.ZkClient.DEFAULT_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
@@ -130,7 +130,7 @@ public class HelixSetupUtils {
 
     // If this is a fresh cluster we are creating, then the cluster will see the CONSUMING state in the
     // state model. But then the servers will never be asked to go to that STATE (whether they have the code
-    // to handle it or not) unil we complete the feature using low-level kafka consumers and turn the feature on.
+    // to handle it or not) unil we complete the feature using low-level consumers and turn the feature on.
     admin.addStateModelDef(helixClusterName, segmentStateModelName,
         PinotHelixSegmentOnlineOfflineStateModelGenerator.generatePinotStateModelDefinition());
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -855,7 +855,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     TableConfig tableConfig = makeTableConfig(rtTableName, 3, DUMMY_HOST, DEFAULT_SERVER_TENANT);
     segmentManager.addTableToStore(rtTableName, tableConfig, 8);
-    IdealState idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, 10);
+    IdealState idealState = PinotTableIdealStateBuilder.buildEmptyRealtimeIdealStateFor(rtTableName, 10);
     try {
       segmentManager.setupNewTable(tableConfig, idealState);
       Assert.fail("Did not get expected exception when setting up new table with existing segments in ");
@@ -882,7 +882,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager.addTableToStore(tableName, tableConfig, nPartitions);
 
     IdealState idealState =
-        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(tableName, nReplicas);
+        PinotTableIdealStateBuilder.buildEmptyRealtimeIdealStateFor(tableName, nReplicas);
     segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
     segmentManager.setupNewTable(tableConfig, idealState);
     // Now commit the first segment of partition 6.
@@ -1111,7 +1111,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     TableConfig tableConfig =
         makeTableConfig(rtTableName, nReplicas, DUMMY_HOST, DEFAULT_SERVER_TENANT);
     IdealState idealState =
-        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, nReplicas);
+        PinotTableIdealStateBuilder.buildEmptyRealtimeIdealStateFor(rtTableName, nReplicas);
 
     segmentManager.addTableToStore(rtTableName, tableConfig, nPartitions);
     segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -222,7 +222,7 @@ public class RetentionManagerTest {
     List<RealtimeSegmentZKMetadata> allSegments = new ArrayList<>();
 
     IdealState idealState =
-        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(REALTIME_TABLE_NAME, replicaCount);
+        PinotTableIdealStateBuilder.buildEmptyRealtimeIdealStateFor(REALTIME_TABLE_NAME, replicaCount);
 
     final int kafkaPartition = 5;
     final long millisInDays = TimeUnit.DAYS.toMillis(1);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -172,7 +172,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     // lets create a new realtime segment
-    segmentLogger.info("Started kafka stream provider");
+    segmentLogger.info("Started {} stream provider", _streamConfig.getType());
     final int capacity = _streamConfig.getFlushThresholdRows();
     RealtimeSegmentConfig realtimeSegmentConfig = new RealtimeSegmentConfig.Builder().setSegmentName(segmentName)
         .setStreamName(_streamConfig.getTopicName())
@@ -302,13 +302,13 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           ImmutableSegment segment =
               ImmutableSegmentLoader.load(new File(resourceDir, segmentMetatdaZk.getSegmentName()), indexLoadingConfig);
 
-          segmentLogger.info("Committing Kafka offsets");
+          segmentLogger.info("Committing {} offsets", _streamConfig.getType());
           boolean commitSuccessful = false;
           try {
             _streamLevelConsumer.commit();
             commitSuccessful = true;
             _streamLevelConsumer.shutdown();
-            segmentLogger.info("Successfully committed Kafka offsets, consumer release requested.");
+            segmentLogger.info("Successfully committed {} offsets, consumer release requested.", _streamConfig.getType());
           } catch (Throwable e) {
             // If we got here, it means that either the commit or the shutdown failed. Considering that the
             // KafkaConsumerManager delays shutdown and only adds the consumer to be released in a deferred way, this
@@ -441,7 +441,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     try {
       _streamLevelConsumer.shutdown();
     } catch (Exception e) {
-      LOGGER.error("Failed to shutdown kafka stream provider!", e);
+      LOGGER.error("Failed to shutdown stream consumer!", e);
     }
     keepIndexing = false;
     segmentStatusTask.cancel();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -332,7 +332,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     final long _endOffset = Long.MAX_VALUE; // No upper limit on stream offset
     segmentLogger.info("Starting consumption loop start offset {}, finalOffset {}", _currentOffset, _finalOffset);
     while(!_shouldStop && !endCriteriaReached()) {
-      // Consume for the next _kafkaReadTime ms, or we get to final offset, whichever happens earlier,
+      // Consume for the next readTime ms, or we get to final offset, whichever happens earlier,
       // Update _currentOffset upon return from this method
       MessageBatch messageBatch;
       try {
@@ -405,7 +405,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         //    we hit the row limit.
         //    Throw an exception.
         //
-        // 2. We are in CATCHING_UP state, and we legally hit this error due to Kafka unclean leader election where
+        // 2. We are in CATCHING_UP state, and we legally hit this error due to unclean leader election where
         //    offsets get changed with higher generation numbers for some pinot servers but not others. So, if another
         //    server (who got a larger stream offset) asked us to catch up to that offset, but we are connected to a
         //    broker who has smaller offsets, then we may try to push more rows into the buffer than maximum. This
@@ -455,8 +455,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       segmentLogger.debug("Indexed {} messages ({} messages read from stream) current offset {}", indexedMessageCount,
           streamMessageCount, _currentOffset);
     } else {
-      // If there were no messages to be fetched from Kafka, wait for a little bit as to avoid hammering the
-      // Kafka broker
+      // If there were no messages to be fetched from stream, wait for a little bit as to avoid hammering the stream
       Uninterruptibles.sleepUninterruptibly(idlePipeSleepTimeMillis, TimeUnit.MILLISECONDS);
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -36,7 +36,6 @@ import com.linkedin.pinot.core.data.manager.SegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaConsumerManager;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.segment.index.loader.LoaderUtils;
 import java.io.File;
@@ -52,7 +51,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
 
-import static com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema;
+import static com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory.*;
 
 
 @ThreadSafe
@@ -141,7 +140,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
       segmentDataManager.destroy();
     }
-    KafkaConsumerManager.closeAllConsumers();
     if (_leaseExtender != null) {
       _leaseExtender.shutDown();
     }
@@ -188,10 +186,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    *   we treat it exactly like how OfflineTableDataManager would -- wrap it into an OfflineSegmentDataManager, and put it
    *   in the map.
    * - We are being asked to own up a new realtime segment. In this case, we wrap the segment with a RealTimeSegmentDataManager
-   *   (that kicks off Kafka consumption). When the segment is committed we get notified via the notifySegmentCommitted call, at
+   *   (that kicks off consumption). When the segment is committed we get notified via the notifySegmentCommitted call, at
    *   which time we replace the segment with the OfflineSegmentDataManager
    * For LL Segments:
-   * - We are being asked to start consuming from a kafka partition.
+   * - We are being asked to start consuming from a partition.
    * - We did not know about the segment and are being asked to download and own the segment (re-balancing, or
    *   replacing a realtime server with a fresh one, maybe). We need to look at segment metadata and decide whether
    *   to start consuming or download the segment.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
@@ -35,7 +35,7 @@ public class KafkaJSONMessageDecoder implements StreamMessageDecoder<byte[]> {
   private Schema schema;
 
   @Override
-  public void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception {
+  public void init(Map<String, String> props, Schema indexingSchema, String topicName) throws Exception {
     this.schema = indexingSchema;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/MessageBatch.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/MessageBatch.java
@@ -16,33 +16,33 @@
 package com.linkedin.pinot.core.realtime.stream;
 
 /**
- * Interface wrapping Kafka consumer. Throws IndexOutOfBoundsException when trying to access a message at an
+ * Interface wrapping stream consumer. Throws IndexOutOfBoundsException when trying to access a message at an
  * invalid index.
  * @param <T>
  */
 public interface MessageBatch<T> {
     /**
      *
-     * @return number of messages returned from kafka
+     * @return number of messages returned from the stream
      */
     int getMessageCount();
 
     /**
-     * Returns the message at a particular index inside a set of messages returned from Kafka.
+     * Returns the message at a particular index inside a set of messages returned from the stream.
      * @param index
      * @return
      */
     T getMessageAtIndex(int index);
 
     /**
-     * Returns the offset of the message at a particular index inside a set of messages returned from Kafka.
+     * Returns the offset of the message at a particular index inside a set of messages returned from the stream.
      * @param index
      * @return
      */
     int getMessageOffsetAtIndex(int index);
 
     /**
-     * Returns the length of the message at a particular index inside a set of messages returned from Kafka.
+     * Returns the length of the message at a particular index inside a set of messages returned from the stream.
      * @param index
      * @return
      */

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamConfigProperties.java
@@ -49,12 +49,12 @@ public class StreamConfigProperties {
    * then a high level consumer would have a buffer size of two million.
    *
    * For LLC, this size is divided across all the segments assigned to a given server and is set on a per segment
-   * basis. Assuming a low level consumer server is assigned four Kafka partitions to consume from and a flush
+   * basis. Assuming a low level consumer server is assigned four stream partitions to consume from and a flush
    * size of two million, then each consuming segment would have a flush size of five hundred thousand rows, for a
    * total of two million rows in memory.
    *
    * Keep in mind that this NOT a hard threshold, as other tables can also be assigned to this server, and that in
-   * certain conditions (eg. if the number of servers, replicas of Kafka partitions changes) where Kafka partition
+   * certain conditions (eg. if the number of servers, replicas of partitions changes) where partition
    * to server assignment changes, it's possible to end up with more (or less) than this number of rows in memory.
    *
    * If this value is set to 0, then the consumers adjust the number of rows consumed by a partition such that

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/stream/StreamMessageDecoder.java
@@ -28,7 +28,7 @@ public interface StreamMessageDecoder<T> {
    * @param props
    * @throws Exception
    */
-  void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception;
+  void init(Map<String, String> props, Schema indexingSchema, String topicName) throws Exception;
 
   /**
    *

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -139,7 +139,7 @@ public class LLRealtimeSegmentDataManagerTest {
   public static class FakeStreamMessageDecoder implements StreamMessageDecoder<byte[]> {
 
     @Override
-    public void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception {
+    public void init(Map<String, String> props, Schema indexingSchema, String topicName) throws Exception {
 
     }
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -344,7 +344,7 @@ public abstract class ClusterTest extends ControllerTest {
     private DatumReader<GenericData.Record> _reader;
 
     @Override
-    public void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception {
+    public void init(Map<String, String> props, Schema indexingSchema, String topicName) throws Exception {
       // Load Avro schema
       DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(avroFile);
       _avroSchema = reader.getSchema();


### PR DESCRIPTION
This is part 1 of cleanup for removing references to kafka in places which should be generic. This PR only involves renaming