### PR TITLE
[TE] frontend - Anomaly resolution change label fix

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -55,7 +55,7 @@ export default Component.extend({
      onChangeAnomalyResponse: async function(humanizedAnomaly, selectedResponse, inputObj) {
       const responseObj = anomalyUtil.anomalyResponseObj.find(res => res.name === selectedResponse);
       set(inputObj, 'selected', selectedResponse);
-      set(this, 'renderStatusIcon', false);
+      // Reset icon display props
       setProperties(this, {
         renderStatusIcon: false,
         showResponseFailed: false,

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
@@ -2,11 +2,16 @@
   {{#if isUserReported}}
     <div class="te-anomaly-table__text">User Reported</div>
   {{else}}
-    {{#if showResponseSaved}}
-      <i class="{{if showResponseSaved "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-ok-circle" ></i>
-    {{else}}
-      <i class="{{if showResponseFailed "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-remove-circle" ></i>
-    {{/if}}
+    <div class="te-anomaly-table__icon-wrapper">
+      {{#if renderStatusIcon}}
+        {{#if showResponseSaved}}
+          <i class="te-anomaly-table__icon--status-no-margin glyphicon glyphicon-ok-circle"></i>
+        {{/if}}
+        {{#if showResponseFailed}}
+          <i class="te-anomaly-table__icon--status-no-margin te-anomaly-table__icon--error glyphicon glyphicon-remove-circle"></i>
+        {{/if}}
+      {{/if}}
+    </div>
 
     {{#if (eq record.anomalyFeedback "True anomaly")}}
       <div class="te-anomaly-table__value-label--down">

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -252,12 +252,13 @@
                   </ul>
                  </td>
                  <td class="te-anomaly-table__cell">
-                    {{#if anomaly.showResponseSaved}}
-                      <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
-                    {{/if}}
-
-                    {{#if anomaly.showResponseFailed}}
-                      <i class="te-anomaly-table__icon--status glyphicon glyphicon-remove-circle"></i>
+                    {{#if renderStatusIcon}}
+                      {{#if anomaly.showResponseSaved}}
+                        <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
+                      {{/if}}
+                      {{#if anomaly.showResponseFailed}}
+                        <i class="te-anomaly-table__icon--status te-anomaly-table__icon--error glyphicon glyphicon-remove-circle"></i>
+                      {{/if}}
                     {{/if}}
 
                     {{#if anomaly.isUserReported}}

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -14,6 +14,7 @@
 @import "shared/variable";
 @import "shared/mixins";
 @import "shared/styles";
+@import "shared/placeholders";
 
 // Wrapper
 @import "wrapper/color";

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -192,7 +192,6 @@
 
     &--status {
       position: absolute;
-      //font-size: 20px;
       margin: 14px 0 0 -26px;
       @extend %te-icon-animation;
     }
@@ -213,8 +212,6 @@
 
     &--error {
       color: #e75858;
-      /*font-size: 20px;
-      margin: 14px 0 0 -26px;*/
     }
   }
 

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-anomaly-table.scss
@@ -181,22 +181,24 @@
     font-weight: normal;
   }
 
+  &__icon-wrapper {
+    width: 20px;
+    height: 30px;
+  }
+
   &__icon {
     font-size: 14px;
     margin-left: 5px;
 
     &--status {
-      -webkit-animation: fadeinout 4s linear forwards;
-      animation: fadeinout 4s linear forwards;
       position: absolute;
-      font-size: 20px;
+      //font-size: 20px;
       margin: 14px 0 0 -26px;
+      @extend %te-icon-animation;
     }
 
     &--status-no-margin {
-      -webkit-animation: fadeinout 4s linear forwards;
-      animation: fadeinout 4s linear forwards;
-      font-size: 20px;
+      @extend %te-icon-animation;
     }
 
     &--hidden {
@@ -207,6 +209,12 @@
     &--small {
       font-size: 11px;
       margin-left: 0px;
+    }
+
+    &--error {
+      color: #e75858;
+      /*font-size: 20px;
+      margin: 14px 0 0 -26px;*/
     }
   }
 

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_placeholders.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_placeholders.scss
@@ -1,0 +1,10 @@
+/* -----------------------------------------------------------------------------
+ * TE shared style placeholders. See https://sass-lang.com/guide
+ * Placeholders will only print when extended
+ * ---------------------------------------------------------------------------*/
+%te-icon-animation {
+  -webkit-animation: $te-icon-animation;
+  animation: $te-icon-animation;
+  background: white;
+  font-size: 20px;
+}

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_variable.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_variable.scss
@@ -24,3 +24,5 @@ $te-spacing: 14px;
 $te-spacing--sm: 8px;
 $te-spacing--md: 16px;
 $te-spacing--lg: 24px;
+
+$te-icon-animation: fadeinout 4s linear forwards;

--- a/thirdeye/thirdeye-frontend/app/utils/anomaly.js
+++ b/thirdeye/thirdeye-frontend/app/utils/anomaly.js
@@ -28,7 +28,7 @@ export const anomalyResponseObj = [
   },
   { name: 'Expected permanent change',
     value: 'ANOMALY_NEW_TREND',
-    status: 'New Trend'
+    status: 'Confirmed - New Trend'
   },
   { name: 'No change observed',
     value: 'NOT_ANOMALY',


### PR DESCRIPTION
Resolving the following:
- One of the resolution options was indicating an error when it was actually success (validation was too strict)
- Success/failure icons were not displaying correctly
- Frontend is receiving updated `anomalyFeedback` properties for all feedback types except for one: "Expected Anomaly". This occurs only on Alert Page (using a specific API)