### PR TITLE
Limit the ByteArray wrapper logic inside segment creator

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.core.data.recordtransformer;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.data.GenericRow;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +43,6 @@ public class DataTypeTransformer implements RecordTransformer {
     SINGLE_VALUE_TYPE_MAP.put(Double.class, PinotDataType.DOUBLE);
     SINGLE_VALUE_TYPE_MAP.put(String.class, PinotDataType.STRING);
     SINGLE_VALUE_TYPE_MAP.put(byte[].class, PinotDataType.BYTES);
-    SINGLE_VALUE_TYPE_MAP.put(ByteArray.class, PinotDataType.BYTES);
 
     MULTI_VALUE_TYPE_MAP.put(Byte.class, PinotDataType.BYTE_ARRAY);
     MULTI_VALUE_TYPE_MAP.put(Character.class, PinotDataType.CHARACTER_ARRAY);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/SanitationTransformer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/recordtransformer/SanitationTransformer.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.core.data.recordtransformer;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.StringUtil;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.data.GenericRow;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,22 +28,18 @@ import java.util.Map;
  * The {@code SanitationTransformer} class will sanitize the values to follow certain rules including:
  * <ul>
  *   <li>No {@code null} characters in string values</li>
- *   <li>Bytes values are stored as {@link ByteArray}</li>
  * </ul>
  * <p>NOTE: should put this after the {@link DataTypeTransformer} so that all values follow the data types in
  * {@link FieldSpec}.
  */
 public class SanitationTransformer implements RecordTransformer {
-  List<String> _stringColumns = new ArrayList<>();
-  List<String> _bytesColumns = new ArrayList<>();
+  private final List<String> _stringColumns = new ArrayList<>();
 
   public SanitationTransformer(Schema schema) {
     for (Map.Entry<String, FieldSpec> entry : schema.getFieldSpecMap().entrySet()) {
       FieldSpec.DataType dataType = entry.getValue().getDataType();
       if (dataType == FieldSpec.DataType.STRING) {
         _stringColumns.add(entry.getKey());
-      } else if (dataType == FieldSpec.DataType.BYTES) {
-        _bytesColumns.add(entry.getKey());
       }
     }
   }
@@ -71,14 +66,6 @@ public class SanitationTransformer implements RecordTransformer {
         }
       }
     }
-
-    for (String bytesColumn : _bytesColumns) {
-      Object value = record.getValue(bytesColumn);
-      if (value instanceof byte[]) {
-        record.putField(bytesColumn, new ByteArray((byte[]) value));
-      }
-    }
-
     return record;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -29,23 +29,26 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
-    return getDictId(rawValue);
+    assert rawValue instanceof byte[];
+    return getDictId(new ByteArray((byte[]) rawValue));
+  }
+
+  @Override
+  public byte[] get(int dictId) {
+    return ((ByteArray) super.get(dictId)).getBytes();
+  }
+
+  @Override
+  public byte[] getBytesValue(int dictId) {
+    return get(dictId);
   }
 
   @Override
   public void index(@Nonnull Object rawValue) {
-    if (rawValue instanceof ByteArray) {
-      // Single value
-      indexValue(rawValue);
-      updateMinMax((ByteArray) rawValue);
-    } else {
-      // Multi value
-      Object[] values = (Object[]) rawValue;
-      for (Object value : values) {
-        indexValue(value);
-        updateMinMax((ByteArray) value);
-      }
-    }
+    assert rawValue instanceof byte[];
+    ByteArray byteArray = new ByteArray((byte[]) rawValue);
+    indexValue(byteArray);
+    updateMinMax(byteArray);
   }
 
   @Override
@@ -73,31 +76,11 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
     ByteArray[] sortedValues = new ByteArray[numValues];
 
     for (int i = 0; i < numValues; i++) {
-      sortedValues[i] = (ByteArray) get(i);
+      sortedValues[i] = (ByteArray) super.get(i);
     }
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public int getIntValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public long getLongValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public float getFloatValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public double getDoubleValue(int dictId) {
-    throw new UnsupportedOperationException();
   }
 
   private void updateMinMax(ByteArray value) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
