### PR TITLE
Add stream agnostic metrics for realtime

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -50,6 +50,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_AUTO_CREATED_PARTITIONS("creates", false),
   LLC_ZOOKEEPER_UPDATE_FAILURES("failures", false),
   LLC_KAFKA_DATA_LOSS("dataLoss", false),
+  // Introducing a new stream agnostic metric to replace LLC_KAFKA_DATA_LOSS.
+  // We can phase out LLC_KAFKA_DATA_LOSS once we have collected sufficient metrics for the new one
+  LLC_STREAM_DATA_LOSS("dataLoss", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -27,12 +27,18 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   SEGMENT_COUNT("segments", false),
   LLC_PARTITION_CONSUMING("state", false),
   HIGHEST_KAFKA_OFFSET_CONSUMED("messages", false),
+  // Introducing a new stream agnostic metric to replace HIGHEST_KAFKA_OFFSET_CONSUMED.
+  // We can phase out HIGHEST_KAFKA_OFFSET_CONSUMED once we have collected sufficient metrics for the new one
+  HIGHEST_STREAM_OFFSET_CONSUMED("messages", false),
   LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_CREATION_WAIT_TIME_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_INITIAL_CONSUMPTION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS("seconds", false),
   KAFKA_PARTITION_OFFSET_LAG("messages", false),
+  // Introducing a new stream agnostic metric to replace KAFKA_PARTITION_OFFSET_LAG.
+  // We can phase out KAFKA_PARTITION_OFFSET_LAG once we have collected sufficient metrics for the new one
+  STREAM_PARTITION_OFFSET_LAG("messages", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   RUNNING_QUERIES("runningQueries", false),
   REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -739,6 +739,7 @@ public class PinotLLCRealtimeSegmentManager {
             oldestOffsetInKafka, realtimeTableName, partition, nextSeqNum);
         // Start from the earliest offset in kafka
         _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_KAFKA_DATA_LOSS, 1);
+        _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
       }
     } else {
       // Status must be DONE, so we have a valid end-offset for the previous segment
@@ -754,6 +755,7 @@ public class PinotLLCRealtimeSegmentManager {
         LOGGER.warn("Data lost from kafka offset {} to {} for table {} partition {} sequence {}", prevSegEndOffset,
             oldestOffsetInKafka, realtimeTableName, partition, nextSeqNum);
         _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_KAFKA_DATA_LOSS, 1);
+        _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_STREAM_DATA_LOSS, 1);
       } else {
         // The two happen to be equal. A rarity, so log it.
         LOGGER.info("Kafka earliest offset {} is the same as new segment start offset", oldestOffsetInKafka);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -360,6 +360,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       if (_currentOffset != lastUpdatedOffset) {
         // We consumed something. Update the highest stream offset as well as partition-consuming metric.
         _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.HIGHEST_KAFKA_OFFSET_CONSUMED, _currentOffset);
+        _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.HIGHEST_STREAM_OFFSET_CONSUMED, _currentOffset);
         _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LLC_PARTITION_CONSUMING, 1);
         lastUpdatedOffset = _currentOffset;
       } else {


### PR DESCRIPTION
Some of the metrics in Controller and Server have KAFKA in their names. We cannot directly rename them, as we will lose out on alerts setup on the old names, if any. 
The plan is to introduce new metrics which have stream agnostic names. We will start using the new metrics, while also having the older one around. Once we have collected sufficient days of metrics for the enw one, we can phase out the old one.
We need to announce to the open source community that the older metrics will be going away eventually, and a shift to the new ones is required.