### PR TITLE
Replace ENABLE_SEGMENT_LEVEL_VALIDATION config with SEGMENT_LEVEL_VALIDATION_INTERVALS

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -70,7 +70,10 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
   private static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = "controller.realtime.segment.metadata.commit.numLocks";
   private static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
-  private static final String ENABLE_SEGMENT_LEVEL_VALIDATION = "controller.enable.segment.level.validation";
+  // Because segment level validation is expensive and requires heavy ZK access, we run segment level validation with a
+  // separate interval
+  private static final String SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS =
+      "controller.segment.level.validation.intervalInSeconds";
 
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_PREFIX = "controller.storage.factory.class";
@@ -93,7 +96,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
   private static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
   private static final boolean DEFAULT_ENABLE_STORAGE_QUOTA_CHECK = true;
-  private static final boolean DEFAULT_ENABLE_SEGMENT_LEVEL_VALIDATION = true;
+  private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
@@ -456,7 +459,7 @@ public class ControllerConf extends PropertiesConfiguration {
     return getBoolean(ENABLE_STORAGE_QUOTA_CHECK, DEFAULT_ENABLE_STORAGE_QUOTA_CHECK);
   }
 
-  public boolean getEnableSegmentLevelValidation() {
-    return getBoolean(ENABLE_SEGMENT_LEVEL_VALIDATION, DEFAULT_ENABLE_SEGMENT_LEVEL_VALIDATION);
+  public int getSegmentLevelValidationIntervalInSeconds() {
+    return getInt(SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS, DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.controller.validation;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.model.InstanceConfig;
 import org.joda.time.Duration;
@@ -50,15 +52,18 @@ import org.slf4j.LoggerFactory;
 public class ValidationManager extends ControllerPeriodicTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(ValidationManager.class);
 
-  private final boolean _enableSegmentLevelValidation;
+  private final int _segmentLevelValidationIntervalInSeconds;
   private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
   private final ValidationMetrics _validationMetrics;
+
+  private long _lastSegmentLevelValidationTimeMs = 0L;
 
   public ValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, ValidationMetrics validationMetrics) {
     super("ValidationManager", config.getValidationControllerFrequencyInSeconds(),
         config.getValidationControllerFrequencyInSeconds() / 2, pinotHelixResourceManager);
-    _enableSegmentLevelValidation = config.getEnableSegmentLevelValidation();
+    _segmentLevelValidationIntervalInSeconds = config.getSegmentLevelValidationIntervalInSeconds();
+    Preconditions.checkState(_segmentLevelValidationIntervalInSeconds > 0);
     _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
     _validationMetrics = validationMetrics;
   }
@@ -79,6 +84,16 @@ public class ValidationManager extends ControllerPeriodicTask {
    * @param allTableNames List of all the table names
    */
   private void runValidation(List<String> allTableNames) {
+    // Run segment level validation using a separate interval
+    boolean runSegmentLevelValidation = false;
+    long currentTimeMs = System.currentTimeMillis();
+    if (TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastSegmentLevelValidationTimeMs)
+        >= _segmentLevelValidationIntervalInSeconds) {
+      LOGGER.info("Run segment-level validation");
+      runSegmentLevelValidation = true;
+      _lastSegmentLevelValidationTimeMs = currentTimeMs;
+    }
+
     // Cache instance configs to reduce ZK access
     List<InstanceConfig> instanceConfigs = _pinotHelixResourceManager.getAllHelixInstanceConfigs();
 
@@ -98,14 +113,14 @@ public class ValidationManager extends ControllerPeriodicTask {
         // Perform validation based on the table type
         TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
         if (tableType == TableType.OFFLINE) {
-          if (_enableSegmentLevelValidation) {
+          if (runSegmentLevelValidation) {
             validateOfflineSegmentPush(tableConfig);
           }
         } else {
-          if (_enableSegmentLevelValidation) {
+          if (runSegmentLevelValidation) {
             updateRealtimeDocumentCount(tableConfig);
           }
-          Map<String, String> streamConfigMap =  tableConfig.getIndexingConfig().getStreamConfigs();
+          Map<String, String> streamConfigMap = tableConfig.getIndexingConfig().getStreamConfigs();
           StreamConfig streamConfig = new StreamConfig(streamConfigMap);
           if (streamConfig.hasLowLevelConsumerType()) {
             _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);


### PR DESCRIPTION
Segment level validation is useful to track missing segments and total document count
Instead of disabling it, we run segment level validation with intervals
By default, run segment level validation once per 24 rounds of validation