@@ -173,15 +173,10 @@ public class SegmentDictionaryCreator implements Closeable {
         Preconditions.checkState(numValues > 0);
         _bytesValueToIndexMap = new Object2IntOpenHashMap<>(numValues);
 
-        // Get the maximum length of all entries
-        byte[][] sortedValues = new byte[numValues][];
-
         for (int i = 0; i < numValues; i++) {
           ByteArray value = sortedBytes[i];
           _bytesValueToIndexMap.put(value, i);
-          byte[] valueBytes = value.getBytes();
-          sortedValues[i] = valueBytes;
-          _numBytesPerEntry = Math.max(_numBytesPerEntry, valueBytes.length);
+          _numBytesPerEntry = Math.max(_numBytesPerEntry, value.getBytes().length);
         }
 
         // Backward-compatible: index file is always big-endian
@@ -195,8 +190,7 @@ public class SegmentDictionaryCreator implements Closeable {
         }
         LOGGER.info(
             "Created dictionary for BYTES column: {} with cardinality: {}, max length in bytes: {}, range: {} to {}",
-            _fieldSpec.getName(), numValues, _numBytesPerEntry, Arrays.asList(sortedValues[0]),
-            Arrays.asList(sortedValues[numValues - 1]));
+            _fieldSpec.getName(), numValues, _numBytesPerEntry, sortedBytes[0], sortedBytes[numValues - 1]);
         return;
 
       default:
