### PR TITLE
Fix the bug for transferring more than 2G bytes

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUtils.java
@@ -17,18 +17,13 @@ package com.linkedin.pinot.common.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.util.Random;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-
-/**
- * Nov 12, 2014
- */
 
 public class FileUtils {
-
-  public static Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
+  private FileUtils() {
+  }
 
   private static final Random RANDOM = new Random();
 
@@ -46,5 +41,22 @@ public class FileUtils {
       org.apache.commons.io.FileUtils.deleteQuietly(destFile);
     }
     org.apache.commons.io.FileUtils.moveFile(srcFile, destFile);
+  }
+
+  /**
+   * Transfers bytes from the source file to the destination file. This method can handle transfer size larger than 2G.
+   *
+   * @param src Source file channel
+   * @param position Position in source file
+   * @param count Number of bytes to transfer
+   * @param dest Destination file channel
+   * @throws IOException
+   */
+  public static void transferBytes(FileChannel src, long position, long count, FileChannel dest) throws IOException {
+    long numBytesTransferred;
+    while ((numBytesTransferred = src.transferTo(position, count, dest)) < count) {
+      position += numBytesTransferred;
+      count -= numBytesTransferred;
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.startree;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.linkedin.pinot.common.data.FieldSpec;
@@ -603,10 +602,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
       File tempFile = new File(_tempDir, startDocId + "_" + endDocId + ".unique.tmp");
       try (FileChannel src = new RandomAccessFile(_dataFile, "r").getChannel();
           FileChannel dest = new RandomAccessFile(tempFile, "rw").getChannel()) {
-        long numBytesTransferred = src.transferTo(startDocId * _docSizeLong, tempBufferSize, dest);
-        Preconditions.checkState(numBytesTransferred == tempBufferSize,
-            "Error transferring data from data file to temp file, transfer size mis-match");
-        dest.force(false);
+        com.linkedin.pinot.common.utils.FileUtils.transferBytes(src, startDocId * _docSizeLong, tempBufferSize, dest);
       }
       tempBuffer = PinotDataBuffer.mapFile(tempFile, false, 0, tempBufferSize, PinotDataBuffer.NATIVE_ORDER,
           "OffHeapStarTreeBuilder#getUniqueCombinations: temp buffer");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/v2/builder/StarTreeIndexCombiner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/v2/builder/StarTreeIndexCombiner.java
@@ -74,16 +74,13 @@ public class StarTreeIndexCombiner implements Closeable {
     try (FileChannel src = new RandomAccessFile(srcFile, "r").getChannel()) {
       long offset = _fileChannel.position();
       long size = src.size();
-      long numBytesTransferred = src.transferTo(0, size, _fileChannel);
-      Preconditions.checkState(numBytesTransferred == size,
-          "Error writing file: " + srcFile + ", transfer size mis-match");
+      com.linkedin.pinot.common.utils.FileUtils.transferBytes(src, 0, size, _fileChannel);
       return new IndexValue(offset, size);
     }
   }
 
   @Override
   public void close() throws IOException {
-    _fileChannel.force(false);
     _fileChannel.close();
   }
 }


### PR DESCRIPTION
FileChannel.transferTo() can transfer at most 2G bytes
Added FileUtils.transferBytes() to handle transferring more than 2G bytes