### PR TITLE
Add max length limit to string values

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.common.utils;
 
 import java.io.UnsupportedEncodingException;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -32,26 +31,30 @@ public class StringUtil {
   }
 
   /**
-   * Returns whether the string contains null character.
+   * Sanitizes a string value.
+   * <ul>
+   *   <li>Truncate characters after the first {@code null} character as it is reserved as the padding character</li>
+   *   <li>Limit the length of the string</li>
+   * </ul>
+   *
+   * @param value String value to sanitize
+   * @param maxLength Max number of characters allowed
+   * @return Modified value, or value itself if not modified
    */
-  public static boolean containsNullCharacter(@Nonnull String input) {
-    return input.indexOf(NULL_CHARACTER) >= 0;
-  }
-
-  /**
-   * Removes the null characters from a string.
-   * NOTE: call {@link #containsNullCharacter(String)} first to avoid the extra cost of removing null characters.
-   */
-  public static String removeNullCharacters(@Nonnull String input) {
-    char[] chars = input.toCharArray();
+  public static String sanitizeStringValue(String value, int maxLength) {
+    char[] chars = value.toCharArray();
     int length = chars.length;
-    int index = 0;
-    for (int i = 0; i < length; i++) {
-      if (chars[i] != NULL_CHARACTER) {
-        chars[index++] = chars[i];
+    int limit = Math.min(length, maxLength);
+    for (int i = 0; i < limit; i++) {
+      if (chars[i] == NULL_CHARACTER) {
+        return new String(chars, 0, i);
       }
     }
-    return new String(chars, 0, index);
+    if (limit < length) {
+      return new String(chars, 0, limit);
+    } else {
+      return value;
+    }
   }
 
   public static byte[] encodeUtf8(String s) {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/StringUtilTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/StringUtilTest.java
@@ -15,8 +15,9 @@
  */
 package com.linkedin.pinot.common.utils;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 /**
@@ -25,18 +26,14 @@ import org.testng.annotations.Test;
 public class StringUtilTest {
 
   @Test
-  public void testContainsNullCharacter() {
-    Assert.assertFalse(StringUtil.containsNullCharacter(""));
-    Assert.assertFalse(StringUtil.containsNullCharacter("potato"));
-    Assert.assertTrue(StringUtil.containsNullCharacter("\0"));
-    Assert.assertTrue(StringUtil.containsNullCharacter("pot\0ato"));
-  }
+  public void testSanitizeStringValue() {
+    assertEquals(StringUtil.sanitizeStringValue("pot\0ato", 3), "pot");
+    assertEquals(StringUtil.sanitizeStringValue("pot\0ato", 6), "pot");
+    assertEquals(StringUtil.sanitizeStringValue("potato", 2), "po");
+    assertEquals(StringUtil.sanitizeStringValue("pot\0ato", 2), "po");
 
-  @Test
-  public void testRemoveNullCharacters() {
-    Assert.assertEquals(StringUtil.removeNullCharacters(""), "");
-    Assert.assertEquals(StringUtil.removeNullCharacters("potato"), "potato");
-    Assert.assertEquals(StringUtil.removeNullCharacters("\0"), "");
-    Assert.assertEquals(StringUtil.removeNullCharacters("pot\0ato"), "potato");
+    String value = "potato";
+    assertSame(StringUtil.sanitizeStringValue(value, 6), value);
+    assertSame(StringUtil.sanitizeStringValue(value, 7), value);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
@@ -72,9 +72,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @BeforeClass
-  public void setup()
-      throws Exception {
-
+  public void setup() throws Exception {
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec(INT_COLUMN, FieldSpec.DataType.INT, true));
     schema.addField(new DimensionFieldSpec(LONG_COLUMN, FieldSpec.DataType.LONG, true));
@@ -100,8 +98,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @Test
-  public void testIntRawIndexCreator()
-      throws Exception {
+  public void testIntRawIndexCreator() throws Exception {
     testFixedLengthRawIndexCreator(INT_COLUMN, FieldSpec.DataType.INT);
   }
 
@@ -111,8 +108,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @Test
-  public void testLongRawIndexCreator()
-      throws Exception {
+  public void testLongRawIndexCreator() throws Exception {
     testFixedLengthRawIndexCreator(LONG_COLUMN, FieldSpec.DataType.LONG);
   }
 
@@ -122,8 +118,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @Test
-  public void testFloatRawIndexCreator()
-      throws Exception {
+  public void testFloatRawIndexCreator() throws Exception {
     testFixedLengthRawIndexCreator(FLOAT_COLUMN, FieldSpec.DataType.FLOAT);
   }
 
@@ -133,8 +128,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @Test
-  public void testDoubleRawIndexCreator()
-      throws Exception {
+  public void testDoubleRawIndexCreator() throws Exception {
     testFixedLengthRawIndexCreator(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE);
   }
 
@@ -144,8 +138,7 @@ public class RawIndexCreatorTest {
    * @throws Exception
    */
   @Test
-  public void testStringRawIndexCreator()
-      throws Exception {
+  public void testStringRawIndexCreator() throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(STRING_COLUMN);
     VarByteChunkSingleValueReader rawIndexReader = new VarByteChunkSingleValueReader(indexBuffer);
 
@@ -166,8 +159,7 @@ public class RawIndexCreatorTest {
    * @param dataType Data type of the column
    * @throws Exception
    */
-  private void testFixedLengthRawIndexCreator(String column, FieldSpec.DataType dataType)
-      throws Exception {
+  private void testFixedLengthRawIndexCreator(String column, FieldSpec.DataType dataType) throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(column);
 
     FixedByteChunkSingleValueReader rawIndexReader = new FixedByteChunkSingleValueReader(indexBuffer);
@@ -189,8 +181,7 @@ public class RawIndexCreatorTest {
    * @param column Column name for which to get the index file name
    * @return Name of index file for the given column name
    */
-  private PinotDataBuffer getIndexBufferForColumn(String column)
-      throws IOException {
+  private PinotDataBuffer getIndexBufferForColumn(String column) throws IOException {
     return _segmentReader.getIndexFor(column, ColumnIndexType.FORWARD_INDEX);
   }
 
@@ -200,8 +191,7 @@ public class RawIndexCreatorTest {
    * @return Array of string values for the rows in the generated index.
    * @throws Exception
    */
-  private RecordReader buildIndex(Schema schema)
-      throws Exception {
+  private RecordReader buildIndex(Schema schema) throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     config.setRawIndexCreationColumns(schema.getDimensionNames());
 
@@ -251,7 +241,8 @@ public class RawIndexCreatorTest {
       case DOUBLE:
         return random.nextDouble();
       case STRING:
-        return StringUtil.removeNullCharacters(RandomStringUtils.random(random.nextInt(MAX_STRING_LENGTH)));
+        return StringUtil.sanitizeStringValue(RandomStringUtils.random(random.nextInt(MAX_STRING_LENGTH)),
+            Integer.MAX_VALUE);
       default:
         throw new UnsupportedOperationException("Unsupported data type for random value generator: " + dataType);
     }


### PR DESCRIPTION
Motivation:
Recently, we run into issues where bad data is getting indexed into Pinot.
The length of one single string value is more than 1M, and cause the
dictionary size to be huge (>2G) and also cause int overflow and then crash
the server. In most of the cases, super long string is not even queriable,
and trying to index them is usually caused by client code bug. So we decide
to add a configurable limit to the length of string columns. If the value
for the column goes over the limit, the value will be trimmed to be the
length limit.

Added "maxLength" into FieldSpec, so each field (column) can have different
length limit.
The default limit is 512 (number of characters but not decoded bytes length).

NOTE: for string with null character, the part after the first null character
will be truncated because null character is reserved as padding character