@@ -221,7 +215,7 @@ public class SegmentDictionaryCreator implements Closeable {
       case STRING:
         return _stringValueToIndexMap.getInt(value);
       case BYTES:
-        return _bytesValueToIndexMap.get(value);
+        return _bytesValueToIndexMap.get(new ByteArray((byte[]) value));
       default:
         throw new UnsupportedOperationException("Unsupported data type : " + _fieldSpec.getDataType());
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.segment.creator.impl.fwd;
 
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import com.linkedin.pinot.core.io.writer.impl.v1.VarByteChunkSingleValueWriter;
 import com.linkedin.pinot.core.segment.creator.BaseSingleValueRawIndexCreator;
@@ -51,8 +50,6 @@ public class SingleValueVarByteRawIndexCreator extends BaseSingleValueRawIndexCr
       _indexWriter.setString(docId, (String) valueToIndex);
     } else if (valueToIndex instanceof byte[]) {
       _indexWriter.setBytes(docId, (byte[]) valueToIndex);
-    } else if (valueToIndex instanceof ByteArray) {
-      _indexWriter.setBytes(docId, ((ByteArray) valueToIndex).getBytes());
     } else {
       throw new IllegalArgumentException(
           "Illegal data type for variable length indexing: " + valueToIndex.getClass().getName());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -119,7 +119,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   }
 
   private static ImmutableDictionaryReader loadDictionary(PinotDataBuffer dictionaryBuffer, ColumnMetadata metadata,
-      boolean loadOnHeap) throws IOException {
+      boolean loadOnHeap) {
     FieldSpec.DataType dataType = metadata.getDataType();
     if (loadOnHeap) {
       String columnName = metadata.getColumnName();
@@ -152,8 +152,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
       case BYTES:
         numBytesPerValue = metadata.getColumnMaxLength();
-        paddingByte = (byte) metadata.getPaddingCharacter();
-        return new BytesDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte);
+        return new BytesDictionary(dictionaryBuffer, length, numBytesPerValue);
 
       default:
         throw new IllegalStateException("Illegal data type for dictionary: " + dataType);
@@ -161,7 +160,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   }
 
   private static SingleColumnSingleValueReader loadRawForwardIndex(PinotDataBuffer forwardIndexBuffer,
-      FieldSpec.DataType dataType) throws IOException {
+      FieldSpec.DataType dataType) {
 
     switch (dataType) {
       case INT:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BytesDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/BytesDictionary.java
@@ -23,8 +23,8 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
  */
 public class BytesDictionary extends ImmutableDictionaryReader {
 
-  public BytesDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue, byte paddingByte) {
-    super(dataBuffer, length, numBytesPerValue, paddingByte);
+  public BytesDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue) {
+    super(dataBuffer, length, numBytesPerValue, (byte) 0);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/AvroUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/AvroUtils.java
@@ -21,7 +21,6 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.data.GenericRow;
 import java.io.File;
 import java.io.FileInputStream;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/recordtransformer/RecordTransformerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/recordtransformer/RecordTransformerTest.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.core.data.recordtransformer;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.data.GenericRow;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,12 +33,12 @@ public class RecordTransformerTest {
       .addSingleValueDimension("svLong", FieldSpec.DataType.LONG)
       .addSingleValueDimension("svFloat", FieldSpec.DataType.FLOAT)
       .addSingleValueDimension("svDouble", FieldSpec.DataType.DOUBLE)
+      .addSingleValueDimension("svBytes", FieldSpec.DataType.BYTES)
       .addMultiValueDimension("mvInt", FieldSpec.DataType.INT)
       .addMultiValueDimension("mvLong", FieldSpec.DataType.LONG)
       .addMultiValueDimension("mvFloat", FieldSpec.DataType.FLOAT)
       .addMultiValueDimension("mvDouble", FieldSpec.DataType.DOUBLE)
       // For sanitation
-      .addSingleValueDimension("svBytes", FieldSpec.DataType.BYTES)
       .addSingleValueDimension("svStringWithNullCharacters", FieldSpec.DataType.STRING)
       // For time conversion
       .addTime("incoming", 6, TimeUnit.HOURS, FieldSpec.DataType.INT, "outgoing", 1, TimeUnit.MILLISECONDS,
@@ -55,11 +54,11 @@ public class RecordTransformerTest {
     fields.put("svLong", (char) 123);
     fields.put("svFloat", (short) 123);
     fields.put("svDouble", "123");
+    fields.put("svBytes", new byte[]{123, 123});
     fields.put("mvInt", new Object[]{123L});
     fields.put("mvLong", new Object[]{123f});
     fields.put("mvFloat", new Object[]{123d});
     fields.put("mvDouble", new Object[]{123});
-    fields.put("svBytes", new byte[]{123});
     fields.put("svStringWithNullCharacters", "1\0002\0003");
     fields.put("incoming", "123");
     record.init(fields);
@@ -90,11 +89,11 @@ public class RecordTransformerTest {
       assertEquals(record.getValue("svLong"), 123L);
       assertEquals(record.getValue("svFloat"), 123f);
       assertEquals(record.getValue("svDouble"), 123d);
+      assertEquals(record.getValue("svBytes"), new byte[]{123, 123});
       assertEquals(record.getValue("mvInt"), new Object[]{123});
       assertEquals(record.getValue("mvLong"), new Object[]{123L});
       assertEquals(record.getValue("mvFloat"), new Object[]{123f});
       assertEquals(record.getValue("mvDouble"), new Object[]{123d});
-      assertEquals(record.getValue("svBytes"), new byte[]{123});
       assertEquals(record.getValue("svStringWithNullCharacters"), "1\0002\0003");
       // Incoming time field won't be converted (it's ignored in this transformer)
       assertEquals(record.getValue("incoming"), "123");
@@ -111,7 +110,6 @@ public class RecordTransformerTest {
     for (int i = 0; i < NUM_ROUNDS; i++) {
       record = transformer.transform(record);
       assertNotNull(record);
-      assertEquals(record.getValue("svBytes"), new ByteArray(new byte[]{123}));
       assertEquals(record.getValue("svStringWithNullCharacters"), "123");
     }
   }
@@ -127,11 +125,11 @@ public class RecordTransformerTest {
       assertEquals(record.getValue("svLong"), 123L);
       assertEquals(record.getValue("svFloat"), 123f);
       assertEquals(record.getValue("svDouble"), 123d);
+      assertEquals(record.getValue("svBytes"), new byte[]{123, 123});
       assertEquals(record.getValue("mvInt"), new Object[]{123});
       assertEquals(record.getValue("mvLong"), new Object[]{123L});
       assertEquals(record.getValue("mvFloat"), new Object[]{123f});
       assertEquals(record.getValue("mvDouble"), new Object[]{123d});
-      assertEquals(record.getValue("svBytes"), new ByteArray(new byte[]{123}));
       assertEquals(record.getValue("svStringWithNullCharacters"), "123");
       assertEquals(record.getValue("incoming"), "123");
       assertEquals(record.getValue("outgoing"), 123 * 6 * 3600 * 1000L);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.segment.index.readers;
 
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentDictionaryCreator;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
@@ -31,10 +32,11 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.RandomStringUtils;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class ImmutableDictionaryReaderTest {
@@ -45,14 +47,17 @@ public class ImmutableDictionaryReaderTest {
   private static final String FLOAT_COLUMN_NAME = "floatColumn";
   private static final String DOUBLE_COLUMN_NAME = "doubleColumn";
   private static final String STRING_COLUMN_NAME = "stringColumn";
+  private static final String BYTES_COLUMN_NAME = "bytesColumn";
   private static final int NUM_VALUES = 1000;
   private static final int MAX_STRING_LENGTH = 100;
+  private static final int BYTES_LENGTH = 100;
 
   private int[] _intValues;
   private long[] _longValues;
   private float[] _floatValues;
   private double[] _doubleValues;
   private String[] _stringValues;
+  private ByteArray[] _bytesValues;
 
   private int _numBytesPerStringValue;
 
@@ -95,6 +100,15 @@ public class ImmutableDictionaryReaderTest {
     _stringValues = stringSet.toArray(new String[NUM_VALUES]);
     Arrays.sort(_stringValues);
 
+    Set<ByteArray> bytesSet = new HashSet<>();
+    while (bytesSet.size() < NUM_VALUES) {
+      byte[] bytes = new byte[BYTES_LENGTH];
+      RANDOM.nextBytes(bytes);
+      bytesSet.add(new ByteArray(bytes));
+    }
+    _bytesValues = bytesSet.toArray(new ByteArray[NUM_VALUES]);
+    Arrays.sort(_bytesValues);
+
     try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_intValues,
         new DimensionFieldSpec(INT_COLUMN_NAME, FieldSpec.DataType.INT, true), TEMP_DIR)) {
       dictionaryCreator.build();
@@ -120,6 +134,12 @@ public class ImmutableDictionaryReaderTest {
       dictionaryCreator.build();
       _numBytesPerStringValue = dictionaryCreator.getNumBytesPerEntry();
     }
+
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_bytesValues,
+        new DimensionFieldSpec(BYTES_COLUMN_NAME, FieldSpec.DataType.BYTES, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+      assertEquals(dictionaryCreator.getNumBytesPerEntry(), BYTES_LENGTH);
+    }
   }
 
   @Test
@@ -128,17 +148,17 @@ public class ImmutableDictionaryReaderTest {
         PinotDataBuffer.mapReadOnlyBigEndianFile(new File(TEMP_DIR, INT_COLUMN_NAME + V1Constants.Dict.FILE_EXTENSION)),
         NUM_VALUES)) {
       for (int i = 0; i < NUM_VALUES; i++) {
-        Assert.assertEquals(intDictionary.get(i).intValue(), _intValues[i]);
-        Assert.assertEquals(intDictionary.getIntValue(i), _intValues[i]);
-        Assert.assertEquals(intDictionary.getLongValue(i), _intValues[i]);
-        Assert.assertEquals(intDictionary.getFloatValue(i), _intValues[i], 0.0f);
-        Assert.assertEquals(intDictionary.getDoubleValue(i), _intValues[i], 0.0);
-        Assert.assertEquals(Integer.parseInt(intDictionary.getStringValue(i)), _intValues[i]);
+        assertEquals(intDictionary.get(i).intValue(), _intValues[i]);
+        assertEquals(intDictionary.getIntValue(i), _intValues[i]);
+        assertEquals(intDictionary.getLongValue(i), _intValues[i]);
+        assertEquals(intDictionary.getFloatValue(i), _intValues[i], 0.0f);
+        assertEquals(intDictionary.getDoubleValue(i), _intValues[i], 0.0);
+        assertEquals(Integer.parseInt(intDictionary.getStringValue(i)), _intValues[i]);
 
-        Assert.assertEquals(intDictionary.indexOf(_intValues[i]), i);
+        assertEquals(intDictionary.indexOf(_intValues[i]), i);
 
         int randomInt = RANDOM.nextInt();
-        Assert.assertEquals(intDictionary.insertionIndexOf(randomInt), Arrays.binarySearch(_intValues, randomInt));
+        assertEquals(intDictionary.insertionIndexOf(randomInt), Arrays.binarySearch(_intValues, randomInt));
       }
     }
   }
@@ -148,17 +168,17 @@ public class ImmutableDictionaryReaderTest {
     try (LongDictionary longDictionary = new LongDictionary(PinotDataBuffer.mapReadOnlyBigEndianFile(
         new File(TEMP_DIR, LONG_COLUMN_NAME + V1Constants.Dict.FILE_EXTENSION)), NUM_VALUES)) {
       for (int i = 0; i < NUM_VALUES; i++) {
-        Assert.assertEquals(longDictionary.get(i).longValue(), _longValues[i]);
-        Assert.assertEquals(longDictionary.getIntValue(i), (int) _longValues[i]);
-        Assert.assertEquals(longDictionary.getLongValue(i), _longValues[i]);
-        Assert.assertEquals(longDictionary.getFloatValue(i), _longValues[i], 0.0f);
-        Assert.assertEquals(longDictionary.getDoubleValue(i), _longValues[i], 0.0);
-        Assert.assertEquals(Long.parseLong(longDictionary.getStringValue(i)), _longValues[i]);
+        assertEquals(longDictionary.get(i).longValue(), _longValues[i]);
+        assertEquals(longDictionary.getIntValue(i), (int) _longValues[i]);
+        assertEquals(longDictionary.getLongValue(i), _longValues[i]);
+        assertEquals(longDictionary.getFloatValue(i), _longValues[i], 0.0f);
+        assertEquals(longDictionary.getDoubleValue(i), _longValues[i], 0.0);
+        assertEquals(Long.parseLong(longDictionary.getStringValue(i)), _longValues[i]);
 
-        Assert.assertEquals(longDictionary.indexOf(_longValues[i]), i);
+        assertEquals(longDictionary.indexOf(_longValues[i]), i);
 
         long randomLong = RANDOM.nextLong();
-        Assert.assertEquals(longDictionary.insertionIndexOf(randomLong), Arrays.binarySearch(_longValues, randomLong));
+        assertEquals(longDictionary.insertionIndexOf(randomLong), Arrays.binarySearch(_longValues, randomLong));
       }
     }
   }
@@ -168,18 +188,17 @@ public class ImmutableDictionaryReaderTest {
     try (FloatDictionary floatDictionary = new FloatDictionary(PinotDataBuffer.mapReadOnlyBigEndianFile(
         new File(TEMP_DIR, FLOAT_COLUMN_NAME + V1Constants.Dict.FILE_EXTENSION)), NUM_VALUES)) {
       for (int i = 0; i < NUM_VALUES; i++) {
-        Assert.assertEquals(floatDictionary.get(i), _floatValues[i], 0.0f);
-        Assert.assertEquals(floatDictionary.getIntValue(i), (int) _floatValues[i]);
-        Assert.assertEquals(floatDictionary.getLongValue(i), (long) _floatValues[i]);
-        Assert.assertEquals(floatDictionary.getFloatValue(i), _floatValues[i], 0.0f);
-        Assert.assertEquals(floatDictionary.getDoubleValue(i), _floatValues[i], 0.0);
-        Assert.assertEquals(Float.parseFloat(floatDictionary.getStringValue(i)), _floatValues[i], 0.0f);
+        assertEquals(floatDictionary.get(i), _floatValues[i], 0.0f);
+        assertEquals(floatDictionary.getIntValue(i), (int) _floatValues[i]);
+        assertEquals(floatDictionary.getLongValue(i), (long) _floatValues[i]);
+        assertEquals(floatDictionary.getFloatValue(i), _floatValues[i], 0.0f);
+        assertEquals(floatDictionary.getDoubleValue(i), _floatValues[i], 0.0);
+        assertEquals(Float.parseFloat(floatDictionary.getStringValue(i)), _floatValues[i], 0.0f);
 
-        Assert.assertEquals(floatDictionary.indexOf(_floatValues[i]), i);
+        assertEquals(floatDictionary.indexOf(_floatValues[i]), i);
 
         float randomFloat = RANDOM.nextFloat();
-        Assert.assertEquals(floatDictionary.insertionIndexOf(randomFloat),
-            Arrays.binarySearch(_floatValues, randomFloat));
+        assertEquals(floatDictionary.insertionIndexOf(randomFloat), Arrays.binarySearch(_floatValues, randomFloat));
       }
     }
   }
@@ -189,18 +208,17 @@ public class ImmutableDictionaryReaderTest {
     try (DoubleDictionary doubleDictionary = new DoubleDictionary(PinotDataBuffer.mapReadOnlyBigEndianFile(
         new File(TEMP_DIR, DOUBLE_COLUMN_NAME + V1Constants.Dict.FILE_EXTENSION)), NUM_VALUES)) {
       for (int i = 0; i < NUM_VALUES; i++) {
-        Assert.assertEquals(doubleDictionary.get(i), _doubleValues[i], 0.0);
-        Assert.assertEquals(doubleDictionary.getIntValue(i), (int) _doubleValues[i]);
-        Assert.assertEquals(doubleDictionary.getLongValue(i), (long) _doubleValues[i]);
-        Assert.assertEquals(doubleDictionary.getFloatValue(i), (float) _doubleValues[i], 0.0f);
-        Assert.assertEquals(doubleDictionary.getDoubleValue(i), _doubleValues[i], 0.0);
-        Assert.assertEquals(Double.parseDouble(doubleDictionary.getStringValue(i)), _doubleValues[i], 0.0);
+        assertEquals(doubleDictionary.get(i), _doubleValues[i], 0.0);
+        assertEquals(doubleDictionary.getIntValue(i), (int) _doubleValues[i]);
+        assertEquals(doubleDictionary.getLongValue(i), (long) _doubleValues[i]);
+        assertEquals(doubleDictionary.getFloatValue(i), (float) _doubleValues[i], 0.0f);
+        assertEquals(doubleDictionary.getDoubleValue(i), _doubleValues[i], 0.0);
+        assertEquals(Double.parseDouble(doubleDictionary.getStringValue(i)), _doubleValues[i], 0.0);
 
-        Assert.assertEquals(doubleDictionary.indexOf(_doubleValues[i]), i);
+        assertEquals(doubleDictionary.indexOf(_doubleValues[i]), i);
 
         double randomDouble = RANDOM.nextDouble();
-        Assert.assertEquals(doubleDictionary.insertionIndexOf(randomDouble),
-            Arrays.binarySearch(_doubleValues, randomDouble));
+        assertEquals(doubleDictionary.insertionIndexOf(randomDouble), Arrays.binarySearch(_doubleValues, randomDouble));
       }
     }
   }
@@ -226,15 +244,32 @@ public class ImmutableDictionaryReaderTest {
 
   private void testStringDictionary(ImmutableDictionaryReader stringDictionary) {
     for (int i = 0; i < NUM_VALUES; i++) {
-      Assert.assertEquals(stringDictionary.get(i), _stringValues[i]);
-      Assert.assertEquals(stringDictionary.getStringValue(i), _stringValues[i]);
+      assertEquals(stringDictionary.get(i), _stringValues[i]);
+      assertEquals(stringDictionary.getStringValue(i), _stringValues[i]);
 
-      Assert.assertEquals(stringDictionary.indexOf(_stringValues[i]), i);
+      assertEquals(stringDictionary.indexOf(_stringValues[i]), i);
 
       // Test String longer than MAX_STRING_LENGTH
       String randomString = RandomStringUtils.random(RANDOM.nextInt(2 * MAX_STRING_LENGTH)).replace('\0', ' ');
-      Assert.assertEquals(stringDictionary.insertionIndexOf(randomString),
-          Arrays.binarySearch(_stringValues, randomString));
+      assertEquals(stringDictionary.insertionIndexOf(randomString), Arrays.binarySearch(_stringValues, randomString));
+    }
+  }
+
+  @Test
+  public void testBytesDictionary() throws Exception {
+    try (BytesDictionary bytesDictionary = new BytesDictionary(PinotDataBuffer.mapReadOnlyBigEndianFile(
+        new File(TEMP_DIR, BYTES_COLUMN_NAME + V1Constants.Dict.FILE_EXTENSION)), NUM_VALUES, BYTES_LENGTH)) {
+      for (int i = 0; i < NUM_VALUES; i++) {
+        assertEquals(new ByteArray(bytesDictionary.get(i)), _bytesValues[i]);
+        assertEquals(new ByteArray(bytesDictionary.getBytesValue(i)), _bytesValues[i]);
+
+        assertEquals(bytesDictionary.indexOf(_bytesValues[i].getBytes()), i);
+
+        byte[] randomBytes = new byte[BYTES_LENGTH];
+        RANDOM.nextBytes(randomBytes);
+        assertEquals(bytesDictionary.insertionIndexOf(randomBytes),
+            Arrays.binarySearch(_bytesValues, new ByteArray(randomBytes)));
+      }
     }
   }
 


### PR DESCRIPTION
Limit the ByteArray wrapper logic in segment creator only. Use byte[] in all other places.
With this change, ByteArray become transparent outside of segment creation.

Unify the behavior of dictionary:
- Use byte[] for value insertion, value fetch
- Use ByteArray for min-value, max-value, sorted-values